### PR TITLE
Ensure we clean up static images even if an image is tagged to multiple tags

### DIFF
--- a/src/_base/harness/scripts/destroy.sh
+++ b/src/_base/harness/scripts/destroy.sh
@@ -9,8 +9,7 @@ if [[ "$USE_DOCKER_SYNC" = "yes" ]]; then
 fi
 
 if [[ "$APP_BUILD" = "static" ]]; then
-    # shellcheck disable=SC2046
-    run docker image rm $(docker images --filter=reference="${DOCKER_REPOSITORY}:${APP_VERSION}-*" -q)
+    run docker images --filter=reference="${DOCKER_REPOSITORY}:${APP_VERSION}-*" -q | xargs --no-run-if-empty docker image rm --force
 fi
 
 run rm -f .my127ws/.flag-built

--- a/src/_base/harness/scripts/destroy.sh
+++ b/src/_base/harness/scripts/destroy.sh
@@ -9,7 +9,7 @@ if [[ "$USE_DOCKER_SYNC" = "yes" ]]; then
 fi
 
 if [[ "$APP_BUILD" = "static" ]]; then
-    run docker images --filter=reference="${DOCKER_REPOSITORY}:${APP_VERSION}-*" -q | xargs --no-run-if-empty docker image rm -f
+    run "docker images --filter=reference='${DOCKER_REPOSITORY}:${APP_VERSION}-*' -q | xargs --no-run-if-empty docker image rm --force"
 fi
 
 run rm -f .my127ws/.flag-built

--- a/src/_base/harness/scripts/destroy.sh
+++ b/src/_base/harness/scripts/destroy.sh
@@ -9,7 +9,7 @@ if [[ "$USE_DOCKER_SYNC" = "yes" ]]; then
 fi
 
 if [[ "$APP_BUILD" = "static" ]]; then
-    run docker images --filter=reference="${DOCKER_REPOSITORY}:${APP_VERSION}-*" -q | xargs --no-run-if-empty docker image rm --force
+    run docker images --filter=reference="${DOCKER_REPOSITORY}:${APP_VERSION}-*" -q | xargs --no-run-if-empty docker image rm -f
 fi
 
 run rm -f .my127ws/.flag-built


### PR DESCRIPTION
The `--force` flag is needed if `docker tag image-console image-nginx` has happened.

Converting to `xargs --no-run-if-empty` also stops an error message occurring if the build failed whilst building the first docker image.