### PR TITLE
Add package namespace to all composer skeleton files

### DIFF
--- a/src/magento2/application/skeleton/composer.json.twig
+++ b/src/magento2/application/skeleton/composer.json.twig
@@ -1,5 +1,5 @@
 {
-    "name": "{{ @('workspace.name') }}",
+    "name": "{{ @('workspace.name')|lower }}/magento2",
     "type": "project",
     "license": "proprietary",
     "require": {

--- a/src/wordpress/application/skeleton/composer.json.twig
+++ b/src/wordpress/application/skeleton/composer.json.twig
@@ -1,5 +1,5 @@
 {
-    "name": "{{ @('workspace.name') }}",
+    "name": "{{ @('workspace.name')|lower }}/wordpress",
     "type": "project",
     "license": "proprietary",
     "require": {


### PR DESCRIPTION
Stop deprecation messages surrounding lack of package namespace on any composer command.