### PR TITLE
Fix mutagen file permissions sync to host

### DIFF
--- a/src/_base/mutagen.yml.twig
+++ b/src/_base/mutagen.yml.twig
@@ -8,6 +8,12 @@ sync:
     alpha: "."
     beta: "docker://{{ @('workspace.name') }}-sync/app"
     mode: "two-way-resolved"
+    # Configuration for host file system as configured above for "alpha" key
+    configurationAlpha:
+      permissions:
+        defaultFileMode: 0644
+        defaultDirectoryMode: 0755
+    # Configuration for docker file system as configured above for "beta" key
     configurationBeta:
       permissions:
         defaultOwner: "id:1000"


### PR DESCRIPTION
Fixes #238

Files and folders created by composer install or similar inside the console container got copied back to the host filesystem with 0600 and 0700 permissions.

Once edited on the host, they got synced back into the container as-is, causing nginx to not be able to access them and a 403 error presented when accessing (test file for editing on host was Magento 2's pub/index.php - the main entrypoint for the site).