### PR TITLE
Add phpstan with extension for Magento 1 to magento1 harness

### DIFF
--- a/src/magento1/application/skeleton/_twig/composer.json/default.twig
+++ b/src/magento1/application/skeleton/_twig/composer.json/default.twig
@@ -20,12 +20,14 @@
         "friends-of-behat/cross-container-extension": "^1.1",
         "friendsofphp/php-cs-fixer": "~2.2.1",
         "inviqa/magento1-coding-standard": "dev-master",
+        "inviqa/phpstan-magento1": "~0.1.5",
         "lusitanian/oauth": "~0.8.10",
         "magento/marketplace-eqp": "dev-master#3303dfc as 2.0.1",
         "magetest/magento-phpspec-extension": "^5.0",
         "pdepend/pdepend": "2.5.2",
         "phpmd/phpmd": "@stable",
         "phpspec/phpspec": "^4.0",
+        "phpstan/phpstan-shim": "~0.11.5",
         "phpunit/phpunit": "~6.2.0",
         "sebastian/phpcpd": "2.0.4",
         "sensiolabs/behat-page-object-extension": "^2.1",
@@ -85,6 +87,7 @@
         ],
         "test-quality": [
             "phpcs -v ./src",
+            "phpstan analyse",
             "phpmd ./src text ./phpmd.xml"
         ],
         "test-unit": [

--- a/src/magento1/application/skeleton/phpstan.neon
+++ b/src/magento1/application/skeleton/phpstan.neon
@@ -1,0 +1,6 @@
+includes:
+    - vendor/inviqa/phpstan-magento1/extension.neon
+    - .my127ws/application/static/phpstan.neon
+
+parameters:
+    level: 7

--- a/src/magento1/application/static/phpstan.neon
+++ b/src/magento1/application/static/phpstan.neon
@@ -1,0 +1,1 @@
+# file include for future improvements


### PR DESCRIPTION
This only includes codebase testing, not tests.

Need to investigate the phpspec and prophecy extensions, as I think the former duplicates some of the latter.

There are known issues mentioned on https://github.com/inviqa/phpstan-magento1 that currently can't be solved by the extension, but the Magento codebase.