### PR TITLE
Ignore mutagen.yml in gitignore

### DIFF
--- a/src/akeneo/application/skeleton/.gitignore
+++ b/src/akeneo/application/skeleton/.gitignore
@@ -39,10 +39,11 @@ package-lock.json
 
 # Files
 /.dockerignore
-/mutagen.yml.lock
 /auth.json
 /docker-compose.yml
 /docker-sync.yml
+/mutagen.yml
+/mutagen.yml.lock
 /phpcs.xml
 /phpmd.xml
 /phpunit.xml

--- a/src/drupal8/application/skeleton/.gitignore.twig
+++ b/src/drupal8/application/skeleton/.gitignore.twig
@@ -7,10 +7,11 @@
 
 # Files
 /.dockerignore
-/mutagen.yml.lock
 /auth.json
 /docker-compose.yml
 /docker-sync.yml
+/mutagen.yml
+/mutagen.yml.lock
 /phpcs.xml
 /phpmd.xml
 /phpunit.xml

--- a/src/magento1/application/skeleton/.gitignore
+++ b/src/magento1/application/skeleton/.gitignore
@@ -14,9 +14,10 @@
 # Files
 
 /.dockerignore
-/mutagen.yml.lock
 /docker-compose.yml
 /docker-sync.yml
+/mutagen.yml
+/mutagen.yml.lock
 /phpcs.xml
 /phpmd.xml
 /public/app/etc/local.xml

--- a/src/magento2/application/skeleton/.gitignore
+++ b/src/magento2/application/skeleton/.gitignore
@@ -22,16 +22,13 @@
 # Files
 
 /.dockerignore
-/mutagen.yml.lock
 /.htaccess*
 /.php_cs*
 /.travis.yml
 /.user.ini
+/behat.yml
 /docker-compose.yml
 /docker-sync.yml
-/phpcs.xml
-/phpmd.xml
-/behat.yml
 /app/.htaccess
 /app/*.php
 /auth.json
@@ -47,9 +44,13 @@
 /LICENSE_AFL.txt
 /LICENSE_EE.txt
 /PULL_REQUEST_TEMPLATE.md
+/mutagen.yml
+/mutagen.yml.lock
 /nginx.conf.sample
 /package.json.sample
 /php.ini.sample
+/phpcs.xml
+/phpmd.xml
 /README_EE.md
 /workspace.override.yml
 

--- a/src/spryker/application/skeleton/.gitignore.twig
+++ b/src/spryker/application/skeleton/.gitignore.twig
@@ -32,13 +32,14 @@
 /src/Orm/Propel/*/Sql
 
 # Files
-/.dockerignore
-/mutagen.yml.lock
-/auth.json
-/workspace.override.yml
-/docker-compose.yml
 .DS_Store
+/.dockerignore
+/auth.json
+/c3.php
+/docker-compose.yml
+/mutagen.yml
+/mutagen.yml.lock
+/npm-debug.log
 /public/Yves/maintenance/maintenance.marker
 /public/Zed/maintenance/maintenance.marker
-/npm-debug.log
-/c3.php
+/workspace.override.yml

--- a/src/wordpress/application/skeleton/.gitignore
+++ b/src/wordpress/application/skeleton/.gitignore
@@ -11,14 +11,15 @@
 # Files
 
 /.dockerignore
-/mutagen.yml.lock
+/auth.json
+/behat.yml
 /docker-compose.yml
 /docker-sync.yml
+/mutagen.yml
+/mutagen.yml.lock
 /phpcs.xml
 /phpmd.xml
-/behat.yml
 /public/wp-config.php
-/auth.json
 /workspace.override.yml
 
 # Keep


### PR DESCRIPTION
Like docker-sync.yml, as this is rendered each time we do `ws harness prepare` or `ws install`, we don't need to commit it to the project repository.