### PR TITLE
MISC Use admin mysql user/pass var naming

### DIFF
--- a/src/_base/docker/image/console/root/lib/task/assets/apply.sh
+++ b/src/_base/docker/image/console/root/lib/task/assets/apply.sh
@@ -8,10 +8,10 @@ function task_assets_apply()
     if [ "${DB_PLATFORM}" == "mysql" ]; then
         SQL="SELECT IF (COUNT(*) = 0, 'no', 'yes') FROM information_schema.tables WHERE table_schema = '$DB_NAME';"
         IS_DATABASE_APPLIED="$(mysql -ss -h "$DB_HOST" -u "$DB_USER" -p"$DB_PASS" -e "$SQL")"
-        IMPORT_COMMAND="mysql -h $DB_HOST -u root -p$DB_ROOT_PASS $DB_NAME"
+        IMPORT_COMMAND="mysql -h $DB_HOST -u ${DB_ADMIN_USER:-$DB_USER} -p${DB_ROOT_PASS:-${DB_ADMIN_PASS:-$DB_PASS}} $DB_NAME"
     elif [ "${DB_PLATFORM}" == "postgres" ]; then
         SQL="SELECT CASE WHEN COUNT(*) = 0 THEN 'no' ELSE 'yes' END FROM information_schema.tables WHERE table_catalog = '$DB_NAME' and table_schema='public';"
-        IS_DATABASE_APPLIED="$(PGPASSWORD=$DB_PASS psql -qtAX -h "$DB_HOST" -U "$DB_USER" -c "$SQL")"
+        IS_DATABASE_APPLIED="$(PGPASSWORD="$DB_PASS" psql -qtAX -h "$DB_HOST" -U "$DB_USER" -c "$SQL")"
         IMPORT_COMMAND="PGPASSWORD=$DB_PASS psql -h $DB_HOST -U $DB_USER $DB_NAME"
     elif [ -n "${DB_PLATFORM}" ]; then
         (>&2 echo "invalid database type")

--- a/src/_base/docker/image/console/root/lib/task/database/available.sh
+++ b/src/_base/docker/image/console/root/lib/task/database/available.sh
@@ -5,7 +5,7 @@ function task_database_available()
     local command=""
 
     if [ "${DB_PLATFORM}" == "mysql" ]; then
-        command="mysqladmin -h $DB_HOST -u root -p$DB_ROOT_PASS ping --connect_timeout=10"
+        command="mysqladmin -h $DB_HOST -u ${DB_ADMIN_USER:-$DB_USER} -p${DB_ROOT_PASS:-${DB_ADMIN_PASS:-$DB_PASS}} ping --connect_timeout=10"
     elif [ "${DB_PLATFORM}" == "postgres" ]; then
         command="pg_isready -h $DB_HOST"
     elif [ "${DB_PLATFORM}" == "" ]; then

--- a/src/_base/harness/attributes/docker-base.yml
+++ b/src/_base/harness/attributes/docker-base.yml
@@ -16,7 +16,8 @@ attributes:
         FPM_HOST: php-fpm
     console:
       environment:
-        DB_ROOT_PASS: = @('database.root_pass')
+        DB_ADMIN_USER: root
+        DB_ADMIN_PASS: = @('database.root_pass')
     php-fpm:
       environment: 
         AUTOSTART_PHP_FPM: "true"


### PR DESCRIPTION
The application may not always be using the root user for super-user credentials, so shouldn't be called root

It should also allow using the standard user/pass when the mysql user has enough capabilities

This is how our CP images did this

There is BC to support DB_ROOT_PASS if set downstream (its still expected in this case that DB_ADMIN_USER is set to root)