### PR TITLE
Trace of what happens during `ws enable`

### DIFF
--- a/src/_base/harness/config/mutagen.yml
+++ b/src/_base/harness/config/mutagen.yml
@@ -30,5 +30,5 @@ command('switch (mutagen|docker-sync)'):
     else
       passthru ws mutagen stop
     fi
-    run ws enable
+    passthru ws enable
     echo 'Done'


### PR DESCRIPTION
After switching between mutagen and docker-sync, docker-sync can take
10-20 minutes to do the initial sync again, so we need feedback