### PR TITLE
Use default Symfony4 web directory

### DIFF
--- a/src/symfony/harness.yml
+++ b/src/symfony/harness.yml
@@ -13,7 +13,6 @@ attributes:
     web_group: www-data
     web_writable_dirs:
       - '/app/var/'
-    web_directory: /app/web
     services:
       - chrome
       - mysql


### PR DESCRIPTION
The harness specific override of "app.web_directory" will not work with Symfony4+, the default "/app/public" from the base harness should do just fine.