### PR TITLE
More PHP ini settings - loop over settings in the template

### DIFF
--- a/src/_base/docker/image/console/root/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini.twig
+++ b/src/_base/docker/image/console/root/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini.twig
@@ -1,6 +1,6 @@
 {% set xdebug = @('php.ext-xdebug') %}
 
-{% if xdebug.enable == 'yes' %}
+{% if xdebug.cli.enable == 'yes' %}
   zend_extension=xdebug.so
   {% for key, value in xdebug.config -%}
     xdebug.{{ key }}={{ value }}

--- a/src/_base/docker/image/console/root/usr/local/etc/php/php.ini.twig
+++ b/src/_base/docker/image/console/root/usr/local/etc/php/php.ini.twig
@@ -1,3 +1,10 @@
+{% for name, value in @('php.ini') %}
+{{ name }} = {{ value }}
+{% endfor %}
+{% for name, value in @('php.cli.ini') %}
+{{ name }} = {{ value }}
+{% endfor %}
 
-memory_limit = {{ @('php.ini.memory_limit') }}
+# UTC for consistent logging that doesn't vary for Daylight Savings
+# If you need to change it, configure your application to display dates offset from UTC.
 date.timezone = UTC

--- a/src/_base/docker/image/php-fpm/root/usr/local/etc/php/php.ini.twig
+++ b/src/_base/docker/image/php-fpm/root/usr/local/etc/php/php.ini.twig
@@ -1,2 +1,10 @@
+{% for name, value in @('php.ini') %}
+{{ name }} = {{ value }}
+{% endfor %}
+{% for name, value in @('php.fpm.ini') %}
+{{ name }} = {{ value }}
+{% endfor %}
 
-memory_limit = {{ @('php.ini.memory_limit') }}
+# UTC for consistent logging that doesn't vary for Daylight Savings
+# If you need to change it, configure your application to display dates offset from UTC.
+date.timezone = UTC

--- a/src/_base/harness/attributes/common.yml
+++ b/src/_base/harness/attributes/common.yml
@@ -54,10 +54,16 @@ attributes.default:
 
   php:
     version: 7.3
-    ini:
-      memory_limit: 1024M
+    cli:
+      ini: ~
+    fpm:
+      ini:
+        memory_limit: 1024M
+    ini: ~
     ext-xdebug:
       enable: no
+      cli:
+        enable: no
       config:
         remote_enable: 1
         remote_autostart: 1


### PR DESCRIPTION
Also allow Xdebug to be disabled for console separately from the php-fpm container.