### PR TITLE
Add extra cache types to avoid env.php needing to be writable at runtime

### DIFF
--- a/src/magento2/application/overlay/app/etc/env.php.twig
+++ b/src/magento2/application/overlay/app/etc/env.php.twig
@@ -63,10 +63,12 @@ return [
         'collections' => 1,
         'reflection' => 1,
         'db_ddl' => 1,
+        'compiled_config' => 1,
         'eav' => 1,
         'customer_notification' => 1,
         'config_integration' => 1,
         'config_integration_api' => 1,
+        'target_rule' => 1,
         'full_page' => 1,
         'translate' => 1,
         'config_webservice' => 1


### PR DESCRIPTION
Upon first page load, magento is trying to rewrite env.php to add `compiled_config` to the cache types list.
We do not want env.php to be writeable at runtime on a pipeline or production environment. We can avoid this rewrite by ensuring all cache types are present.