### PR TITLE
Set a default PHP_IDE_CONFIG for CLI Xdebug

### DIFF
--- a/src/_base/_twig/docker-compose.yml/environment.yml.twig
+++ b/src/_base/_twig/docker-compose.yml/environment.yml.twig
@@ -6,3 +6,4 @@
       DB_PASS: {{ @('database.pass') }}
       DB_NAME: {{ @('database.name') }}
       DB_ROOT_PASS: {{ @('database.root_pass') }}
+      PHP_IDE_CONFIG: "serverName=workspace"

--- a/src/_base/application/skeleton/README.md.twig
+++ b/src/_base/application/skeleton/README.md.twig
@@ -60,9 +60,15 @@ To enable on CLI in `ws console`, set `attribute('php.ext-xdebug.cli.enable'): y
 ws service php-fpm restart
 ```
 
-Xdebug is set up to listen to your computer's 9000 port once enabled, so all you would need to do in your IDE is listen for connections. [Here's a good guide for PhpStorm](https://www.jetbrains.com/help/PhpStorm/zero-configuration-debugging.html).
+Xdebug is set up to listen to your computer's 9000 port once enabled, so all you would need to do in your IDE is:
+1. Create a mapping from the project root to `/app` for name `workspace`, hostname `localhost` and port 80.
+2. Listen for connections.
 
-If you have trouble with Xdebug not calling back, check that `sudo lsof -i :9000 | grep LISTEN` on your host shows a PhpStorm process. If it doesn't, stop that process and toggle the Xdebug listen button in PhpStorm again.
+[Here's a good guide for PhpStorm](https://www.jetbrains.com/help/phpstorm/zero-configuration-debugging.html).
+
+If you have trouble with triggered requests not starting connections to your IDE, check that
+`sudo lsof -i :9000 | grep LISTEN` on your host shows process from your IDE.
+If it doesn't, stop the indicated process (e.g. `php-fpm`) and toggle the Xdebug listen button off and on again in PhpStorm.
 
 ### Common Issues
 

--- a/src/drupal8/_twig/docker-compose.yml/environment.yml.twig
+++ b/src/drupal8/_twig/docker-compose.yml/environment.yml.twig
@@ -8,3 +8,4 @@
       DB_PASS: {{ @('database.pass') }}
       DB_NAME: {{ @('database.name') }}
       DB_ROOT_PASS: {{ @('database.root_pass') }}
+      PHP_IDE_CONFIG: "serverName=workspace"

--- a/src/magento1/_twig/docker-compose.yml/environment.yml.twig
+++ b/src/magento1/_twig/docker-compose.yml/environment.yml.twig
@@ -7,3 +7,4 @@
       DB_PASS: {{ @('database.pass') }}
       DB_NAME: {{ @('database.name') }}
       DB_ROOT_PASS: {{ @('database.root_pass') }}
+      PHP_IDE_CONFIG: "serverName=workspace"

--- a/src/magento2/_twig/docker-compose.yml/environment.yml.twig
+++ b/src/magento2/_twig/docker-compose.yml/environment.yml.twig
@@ -7,3 +7,4 @@
       DB_PASS: {{ @('database.pass') }}
       DB_NAME: {{ @('database.name') }}
       DB_ROOT_PASS: {{ @('database.root_pass') }}
+      PHP_IDE_CONFIG: "serverName=workspace"

--- a/src/spryker/_twig/docker-compose.yml/environment.yml.twig
+++ b/src/spryker/_twig/docker-compose.yml/environment.yml.twig
@@ -10,6 +10,7 @@
       DB_ROOT_PASS: {{ @('database.root_pass') }}
       ELASTICSEARCH_HOST: {{ @('elasticsearch.host') }}
       ELASTICSEARCH_PORT: {{ @('elasticsearch.port') }}
+      PHP_IDE_CONFIG: "serverName=workspace"
       REDIS_HOST: {{ @('redis.host') }}
       REDIS_PORT: {{ @('redis.port') }}
       REDIS_PROTOCOL: {{ @('redis.protocol') }}

--- a/src/wordpress/_twig/docker-compose.yml/environment.yml.twig
+++ b/src/wordpress/_twig/docker-compose.yml/environment.yml.twig
@@ -16,3 +16,4 @@
       DB_PASS: {{ @('database.pass') }}
       DB_NAME: {{ @('database.name') }}
       DB_ROOT_PASS: {{ @('database.root_pass') }}
+      PHP_IDE_CONFIG: "serverName=workspace"


### PR DESCRIPTION
PhpStorm needs to know what server name to trigger a command line Xdebug request for. It ignores the request unless the `PHP_IDE_CONFIG` environment variable is present.