### PR TITLE
Use locks and milestones in Jenkinsfile for reducing concurrency and …

### DIFF
--- a/src/_base/application/overlay/Jenkinsfile.twig
+++ b/src/_base/application/overlay/Jenkinsfile.twig
@@ -7,7 +7,10 @@ pipeline {
     triggers { cron(env.BRANCH_NAME == '{{ @('git.main_branch') }}' ? 'H H(0-6) * * *' : '') }
     stages {
         stage('Build') {
-            steps { sh 'ws install' }
+            steps {
+                sh 'ws install'
+                milestone(10)
+            }
         }
         stage('Test')  {
             parallel {
@@ -19,7 +22,10 @@ pipeline {
 {% if @('pipeline.publish.enabled') == 'yes' %}
         stage('Publish') {
             when { not { triggeredBy 'TimerTrigger' } }
-            steps { sh 'ws app publish' }
+            steps { 
+                milestone(50)
+                sh 'ws app publish' 
+            }
         }
 {% endif %}
 {% if @('pipeline.qa.enabled') == 'yes' %}
@@ -34,7 +40,11 @@ pipeline {
                 branch '{{ @('pipeline.qa.branch') }}'
             }
             steps {
-                sh 'ws app deploy qa'
+                milestone(100)
+                lock(resource: '{{ @('workspace.name') }}-qa-deploy', inversePrecedence: true) {
+                    milestone(101)
+                    sh 'ws app deploy qa'
+                }
             }
         }
 {% endif %}


### PR DESCRIPTION
…repetition

* milestones - cancel older builds that reach the milestone after a newer build has reached (not older builds which have passed it beforehand)
* locks - block other builds from continuing until step completed
* milestone lock(.., inversePrecedence: true) { milestone ... } cancels older builds and prefers newer builds first when lock unlocked, cancelling older waiting builds

Latter means if build 1, 3 & 4 reach milestone(100) after build 2 has locked the resource, 1 is cancelled, 3 & 4 wait, 4 gets lock, 3 gets cancelled by milestone(101), so effectively only 2 and 4 trigger a deploy

Lockable resources are global scope, so need a prefix.
Milestones are unique to the job, and numbers are used to allow movement and addition of milestones whilst retaining their meaning in older builds