### PR TITLE
Reset console image to use build user by default

### DIFF
--- a/src/_base/docker/image/console/Dockerfile.twig
+++ b/src/_base/docker/image/console/Dockerfile.twig
@@ -29,3 +29,4 @@ VOLUME /home/build/application
 {% endif %}
 
 ENTRYPOINT /entrypoint.sh
+USER build


### PR DESCRIPTION
Fixes direct docker usage without "-u build" creating files that UID 1000 can't modify in local development environments.