### PR TITLE
Anchor mutagen ignore paths at project root

### DIFF
--- a/src/_base/mutagen.yml.twig
+++ b/src/_base/mutagen.yml.twig
@@ -17,7 +17,7 @@ sync:
     ignore:
       vcs: true
       paths:
-        - .docker-sync
-        - .idea
-        - .git
-        - var
+        - /.docker-sync
+        - /.idea
+        - /.git
+        - /var

--- a/src/_base/mutagen.yml.twig
+++ b/src/_base/mutagen.yml.twig
@@ -15,7 +15,6 @@ sync:
         defaultFileMode: 0644
         defaultDirectoryMode: 0755
     ignore:
-      vcs: true
       paths:
         - /.docker-sync
         - /.idea


### PR DESCRIPTION
docker-sync's ignore paths were anchored via the ignored paths being `BelowPath`.

Allows:
```
vendor/magento/magento2-base/pub/opt/magento/var
vendor/magento/magento2-base/pub/opt/magento/var/resource_config.json
vendor/magento/magento2-base/setup/src/Magento/Setup/Test/Unit/Module/Di/_files/var
vendor/magento/magento2-base/setup/src/Magento/Setup/Test/Unit/Module/Di/_files/var/generation
vendor/magento/magento2-base/setup/src/Magento/Setup/Test/Unit/Module/Di/_files
/var/generation/.keep
```
etc to be synced