### PR TITLE
Fix TTY usage when stdin is not a TTY.

### DIFF
--- a/src/_base/harness/config/commands.yml
+++ b/src/_base/harness/config/commands.yml
@@ -51,7 +51,7 @@ command('exec %'):
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|=
-    if [ -t 1 ] ; then
+    if [ -t 0 ] && [ -t 1 ] ; then
       docker-compose exec -u build console ={ input.argument('%') }
     else
       docker-compose exec -T -u build console ={ input.argument('%') }


### PR DESCRIPTION
Fixes "the input device is not a TTY" messages from docker-compose when
running via a git hook