### PR TITLE
Allow updating the docker-compose file version

### DIFF
--- a/src/_base/docker-compose.yml.twig
+++ b/src/_base/docker-compose.yml.twig
@@ -3,7 +3,7 @@
 {% if @('host.os') == 'darwin' and @('docker-sync') == 'yes' %}
 {% set dockersync = true %}
 {% endif %}
-version: '3'
+version: '{{ @('docker.compose.file_version') }}'
 services:
 {% include blocks ~ 'application.yml.twig' %}
 {% for service in @('app.services') %}

--- a/src/_base/harness/attributes/common.yml
+++ b/src/_base/harness/attributes/common.yml
@@ -55,6 +55,8 @@ attributes.default:
 
   docker:
     repository: = @("workspace.name")
+    compose:
+      file_version: '3'
     config: null
     image:
       console: = 'my127/php:' ~ @('php.version') ~ '-fpm-stretch-console'


### PR DESCRIPTION
'3' actually means '3.0', which is very restrictive, however BC is needed, and it's problematic to push a static version update, when an project's override file will have to match

As should be obvious, this can only be used on backwards compatible versions 3.0+