### PR TITLE
Fix merging of docker-compose.override.yml

### DIFF
--- a/src/_base/_twig/docker-compose.yml/application.yml.twig
+++ b/src/_base/_twig/docker-compose.yml/application.yml.twig
@@ -43,7 +43,7 @@
       private:
         aliases:
           - {{ @('hostname') }}
-      shared: ~
+      shared: {}
 
   php-fpm:
 {% if @('app.build') == 'dynamic' %}


### PR DESCRIPTION
Fixes the following error when docker-compose.override.yml is present on docker-compose 1.24-rc1:
```
docker-compose -p project config
compose.config.config.find: Using configuration files: ./docker-compose.yml,./docker-compose.override.yml
Traceback (most recent call last):
  File "docker-compose", line 6, in <module>
  File "compose/cli/main.py", line 71, in main
  File "compose/cli/main.py", line 121, in perform_command
  File "compose/cli/main.py", line 339, in config
  File "compose/cli/command.py", line 70, in get_config_from_options
  File "compose/config/config.py", line 404, in load
  File "compose/config/config.py", line 502, in load_services
  File "compose/config/config.py", line 493, in merge_services
  File "compose/config/config.py", line 493, in <dictcomp>
  File "compose/config/config.py", line 996, in merge_service_dicts_from_files
  File "compose/config/config.py", line 1064, in merge_service_dicts
  File "compose/config/config.py", line 1020, in merge_field
  File "compose/config/config.py", line 1176, in merge_networks
  File "compose/config/config.py", line 1015, in merge_field
  File "compose/config/config.py", line 1012, in needs_merge
TypeError: argument of type 'NoneType' is not iterable
[34761] Failed to execute script docker-compose
```