### PR TITLE
Add setting toggle commands

### DIFF
--- a/src/_base/application/skeleton/README.md.twig
+++ b/src/_base/application/skeleton/README.md.twig
@@ -63,7 +63,7 @@ If you have trouble with Xdebug not calling back, check that `sudo lsof -i :9000
 Page load times with Docker for Mac can vary considerably. This is especially so when there is a large
 quantity of small files, such as with a large composer vendor folder.
 
-{% if @('docker-sync') == 'on' %}
+{% if @('docker-sync') == 'yes' %}
 [docker-sync](https://github.com/EugenMayer/docker-sync/) is enabled on this workspace environment to
 try to overcome this.
 It enables production-like performance at the cost of having to synchronise files with an intermediate
@@ -79,7 +79,7 @@ You can enable docker-sync with `ws docker-sync on` - it takes a while to initia
 If you don't like the tradeoff of having to synchronise files, you can turn docker-sync off
 with `ws docker-sync off`.
 
-{% if @('docker-sync') == 'on' %}
+{% if @('docker-sync') == 'yes' %}
 If your page loads too slowly, you can turn docker-sync back on again  with `ws docker-sync on`
 {% endif %}
 

--- a/src/_base/application/skeleton/README.md.twig
+++ b/src/_base/application/skeleton/README.md.twig
@@ -58,9 +58,43 @@ Xdebug is set up to listen to your computer's 9000 port once enabled, so all you
 
 If you have trouble with Xdebug not calling back, check that `sudo lsof -i :9000 | grep LISTEN` on your host shows a PhpStorm process. If it doesn't, stop that process and toggle the Xdebug listen button in PhpStorm again.
 
+### Performance on MacOS
+
+Page load times with Docker for Mac can vary considerably. This is especially so when there is a large
+quantity of small files, such as with a large composer vendor folder.
+
+{% if @('docker-sync') == 'on' %}
+[docker-sync](https://github.com/EugenMayer/docker-sync/) is enabled on this workspace environment to
+try to overcome this.
+It enables production-like performance at the cost of having to synchronise files with an intermediate
+"data" container.
+{% else %}
+If it takes over 2 seconds to load a page, you can consider enabling
+[docker-sync](https://github.com/EugenMayer/docker-sync/) which should enable production-like performance
+at the cost of having to synchronise files with an intermediate "data" container.
+
+You can enable docker-sync with `ws docker-sync on` - it takes a while to initially sync.
+{% endif %}
+
+If you don't like the tradeoff of having to synchronise files, you can turn docker-sync off
+with `ws docker-sync off`.
+
+{% if @('docker-sync') == 'on' %}
+If your page loads too slowly, you can turn docker-sync back on again  with `ws docker-sync on`
+{% endif %}
+
 ### Common Issues
 
 As setup issues are encountered please detail with step by step fix instructions, and where possible update the project or the upstream workspace harness itself to provide a more permanent fix.
+
+* If you use docker-sync and notice that your changes aren't synchronising to the environment:
+  * Check if your file exists with your changes in `ws console`
+  * If your file in `ws console` has changed okay, check your project for any caching that
+    would prevent changes to source code appearing immediately.
+  * If the file changes do not appear in `ws console` reasonably quickly, it might be that
+    Docker for Mac is overwhelmed with file change events.
+  * Restarting Docker for Mac using the system tray icon's menu and then running `ws enable` again
+    will fix it.
 
 # License
 

--- a/src/_base/application/skeleton/README.md.twig
+++ b/src/_base/application/skeleton/README.md.twig
@@ -50,15 +50,9 @@ To gain access to the `console` container where the builds happen: `ws frontend 
 
 Xdebug is turned off by default as it drastically slows down requests for all developers.
 
-To enable, set `attribute('php.ext-xdebug.enable'): yes` in your `workspace.override.yml` and then run:
-```bash
-ws service php-fpm restart
-```
+To enable, run `ws xdebug on`. To turn off again, `ws xdebug off`.
 
-To enable on CLI in `ws console`, set `attribute('php.ext-xdebug.cli.enable'): yes` in your `workspace.override.yml` and then run:
-```bash
-ws service php-fpm restart
-```
+To enable on CLI in `ws console`, run `ws xdebug cli on`. To turn off again, `ws xdebug cli off`.
 
 Xdebug is set up to listen to your computer's 9000 port once enabled, so all you would need to do in your IDE is listen for connections. [Here's a good guide for PhpStorm](https://www.jetbrains.com/help/PhpStorm/zero-configuration-debugging.html).
 

--- a/src/_base/harness/config/commands.yml
+++ b/src/_base/harness/config/commands.yml
@@ -106,3 +106,39 @@ command('service php-fpm restart'):
     passthru "docker-compose exec console bash -c 'cp -r /.my127ws/docker/image/console/root/usr/local/etc/php/conf.d/* /usr/local/etc/php/conf.d/'"
     passthru "docker-compose exec php-fpm bash -c 'cp -r /.my127ws/docker/image/php-fpm/root/usr/local/etc/php/conf.d/* /usr/local/etc/php/conf.d/'"
     passthru docker-compose exec php-fpm supervisorctl restart php-fpm
+
+command('toggle <attribute> <on_or_off>'):
+  exec: |
+    #!bash(workspace:/)|=
+    export ATTRIBUTE="={input.argument('attribute')}"
+    export YES_OR_NO="={input.argument('on_or_off') == 'on' ? 'yes': 'no'}"
+    if grep -q "attribute('${ATTRIBUTE}'):" workspace.override.yml; then
+      echo 'Removing old "${ATTRIBUTE}" setting from workspace.override.yml'
+      sed -i '' -E "/^attribute\(\'${ATTRIBUTE}\'\): .*$/d" workspace.override.yml
+    fi
+    if grep -q "attribute('${ATTRIBUTE}'):" workspace.override.yml; then
+      echo 'Could not remove line from workspace.override.yml, failing'
+      exit 1
+    fi
+    echo "Setting '${ATTRIBUTE}' setting to '$YES_OR_NO' in workspace.override.yml"
+    echo "attribute('${ATTRIBUTE}'): $YES_OR_NO" >> workspace.override.yml
+
+command('xdebug <on_or_off>'):
+  exec: |
+    #!bash(workspace:/)|=
+    ws toggle php.ext-xdebug.enable ={input.argument('on_or_off')}
+    echo 'Updating templates in .my127ws/'
+    run ws install --step=prepare
+    echo 'Bringing up php-fpm with the new setting'
+    run ws service php-fpm restart
+    echo 'Done'
+
+command('xdebug cli <on_or_off>'):
+  exec: |
+    #!bash(workspace:/)|=
+    ws toggle php.ext-xdebug.cli.enable ={input.argument('on_or_off')}
+    echo 'Updating templates in .my127ws/'
+    run ws install --step=prepare
+    echo 'Bringing up console with the new setting'
+    run ws service php-fpm restart
+    echo 'Done'

--- a/src/_base/harness/config/commands.yml
+++ b/src/_base/harness/config/commands.yml
@@ -69,6 +69,24 @@ command('assets upload'):
     #!bash(workspace:/)|@
     passthru ws.aws s3 sync @('assets.local') @('assets.remote')
 
+command('docker-sync <on_or_off>'):
+  exec: |
+    #!bash(workspace:/)|=
+    export YES_OR_NO="={input.argument('on_or_off') == 'on' ? 'yes': 'no'}"
+    ws toggle docker-sync ={input.argument('on_or_off')}
+    echo 'Updating docker-compose.yml'
+    run ws install --step=prepare
+    echo 'Bringing up the environment with the new setting'
+    if [[ "$YES_OR_NO" = "yes" ]]; then
+      passthru docker-sync start
+    fi
+    passthru ws enable
+    if [[ "$YES_OR_NO" = "no" ]]; then
+      passthru docker-sync stop
+      passthru docker-sync clean
+    fi
+    echo 'Done'
+
 command('frontend build'):
   env:
     COMPOSE_PROJECT_NAME: = @('namespace')
@@ -113,7 +131,7 @@ command('toggle <attribute> <on_or_off>'):
     export ATTRIBUTE="={input.argument('attribute')}"
     export YES_OR_NO="={input.argument('on_or_off') == 'on' ? 'yes': 'no'}"
     if grep -q "attribute('${ATTRIBUTE}'):" workspace.override.yml; then
-      echo 'Removing old "${ATTRIBUTE}" setting from workspace.override.yml'
+      echo "Removing old '${ATTRIBUTE}' setting from workspace.override.yml"
       sed -i '' -E "/^attribute\(\'${ATTRIBUTE}\'\): .*$/d" workspace.override.yml
     fi
     if grep -q "attribute('${ATTRIBUTE}'):" workspace.override.yml; then


### PR DESCRIPTION
Convenience commands that insert into workspace.override.yml and apply the setting immediately:
* `ws xdebug on/off`
* `ws xdebug cli on/off`
* `ws docker-sync on/off`