### PR TITLE
Fix SIMPLETEST_DB using uri Drupal can parse

### DIFF
--- a/src/drupal8/application/overlay/phpunit.xml.twig
+++ b/src/drupal8/application/overlay/phpunit.xml.twig
@@ -22,7 +22,7 @@
         <!-- Example SIMPLETEST_BASE_URL value: http://localhost -->
         <env name="SIMPLETEST_BASE_URL" value="http://domainname.localhost/"/>
         <!-- Example SIMPLETEST_DB value: mysql://username:password@localhost/databasename#table_prefix -->
-        <env name="SIMPLETEST_DB" value="sqlite://tmp/test.sqlite"/>
+        <env name="SIMPLETEST_DB" value="sqlite://ignored//tmp/test.sqlite"/>
         <!-- Example BROWSERTEST_OUTPUT_DIRECTORY value: /path/to/webroot/sites/simpletest/browser_output -->
         <env name="BROWSERTEST_OUTPUT_DIRECTORY" value="/opt/project/docroot/sites/default/files/browser_output"/>
     </php>

--- a/src/drupal8/application/overlay/phpunit.xml.twig
+++ b/src/drupal8/application/overlay/phpunit.xml.twig
@@ -20,7 +20,7 @@
         <!-- Do not limit the amount of memory tests take to run. -->
         <ini name="memory_limit" value="-1"/>
         <!-- Example SIMPLETEST_BASE_URL value: http://localhost -->
-        <env name="SIMPLETEST_BASE_URL" value="http://domainname.localhost/"/>
+        <env name="SIMPLETEST_BASE_URL" value="https://{{ @('hostname') }}/"/>
         <!-- Example SIMPLETEST_DB value: mysql://username:password@localhost/databasename#table_prefix -->
         <env name="SIMPLETEST_DB" value="sqlite://ignored//tmp/test.sqlite"/>
         <!-- Example BROWSERTEST_OUTPUT_DIRECTORY value: /path/to/webroot/sites/simpletest/browser_output -->


### PR DESCRIPTION
sqlite://tmp/test.sqlite appears as host => tmp, path => test.sqlite, which causes the simpletest's site database file to be put in /app/docroot
sqlite:///tmp/test.sqlite would be the correct format, but path_info() doesn't support this unlike file:///, so add a host and retain the root / after it's parsed using ignored//