### PR TITLE
lower the revision history limit for k8s deployments

### DIFF
--- a/src/_base/helm/app/templates/application/console/deployment.yaml
+++ b/src/_base/helm/app/templates/application/console/deployment.yaml
@@ -9,6 +9,7 @@ metadata:
     argocd.argoproj.io/sync-wave: "15"
 spec:
   replicas: 1
+  revisionHistoryLimit: 2
   selector:
     matchLabels:
       app.service: {{ .Values.resourcePrefix }}console

--- a/src/_base/helm/app/templates/application/cron/deployment.yaml
+++ b/src/_base/helm/app/templates/application/cron/deployment.yaml
@@ -9,6 +9,7 @@ metadata:
     argocd.argoproj.io/sync-wave: "15"
 spec:
   replicas: 1
+  revisionHistoryLimit: 2
   selector:
     matchLabels:
       app.service: {{ .Values.resourcePrefix }}cron

--- a/src/_base/helm/app/templates/application/webapp/deployment.yaml
+++ b/src/_base/helm/app/templates/application/webapp/deployment.yaml
@@ -8,6 +8,7 @@ metadata:
     argocd.argoproj.io/sync-wave: "15"
 spec:
   replicas: 1
+  revisionHistoryLimit: 2
   selector:
     matchLabels:
       app.service: {{ .Values.resourcePrefix }}webapp

--- a/src/akeneo/helm/app/templates/application/job-queue-consumer/deployment.yaml
+++ b/src/akeneo/helm/app/templates/application/job-queue-consumer/deployment.yaml
@@ -8,6 +8,7 @@ metadata:
     argocd.argoproj.io/sync-wave: "15"
 spec:
   replicas: 1
+  revisionHistoryLimit: 2
   selector:
     matchLabels:
       app.service: {{ .Values.resourcePrefix }}job-queue-consumer

--- a/src/spryker/helm/app/templates/application/jenkins-runner/deployment.yaml
+++ b/src/spryker/helm/app/templates/application/jenkins-runner/deployment.yaml
@@ -9,6 +9,7 @@ metadata:
     argocd.argoproj.io/sync-wave: "15"
 spec:
   replicas: 1
+  revisionHistoryLimit: 2
   selector:
     matchLabels:
       app.service: {{ .Values.resourcePrefix }}jenkins-runner


### PR DESCRIPTION
unused revisions clutter up the argocd UI, as argo itself handles rollbacks using previous git commits it makes no use of them. 