### PR TITLE
Add mysqladmin connect timeout

### DIFF
--- a/src/_base/docker/image/console/root/lib/task/database/available.sh
+++ b/src/_base/docker/image/console/root/lib/task/database/available.sh
@@ -5,7 +5,7 @@ function task_database_available()
     local command=""
 
     if [ "${DB_PLATFORM}" == "mysql" ]; then
-        command="mysqladmin -h $DB_HOST -u root -p$DB_ROOT_PASS ping --connect_timeout=5"
+        command="mysqladmin -h $DB_HOST -u root -p$DB_ROOT_PASS ping --connect_timeout=10"
     elif [ "${DB_PLATFORM}" == "postgres" ]; then
         command="pg_isready -h $DB_HOST"
     elif [ "${DB_PLATFORM}" == "" ]; then
@@ -20,7 +20,7 @@ function task_database_available()
 
     while ! $command &> /dev/null; do
 
-        if (( counter > 3 )); then
+        if (( counter > 8 )); then
             (>&2 echo "timeout while waiting on ${DB_PLATFORM} to become available")
             exit 1
         fi

--- a/src/_base/docker/image/console/root/lib/task/database/available.sh
+++ b/src/_base/docker/image/console/root/lib/task/database/available.sh
@@ -5,7 +5,7 @@ function task_database_available()
     local command=""
 
     if [ "${DB_PLATFORM}" == "mysql" ]; then
-        command="mysqladmin -h $DB_HOST -u root -p$DB_ROOT_PASS ping"
+        command="mysqladmin -h $DB_HOST -u root -p$DB_ROOT_PASS ping --connect_timeout=5"
     elif [ "${DB_PLATFORM}" == "postgres" ]; then
         command="pg_isready -h $DB_HOST"
     elif [ "${DB_PLATFORM}" == "" ]; then

--- a/src/_base/docker/image/console/root/lib/task/database/available.sh
+++ b/src/_base/docker/image/console/root/lib/task/database/available.sh
@@ -20,7 +20,7 @@ function task_database_available()
 
     while ! $command &> /dev/null; do
 
-        if (( counter > 30 )); then
+        if (( counter > 3 )); then
             (>&2 echo "timeout while waiting on ${DB_PLATFORM} to become available")
             exit 1
         fi


### PR DESCRIPTION
Define timeout value to avoid 12hr default connection timeout when database host cannot be reached.

https://dev.mysql.com/doc/refman/5.6/en/mysqladmin.html

Change gives quicker feedback for `ws install | ws exec app database:available` commands.
