### PR TITLE
respect exit codes for exec

### DIFF
--- a/src/_base/harness/config/commands.yml
+++ b/src/_base/harness/config/commands.yml
@@ -28,7 +28,7 @@ command('destroy'):
 
 command('exec %'): |
   #!bash(harness:/)|=
-  passthru docker-compose -p ={ @('namespace') } exec -T -u build console ={ input.argument('%') }
+  docker-compose -p ={ @('namespace') } exec -T -u build console ={ input.argument('%') }
 
 command('console'): |
   #!bash(harness:/)|@


### PR DESCRIPTION
temporarily remove the "passthru" prefix of "ws exec" due to https://github.com/my127/workspace/issues/14