### PR TITLE
Allow overriding of istio virtualservice gateway with template support

### DIFF
--- a/src/_base/harness/attributes/docker-base.yml
+++ b/src/_base/harness/attributes/docker-base.yml
@@ -48,6 +48,8 @@ attributes:
           environment:
             FPM_HOST: localhost
       istio:
+        gateways:
+          - "istio-system/{{ .Release.Namespace }}-gateway"
         additionalGateways: []
     qa:
       services:

--- a/src/_base/helm/app/templates/application/webapp/ingress-istio.yaml
+++ b/src/_base/helm/app/templates/application/webapp/ingress-istio.yaml
@@ -10,7 +10,9 @@ spec:
  hosts:
  - {{ index .Values.docker.services "php-base" "environment" "APP_HOST" }}
  gateways:
- - istio-system/{{ .Release.Namespace }}-gateway
+{{- range $key, $value := .Values.istio.gateways }}
+ - {{ tpl $value $ | quote }}
+{{- end }}
 {{- range $key, $value := .Values.istio.additionalGateways }}
  - {{ $value | quote }}
 {{- end }}


### PR DESCRIPTION
Potentially deprecates additionalGateways, but that's useful while there's no strong array merge strategy in workspace