### PR TITLE
Add support for multiple php-fpm pools and split spryker zed into one

### DIFF
--- a/src/_base/_twig/docker-compose.yml/application.yml.twig
+++ b/src/_base/_twig/docker-compose.yml/application.yml.twig
@@ -73,3 +73,7 @@
     environment:
 {{ deep_merge_to_yaml([@('services.php-base.environment'), @('services.php-fpm.environment')], 2, 6) | raw }}
 {% include blocks ~ 'environment.yml.twig' %}
+    expose:
+{% for pool in @('php-fpm.pools') %}
+      - {{ pool.port }}
+{% endfor %}

--- a/src/_base/docker/image/php-fpm/root/entrypoint.sh.twig
+++ b/src/_base/docker/image/php-fpm/root/entrypoint.sh.twig
@@ -2,8 +2,10 @@
 
 run_steps()
 {
-    echo "pm.status_path = /status" >> /usr/local/etc/php-fpm.d/www.conf
-
+    {% for poolName, pool in @('php-fpm.pools') -%}
+    FPM_NAME="{{ poolName }}" FPM_PORT="{{ pool.port }}" envsubst < /usr/local/etc/php-fpm.d/pool.conf.template > /usr/local/etc/php-fpm.d/{{ poolName }}.conf;
+    {% endfor %}
+    
     # run any command required to be executed at docker startup
     {% for step in @('php-fpm.entrypoint.steps') -%}
     {{ step|raw }}

--- a/src/_base/docker/image/php-fpm/root/usr/local/etc/php-fpm.d/pool.conf.template
+++ b/src/_base/docker/image/php-fpm/root/usr/local/etc/php-fpm.d/pool.conf.template
@@ -12,3 +12,7 @@ pm.min_spare_servers = 1
 pm.max_spare_servers = 3
 
 pm.status_path = /status
+
+clear_env = no
+catch_workers_output = yes
+

--- a/src/_base/docker/image/php-fpm/root/usr/local/etc/php-fpm.d/pool.conf.template
+++ b/src/_base/docker/image/php-fpm/root/usr/local/etc/php-fpm.d/pool.conf.template
@@ -1,0 +1,14 @@
+[${FPM_NAME}]
+user = www-data
+group = www-data
+
+listen = ${FPM_PORT}
+
+pm = dynamic
+
+pm.max_children = 5
+pm.start_servers = 2
+pm.min_spare_servers = 1
+pm.max_spare_servers = 3
+
+pm.status_path = /status

--- a/src/_base/harness/attributes/common.yml
+++ b/src/_base/harness/attributes/common.yml
@@ -173,6 +173,9 @@ attributes.default:
     timeout: 300
 
   php-fpm:
+    pools:
+      www:
+        port: 9000
     entrypoint:
       steps: []
   

--- a/src/_base/harness/attributes/docker-base.yml
+++ b/src/_base/harness/attributes/docker-base.yml
@@ -24,7 +24,7 @@ attributes:
         AUTOSTART_PHP_FPM: "true"
     php-fpm-exporter:
       environment:
-        PHP_FPM_SCRAPE_URI: tcp://php-fpm:9000/status
+        PHP_FPM_SCRAPE_URI: = php_fpm_exporter_scrape_url('php-fpm', @('php-fpm.pools'))
     mysql:
       environment:
         MYSQL_DATABASE: = @('database.name')
@@ -58,7 +58,7 @@ attributes:
             - port: http
         php-fpm-exporter:
           environment:
-            PHP_FPM_SCRAPE_URI: tcp://127.0.0.1:9000/status
+            PHP_FPM_SCRAPE_URI: = php_fpm_exporter_scrape_url('127.0.0.1', @('php-fpm.pools'))
           metricsEnabled: true
           metricsEndpoints:
             - port: php-fpm-metrics

--- a/src/_base/harness/config/functions.yml
+++ b/src/_base/harness/config/functions.yml
@@ -67,3 +67,16 @@ function('slugify', [text]): |
   $text = preg_replace('~-+~', '-', $text);
   $text = strtolower($text);
   = $text;
+
+function('php_fpm_exporter_scrape_url', [hostname, pools]): |
+  #!php
+  $text = join(
+      ',',
+      array_map(
+        function ($pool) use ($hostname) {
+          return 'tcp://' . $hostname .':' . $pool['port'] . '/status';
+        },
+        $pools
+      )
+    );
+  = $text;

--- a/src/spryker/_twig/docker-compose.yml/application.yml.twig
+++ b/src/spryker/_twig/docker-compose.yml/application.yml.twig
@@ -82,3 +82,7 @@
     environment:
 {{ deep_merge_to_yaml([@('services.php-base.environment'), @('services.php-fpm.environment')], 2, 6) | raw }}
 {% include blocks ~ 'environment.yml.twig' %}
+    expose:
+{% for pool in @('php-fpm.pools') %}
+      - {{ pool.port }}
+{% endfor %}

--- a/src/spryker/docker/image/nginx/root/docker-entrypoint.d/config_render.sh.twig
+++ b/src/spryker/docker/image/nginx/root/docker-entrypoint.d/config_render.sh.twig
@@ -2,9 +2,9 @@
 
 function render_configuration()
 {
-   local vars='$FPM_HOST $ZED_HOST {% for store, yves_external_host in @('yves.external_hosts') %}$YVES_HOST_{{ store }} {% endfor %}{% for store, glue_external_host in @('glue.external_hosts') %}$GLUE_HOST_{{ store }} {% endfor %}'
+  local vars='$FPM_HOST $ZED_HOST {% for store, yves_external_host in @('yves.external_hosts') %}$YVES_HOST_{{ store }} {% endfor %}{% for store, glue_external_host in @('glue.external_hosts') %}$GLUE_HOST_{{ store }} {% endfor %}'
 
-   for file in /etc/nginx/conf.d/*.template; do
+  for file in /etc/nginx/conf.d/*.template; do
     envsubst "$vars" < $file > ${file%.template};
   done
 }

--- a/src/spryker/docker/image/nginx/root/etc/nginx/conf.d/glue.conf.template.twig
+++ b/src/spryker/docker/image/nginx/root/etc/nginx/conf.d/glue.conf.template.twig
@@ -40,7 +40,7 @@ server {
     # PHP application gets all other requests
     location / {
         add_header X-Server $hostname;
-        fastcgi_pass ${FPM_HOST}:9000;
+        fastcgi_pass ${FPM_HOST}:{{ @('php-fpm.pools.www.port') }};
         fastcgi_index index.php;
         include /etc/nginx/fastcgi_params;
         fastcgi_param SCRIPT_NAME /index.php;

--- a/src/spryker/docker/image/nginx/root/etc/nginx/conf.d/yves.conf.template.twig
+++ b/src/spryker/docker/image/nginx/root/etc/nginx/conf.d/yves.conf.template.twig
@@ -52,7 +52,7 @@ server {
         }
 
         add_header X-Server $hostname;
-        fastcgi_pass ${FPM_HOST}:9000;
+        fastcgi_pass ${FPM_HOST}:{{ @('php-fpm.pools.www.port') }};
         fastcgi_index index.php;
         include /etc/nginx/fastcgi_params;
         fastcgi_param SCRIPT_NAME /index.php;

--- a/src/spryker/docker/image/nginx/root/etc/nginx/conf.d/zed.conf.template.twig
+++ b/src/spryker/docker/image/nginx/root/etc/nginx/conf.d/zed.conf.template.twig
@@ -34,7 +34,7 @@ server {
     # PHP application gets all other requests
     location / {
         add_header X-Server $hostname;
-        fastcgi_pass ${FPM_HOST}:9000;
+        fastcgi_pass ${FPM_HOST}:{{ @('php-fpm.pools.zed.port') }};
         fastcgi_index index.php;
         include /etc/nginx/fastcgi_params;
         fastcgi_param SCRIPT_NAME /index.php;

--- a/src/spryker/harness.yml
+++ b/src/spryker/harness.yml
@@ -154,6 +154,11 @@ attributes:
     timeout: 900
 
   php-fpm:
+    pools:
+      www:
+        port: 9000
+      zed:
+        port: 9001
     entrypoint:
       steps:
         - echo "$(getent hosts nginx | awk '{ print $1 }') $ZED_HOST" >> /etc/hosts


### PR DESCRIPTION
Spryker glue and yves make calls to zed, which if on a single pool can lead to zed calls waiting on their own glue/yves requests to finish

Another php-fpm pool keeps zed separate, so frontend requests don't compete with backend requests