### PR TITLE
Set default redis "save" configuration

### DIFF
--- a/src/_base/_twig/docker-compose.yml/service/redis-session.yml.twig
+++ b/src/_base/_twig/docker-compose.yml/service/redis-session.yml.twig
@@ -1,7 +1,7 @@
   redis-session:
     image: redis:4-alpine
     # 1GB; evict key that would expire soonest
-    command: redis-server --maxmemory 1073742000 --maxmemory-policy volatile-ttl
+    command: redis-server --maxmemory 1073742000 --maxmemory-policy volatile-ttl --save 3600 1 --save 300 100 --save 60 10000
     labels:
       - traefik.enable=false
     networks:

--- a/src/_base/_twig/docker-compose.yml/service/redis.yml.twig
+++ b/src/_base/_twig/docker-compose.yml/service/redis.yml.twig
@@ -1,7 +1,7 @@
   redis:
     image: redis:4-alpine
     # 1GB; evict any least recently used key even if they don't have a TTL
-    command: redis-server --maxmemory 1073742000 --maxmemory-policy allkeys-lru
+    command: redis-server --maxmemory 1073742000 --maxmemory-policy allkeys-lru --save 3600 1 --save 300 100 --save 60 10000
     labels:
       - traefik.enable=false
     networks:


### PR DESCRIPTION
When we set any redis configuration via command argument, it resets all default redis configurations. However, only "save" configuration is being affected by this issue. It empties the value of "save", which prevents redis from persisting data on disk. More info: https://github.com/docker-library/redis/issues/87