### PR TITLE
Add PHP syntax checking to code quality testing

### DIFF
--- a/src/drupal8/application/skeleton/composer.json
+++ b/src/drupal8/application/skeleton/composer.json
@@ -65,7 +65,7 @@
       "@test-acceptance"
     ],
     "test-quality": [
-      "find docroot/ -type f \\( -name '*.phtml' -o -name '*.php' \\) | xargs -n 1 -P 8 -i php -l {}",
+      "find docroot/ -type f ! -path 'docroot/core/lib/Drupal/Component/Assertion/global_namespace_php5.php' \\( -name '*.phtml' -o -name '*.php' \\) | xargs -n 1 -P 8 -i php -l {}",
       "phpcs -v ./docroot/modules/custom",
 
       "drupal-check -ad ./docroot/modules/custom"

--- a/src/drupal8/application/skeleton/composer.json
+++ b/src/drupal8/application/skeleton/composer.json
@@ -50,7 +50,7 @@
     "drupal/stage_file_proxy": "^1.0@alpha",
     "drupal/taxonomy_access_fix": "2.6",
     "drupal/token": "1.5",
-    "drupal/ultimate_cron": "^2.0@alpha",
+    "drupal/ultimate_cron": "^2.0",
     "drush/drush": "^8",
     "oomphinc/composer-installers-extender": "^1.1"
   },

--- a/src/drupal8/application/skeleton/composer.json
+++ b/src/drupal8/application/skeleton/composer.json
@@ -50,7 +50,7 @@
     "drupal/stage_file_proxy": "^1.0@alpha",
     "drupal/taxonomy_access_fix": "2.6",
     "drupal/token": "1.5",
-    "drupal/ultimate_cron": "^2.0",
+    "drupal/ultimate_cron": "2.x-dev",
     "drush/drush": "^8",
     "oomphinc/composer-installers-extender": "^1.1"
   },

--- a/src/drupal8/application/skeleton/composer.json
+++ b/src/drupal8/application/skeleton/composer.json
@@ -65,6 +65,7 @@
       "@test-acceptance"
     ],
     "test-quality": [
+      "find docroot/ -type f \\( -name '*.phtml' -o -name '*.php' \\) | xargs -n 1 -P 8 -i php -l {}",
       "phpcs -v ./docroot/modules/custom",
 
       "drupal-check -ad ./docroot/modules/custom"

--- a/src/magento1/application/skeleton/_twig/composer.json/default.twig
+++ b/src/magento1/application/skeleton/_twig/composer.json/default.twig
@@ -88,6 +88,7 @@
             "@test-acceptance"
         ],
         "test-quality": [
+            "find public/app/code/ public/app/design/ -type f \\( -name '*.phtml' -o -name '*.php' \\) | xargs -n 1 -P 8 -i php -l {}",
             "phpcs -v ./src",
             "phpstan analyse",
             "phpmd ./src text ./phpmd.xml"

--- a/src/magento1/application/skeleton/_twig/composer.json/default.twig
+++ b/src/magento1/application/skeleton/_twig/composer.json/default.twig
@@ -88,7 +88,7 @@
             "@test-acceptance"
         ],
         "test-quality": [
-            "find public/app/code/ public/app/design/ -type f \\( -name '*.phtml' -o -name '*.php' \\) | xargs -n 1 -P 8 -i php -l {}",
+            "find public/app/code/ public/app/design/ -type f ! -path 'public/app/code/core/Mage/Adminhtml/Model/Extension.php' \\( -name '*.phtml' -o -name '*.php' \\) | xargs -n 1 -P 8 -i php -l {}",
             "phpcs -v ./src",
             "phpstan analyse",
             "phpmd ./src text ./phpmd.xml"

--- a/src/magento1/application/skeleton/_twig/composer.json/php-5.6.twig
+++ b/src/magento1/application/skeleton/_twig/composer.json/php-5.6.twig
@@ -90,6 +90,7 @@
             "@test-acceptance"
         ],
         "test-quality": [
+            "find public/app/code/ public/app/design/ -type f \\( -name '*.phtml' -o -name '*.php' \\) | xargs -n 1 -P 8 -i php -l {}",
             "phpcs -v ./src",
             "phpmd ./src text ./phpmd.xml"
         ],

--- a/src/magento1/docker/image/console/root/lib/task/welcome.sh
+++ b/src/magento1/docker/image/console/root/lib/task/welcome.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+function task_welcome()
+{
+    echo ""
+    echo "Welcome!"
+    echo "--------"
+    echo "URL: https://${APP_HOST}"
+    echo "Admin: /admin"
+    echo "  Username: admin"
+    echo "  Password: admin123admin123"
+    echo ""
+}

--- a/src/magento1/harness.yml
+++ b/src/magento1/harness.yml
@@ -75,7 +75,7 @@ attributes:
             --admin_lastname 'Last' \
             --admin_email 'admin@example.com' \
             --admin_username 'admin' \
-            --admin_password 'admin123' \
+            --admin_password 'admin123admin123' \
             --encryption_key '${MAGENTO_CRYPT_KEY}' \
             --session_save 'db' \
             --admin_frontname 'admin'"

--- a/src/magento1/harness.yml
+++ b/src/magento1/harness.yml
@@ -36,7 +36,7 @@ attributes:
     version: 7.2
   magento:
     edition: enterprise
-    version: 1.14.4.2
+    version: 1.14.4.4
     environment: ''
     run:
       code: []

--- a/src/magento2/application/skeleton/composer.json.twig
+++ b/src/magento2/application/skeleton/composer.json.twig
@@ -81,6 +81,7 @@
             "@test-acceptance"
         ],
         "test-quality": [
+            "find app/ pub/ -type f \\( -name '*.phtml' -o -name '*.php' \\) | xargs -n 1 -P 8 -i php -l {}",
             "phpcs -v",
             "phpstan analyse",
             "phpmd ./src text ./phpmd.xml"

--- a/src/wordpress/application/skeleton/composer.json.twig
+++ b/src/wordpress/application/skeleton/composer.json.twig
@@ -45,6 +45,7 @@
             "@test-acceptance"
         ],
         "test-quality": [
+            "find public/ -type f -name '*.php' | xargs -n 1 -P 8 -i php -l {}",
             "phpcs"
         ],
         "test-unit": [


### PR DESCRIPTION
Extend the **test-quality** Composer task with framework/platform specific PHP syntax checking:

### Magento 1 & 2:
  - .php files
  - .phtml files

### Wordpress:
  - .php files

### Drupal 8:
  - .php files

Note: I intended to [check the syntax of Twig files](https://symfony.com/doc/4.1/templating/syntax.html) for Drupal projects, but `bin/console` is not installed and I'm not sure if it's a good to create that only for this purpose.