### PR TITLE
Fix `ws docker-sync stop` removing sync container

### DIFF
--- a/src/_base/harness/scripts/docker_sync.sh
+++ b/src/_base/harness/scripts/docker_sync.sh
@@ -58,7 +58,6 @@ stop()
 {
     init_rbenv
     passthru docker-sync stop
-    run docker rm "${NAMESPACE}-sync"
 }
 
 clean()


### PR DESCRIPTION
Causes a painful re-sync on `ws enable`