### PR TITLE
Do not autoload dev classes in production mode

### DIFF
--- a/src/magento1/application/skeleton/_twig/composer.json/default.twig
+++ b/src/magento1/application/skeleton/_twig/composer.json/default.twig
@@ -35,7 +35,6 @@
     },
     "autoload": {
         "psr-0": {
-            "MageTest\\PhpSpec\\MagentoExtension": "src",
             "": [
                 "public/app/code/local",
                 "public/app/code/community",
@@ -53,6 +52,9 @@
         ]
     },
     "autoload-dev": {
+        "psr-0": {
+            "MageTest\\PhpSpec\\MagentoExtension": "src"
+        },
         "psr-4": {
             "Acceptance\\": "features/bootstrap",
             "Magento\\Sniffs\\": "dev/tests/static/framework/Magento/Sniffs/",

--- a/src/magento1/application/skeleton/_twig/composer.json/php-5.6.twig
+++ b/src/magento1/application/skeleton/_twig/composer.json/php-5.6.twig
@@ -33,7 +33,6 @@
     },
     "autoload": {
         "psr-0": {
-            "MageTest\\PhpSpec\\MagentoExtension": "src",
             "": [
                 "public/app/code/local",
                 "public/app/code/community",
@@ -51,6 +50,9 @@
         ]
     },
     "autoload-dev": {
+        "psr-0": {
+            "MageTest\\PhpSpec\\MagentoExtension": "src"
+        },
         "psr-4": {
             "Acceptance\\": "features/bootstrap",
             "Magento\\Sniffs\\": "dev/tests/static/framework/Magento/Sniffs/",


### PR DESCRIPTION
PHP classes under the `MageTest` namespace is added to the autoloader when Composer installs packages in non-dev mode. That's is not needed and just waste resources.
This change make it loaded in dev mode only.