### PR TITLE
Run `setup:di:compile` for Magento 2 in static mode

### DIFF
--- a/src/magento2/harness.yml
+++ b/src/magento2/harness.yml
@@ -57,6 +57,13 @@ attributes:
         - task "composer:install"
         - task "magento:tidy"
         - |
+          if [ "$APP_BUILD" == "static" ] ; then
+            run "mv app/etc/env.php app/etc/env-backup.php"
+            passthru "bin/magento setup:di:compile"
+            run "composer dump-autoload --optimize"
+            run "mv app/etc/env-backup.php app/etc/env.php"
+          fi
+        - |
           if [ "$APP_BUILD" == "static" ] && validate-magento-config ; then
             run "mv app/etc/env.php app/etc/env-backup.php"
             passthru "bin/magento setup:static-content:deploy -f"


### PR DESCRIPTION
Helps catch Dependency Injection compilation issues during the CI build and allows production mode to function when deployed.