### PR TITLE
Add a daily Jenkins build for the main branch (stopping after tests)

### DIFF
--- a/src/_base/application/overlay/Jenkinsfile.twig
+++ b/src/_base/application/overlay/Jenkinsfile.twig
@@ -4,6 +4,7 @@ pipeline {
         MY127WS_KEY = credentials('{{ @('workspace.name') }}-my127ws-key')
         MY127WS_ENV = "pipeline"
     }
+    triggers { cron(env.BRANCH_NAME == '{{ @('git.main_branch') }}' ? 'H H(19-6) * * *' : '') }
     stages {
         stage('Build') {
             steps { sh 'ws install' }
@@ -17,17 +18,19 @@ pipeline {
         }
 {% if @('pipeline.publish.enabled') == 'yes' %}
         stage('Publish') {
+            when { not { triggeredBy 'TimerTrigger' } }
             steps { sh 'ws app publish' }
         }
 {% endif %}
 {% if @('pipeline.preview.enabled') == 'yes' %}
         stage('Deploy') {
+            when { not { triggeredBy 'TimerTrigger' } }
             steps { sh 'ws app deploy preview' }
         }
 {% endif %}
     }
     post {
-        always { 
+        always {
             sh 'ws destroy'
             cleanWs()
         }

--- a/src/_base/harness/attributes/common.yml
+++ b/src/_base/harness/attributes/common.yml
@@ -55,6 +55,9 @@ attributes.default:
       steps:
         - run "npm install"
 
+  git:
+    main_branch: develop
+
   nginx:
     conf: []
 


### PR DESCRIPTION
Run a daily build at a random time between 19:00 and 6:00 to catch dependency issues or other build problems.

Doesn't publish or deploy if publishing or preview is enabled, though we can consider removing the stop later.