### PR TITLE
Fix php warning due to php.ini having # for comments

### DIFF
--- a/src/_base/docker/image/console/root/usr/local/etc/php/php.ini.twig
+++ b/src/_base/docker/image/console/root/usr/local/etc/php/php.ini.twig
@@ -5,6 +5,6 @@
 {{ name }} = {{ value }}
 {% endfor %}
 
-# UTC for consistent logging that doesn't vary for Daylight Savings
-# If you need to change it, configure your application to display dates offset from UTC.
+; UTC for consistent logging that doesn't vary for Daylight Savings
+; If you need to change it, configure your application to display dates offset from UTC.
 date.timezone = UTC

--- a/src/_base/docker/image/php-fpm/root/usr/local/etc/php/php.ini.twig
+++ b/src/_base/docker/image/php-fpm/root/usr/local/etc/php/php.ini.twig
@@ -5,6 +5,6 @@
 {{ name }} = {{ value }}
 {% endfor %}
 
-# UTC for consistent logging that doesn't vary for Daylight Savings
-# If you need to change it, configure your application to display dates offset from UTC.
+; UTC for consistent logging that doesn't vary for Daylight Savings
+; If you need to change it, configure your application to display dates offset from UTC.
 date.timezone = UTC


### PR DESCRIPTION
Hopefully fixes:
```
■ > n98-magerun.phar index:reindex:all
PHP Deprecated:  Comments starting with '#' are deprecated in /usr/local/etc/php/php.ini on line 2 in Unknown on line 0
PHP Deprecated:  Comments starting with '#' are deprecated in /usr/local/etc/php/php.ini on line 3 in Unknown on line 0
```