### PR TITLE
Set unlimited memory for PHP CLI, overriding the default of 128MB

### DIFF
--- a/src/_base/harness/attributes/common.yml
+++ b/src/_base/harness/attributes/common.yml
@@ -55,7 +55,8 @@ attributes.default:
   php:
     version: 7.3
     cli:
-      ini: ~
+      ini:
+        memory_limit: -1
     fpm:
       ini:
         memory_limit: 1024M


### PR DESCRIPTION
Allows magento1's indexers to run, for example.