### PR TITLE
Treat non-relative symlinks as raw in mutagen

### DIFF
--- a/src/_base/application/skeleton/README.md.twig
+++ b/src/_base/application/skeleton/README.md.twig
@@ -103,6 +103,8 @@ ws switch mutagen
 ws switch docker-sync
 # To check the Mutagen sync status (sync is ready when status is "Watching for changes")
 mutagen monitor
+# To debug an errored sync
+mutagen list
 ```
 
 ### Common Issues

--- a/src/_base/mutagen.yml.twig
+++ b/src/_base/mutagen.yml.twig
@@ -14,6 +14,8 @@ sync:
         defaultGroup: "id:1000"
         defaultFileMode: 0644
         defaultDirectoryMode: 0755
+    symlink:
+      mode: posix-raw
     ignore:
       vcs: true
       paths:


### PR DESCRIPTION
Fixes:
```
Last error: alpha scan error: invalid symbolic link (pub/internal/readiness.php): target is absolute
```