### PR TITLE
Fix phpstan include with docker-sync

### DIFF
--- a/src/_base/docker-sync.yml.twig
+++ b/src/_base/docker-sync.yml.twig
@@ -11,7 +11,6 @@ syncs:
     sync_excludes: &IGNORE
       - .docker-sync
       - .idea
-      - .my127ws
       - .git
       - var
     watch_excludes: *IGNORE


### PR DESCRIPTION
https://github.com/inviqa/harness-base-php/blob/0.2.x/src/magento2/application/skeleton/phpstan.neon#L3 doesn't work with docker-sync due to us not syncing .my127ws to the docker-sync data container.

Allow this to be loaded by removing the ignore