### PR TITLE
make console pod optional in app helm chart

### DIFF
--- a/src/_base/helm/app/templates/application/console/deployment.yaml
+++ b/src/_base/helm/app/templates/application/console/deployment.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.console.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -68,3 +69,4 @@ spec:
       {{- else }} []
       {{- end }}
 status: {}
+{{ end }}

--- a/src/_base/helm/app/values.yaml.twig
+++ b/src/_base/helm/app/values.yaml.twig
@@ -1,5 +1,8 @@
 {% set blocks  = 'helm/app/_twig/values.yaml/' %}
 
+console:
+  enabled: true
+
 environment:
 {% include blocks ~ 'environment.yml.twig' %}
 

--- a/src/spryker/helm/app/values.yaml.twig
+++ b/src/spryker/helm/app/values.yaml.twig
@@ -1,5 +1,8 @@
 {% set blocks  = 'helm/app/_twig/values.yaml/' %}
 
+console:
+  enabled: true
+
 environment:
 {% include blocks ~ 'environment.yml.twig' %}
 


### PR DESCRIPTION
As we're being a bit stricter with memory requests it wont be feasible to have the console pod running at all times.

Have made it optional so we can enable it as needed on a per environment basis.