### PR TITLE
Run composer tests in static build

### DIFF
--- a/test
+++ b/test
@@ -79,7 +79,7 @@ function run_pipeline_tests()
 (
     cd "${path_test}"
 
-    if [ -f composer.json ]; then
+    if docker-compose -p "ci-${harness}-sample-${mode}" exec console stat composer.json > /dev/null 2>&1; then
       ws exec composer test-quality
       ws exec composer test-unit
       ws exec composer test-acceptance

--- a/test
+++ b/test
@@ -21,7 +21,7 @@ function test()
     setup_dynamic_mountpoint
     install_environment
     check_environment_started "$harness" "$mode"
-    run_pipeline_tests
+    run_pipeline_tests "$harness" "$mode"
     restart_environment
     check_environment_started "$harness" "$mode"
     teardown
@@ -32,7 +32,7 @@ function test()
       setup_dynamic_mutagen
       install_environment
       check_environment_started "$harness" "$mode"
-      run_pipeline_tests
+      run_pipeline_tests "$harness" "$mode"
       restart_environment
       check_environment_started "$harness" "$mode"
       wait_for_vendor_directory
@@ -77,6 +77,9 @@ function check_environment_started()
 
 function run_pipeline_tests()
 (
+    local harness="$1"
+    local mode="$2"
+
     cd "${path_test}"
 
     if docker-compose -p "ci-${harness}-sample-${mode}" exec console stat composer.json > /dev/null 2>&1; then

--- a/test
+++ b/test
@@ -21,7 +21,7 @@ function test()
     setup_dynamic_mountpoint
     install_environment
     check_environment_started "$harness" "$mode"
-    run_pipeline_tests "$harness" "$mode"
+    run_pipeline_tests
     restart_environment
     check_environment_started "$harness" "$mode"
     teardown
@@ -32,7 +32,7 @@ function test()
       setup_dynamic_mutagen
       install_environment
       check_environment_started "$harness" "$mode"
-      run_pipeline_tests "$harness" "$mode"
+      run_pipeline_tests
       restart_environment
       check_environment_started "$harness" "$mode"
       wait_for_vendor_directory
@@ -77,12 +77,9 @@ function check_environment_started()
 
 function run_pipeline_tests()
 (
-    local harness="$1"
-    local mode="$2"
-
     cd "${path_test}"
 
-    if docker-compose -p "ci-${harness}-sample-${mode}" exec console stat composer.json > /dev/null 2>&1; then
+    if ws exec stat composer.json > /dev/null 2>&1; then
       ws exec composer test-quality
       ws exec composer test-unit
       ws exec composer test-acceptance


### PR DESCRIPTION
The check for composer.json on the filesystem was skipping the static builds as the skeleton does not get copied out from the docker image build to the host filesystem.

Convert check to see if composer.json exists in the console container instead.