### PR TITLE
Disable k8s service links

### DIFF
--- a/src/_base/helm/app/templates/application/app-init.yaml
+++ b/src/_base/helm/app/templates/application/app-init.yaml
@@ -48,3 +48,4 @@ spec:
       imagePullSecrets:
       - name: {{ .Values.resourcePrefix }}docker-config
       restartPolicy: Never
+      enableServiceLinks: false

--- a/src/_base/helm/app/templates/application/app-migrate.yaml
+++ b/src/_base/helm/app/templates/application/app-migrate.yaml
@@ -49,3 +49,4 @@ spec:
       imagePullSecrets:
       - name: {{ .Values.resourcePrefix }}docker-config
       restartPolicy: Never
+      enableServiceLinks: false

--- a/src/_base/helm/app/templates/application/console/deployment.yaml
+++ b/src/_base/helm/app/templates/application/console/deployment.yaml
@@ -61,6 +61,7 @@ spec:
       imagePullSecrets:
       - name: {{ .Values.resourcePrefix }}docker-config
       restartPolicy: Always
+      enableServiceLinks: false
       volumes:
       {{- if not (eq "" (include "application.volumes.console" .)) }}
       {{- include "application.volumes.console" . | indent 6 }}

--- a/src/_base/helm/app/templates/application/cron/deployment.yaml
+++ b/src/_base/helm/app/templates/application/cron/deployment.yaml
@@ -73,6 +73,7 @@ spec:
       imagePullSecrets:
       - name: {{ .Values.resourcePrefix }}docker-config
       restartPolicy: Always
+      enableServiceLinks: false
       volumes:
       {{- if not (and (eq "" (include "application.volumes.backend" .)) (eq "" (include "application.volumes.all" .)) ) }}
       {{- include "application.volumes.backend" . | indent 6 }}

--- a/src/_base/helm/app/templates/application/webapp/deployment.yaml
+++ b/src/_base/helm/app/templates/application/webapp/deployment.yaml
@@ -128,6 +128,7 @@ spec:
       imagePullSecrets:
       - name: {{ .Values.resourcePrefix }}docker-config
       restartPolicy: Always
+      enableServiceLinks: false
       volumes:
       {{- if not (and (eq "" (include "application.volumes.backend" .)) (eq "" (include "application.volumes.all" .)) ) }}
       {{- include "application.volumes.backend" . | indent 6 }}

--- a/src/akeneo/helm/app/templates/application/job-queue-consumer/deployment.yaml
+++ b/src/akeneo/helm/app/templates/application/job-queue-consumer/deployment.yaml
@@ -79,6 +79,7 @@ spec:
       imagePullSecrets:
       - name: {{ .Values.resourcePrefix }}docker-config
       restartPolicy: Always
+      enableServiceLinks: false
       volumes:
       {{- if not (and (eq "" (include "application.volumes.backend" .)) (eq "" (include "application.volumes.all" .)) ) }}
       {{- include "application.volumes.backend" . | indent 6 }}

--- a/src/spryker/helm/app/templates/application/jenkins-runner/deployment.yaml
+++ b/src/spryker/helm/app/templates/application/jenkins-runner/deployment.yaml
@@ -63,6 +63,7 @@ spec:
       imagePullSecrets:
       - name: {{ .Values.resourcePrefix }}docker-config
       restartPolicy: Always
+      enableServiceLinks: false
       volumes:
       {{- if not (and (eq "" (include "application.volumes.backend" .)) (eq "" (include "application.volumes.all" .)) ) }}
       {{- include "application.volumes.backend" . | indent 6 }}


### PR DESCRIPTION
By default k8s injects environment variables with service hostnames and ports into pods, this was used as a form of service discovery before coredns became the standard.

These cause issues, especially the `_PORT` variants, disabling them in favour of always specifying the exact ones we want as needed.