### PR TITLE
Production PHP Settings

### DIFF
--- a/src/_base/harness/attributes/common.yml
+++ b/src/_base/harness/attributes/common.yml
@@ -134,7 +134,16 @@ attributes.default:
     fpm:
       ini:
         memory_limit: 1024M
-    ini: ~
+        expose_php: Off
+        max_input_time: 60
+        output_buffering: 4096
+        disable_functions: pcntl_alarm,pcntl_fork,pcntl_waitpid,pcntl_wait,pcntl_wifexited,pcntl_wifstopped,pcntl_wifsignaled,pcntl_wifcontinued,pcntl_wexitstatus,pcntl_wtermsig,pcntl_wstopsig,pcntl_signal,pcntl_signal_get_handler,pcntl_signal_dispatch,pcntl_get_last_error,pcntl_strerror,pcntl_sigprocmask,pcntl_sigwaitinfo,pcntl_sigtimedwait,pcntl_exec,pcntl_getpriority,pcntl_setpriority,pcntl_async_signals
+        log_errors: On
+        register_argc_argv: Off
+    ini:
+      enable_dl: Off
+      short_open_tag: Off
+      realpath_cache_ttl: 600
     ext-xdebug:
       enable: no
       cli:

--- a/src/_base/harness/attributes/common.yml
+++ b/src/_base/harness/attributes/common.yml
@@ -134,6 +134,7 @@ attributes.default:
     fpm:
       ini:
         disable_functions: pcntl_alarm,pcntl_fork,pcntl_waitpid,pcntl_wait,pcntl_wifexited,pcntl_wifstopped,pcntl_wifsignaled,pcntl_wifcontinued,pcntl_wexitstatus,pcntl_wtermsig,pcntl_wstopsig,pcntl_signal,pcntl_signal_get_handler,pcntl_signal_dispatch,pcntl_get_last_error,pcntl_strerror,pcntl_sigprocmask,pcntl_sigwaitinfo,pcntl_sigtimedwait,pcntl_exec,pcntl_getpriority,pcntl_setpriority,pcntl_async_signals
+        error_reporting: "E_ALL"
         expose_php: Off
         log_errors: On
         max_input_time: 60

--- a/src/_base/harness/attributes/common.yml
+++ b/src/_base/harness/attributes/common.yml
@@ -133,17 +133,20 @@ attributes.default:
         memory_limit: -1
     fpm:
       ini:
-        memory_limit: 1024M
-        expose_php: Off
-        max_input_time: 60
-        output_buffering: 4096
         disable_functions: pcntl_alarm,pcntl_fork,pcntl_waitpid,pcntl_wait,pcntl_wifexited,pcntl_wifstopped,pcntl_wifsignaled,pcntl_wifcontinued,pcntl_wexitstatus,pcntl_wtermsig,pcntl_wstopsig,pcntl_signal,pcntl_signal_get_handler,pcntl_signal_dispatch,pcntl_get_last_error,pcntl_strerror,pcntl_sigprocmask,pcntl_sigwaitinfo,pcntl_sigtimedwait,pcntl_exec,pcntl_getpriority,pcntl_setpriority,pcntl_async_signals
+        expose_php: Off
         log_errors: On
+        max_input_time: 60
+        memory_limit: 1024M
+        output_buffering: 4096
         register_argc_argv: Off
+        request_order: GP
+        variables_order: GPCS
     ini:
       enable_dl: Off
-      short_open_tag: Off
+      opcache.enable_cli: On
       realpath_cache_ttl: 600
+      short_open_tag: Off
     ext-xdebug:
       enable: no
       cli:

--- a/src/_base/harness/attributes/environment/pipeline.yml
+++ b/src/_base/harness/attributes/environment/pipeline.yml
@@ -6,3 +6,7 @@ attributes:
     build: static
     version: =exec("git log -n 1 --pretty=format:'%H'")
     mode: production
+  php:
+    fpm:
+      ini:
+        display_errors: Off

--- a/src/_base/harness/attributes/environment/pipeline.yml
+++ b/src/_base/harness/attributes/environment/pipeline.yml
@@ -10,3 +10,4 @@ attributes:
     fpm:
       ini:
         display_errors: Off
+        zend.assertions: -1

--- a/src/_base/harness/attributes/environment/pipeline.yml
+++ b/src/_base/harness/attributes/environment/pipeline.yml
@@ -10,4 +10,5 @@ attributes:
     fpm:
       ini:
         display_errors: Off
+        error_reporting: "E_ALL & ~E_DEPRECATED & ~E_STRICT"
         zend.assertions: -1


### PR DESCRIPTION
Fixes https://github.com/inviqa/harness-base-php/issues/275

Mostly around display_errors being on instead of off, but compared with `docker run --rm -it my127/php:7.3-fpm-stretch cat /usr/local/etc/php/php.ini-production`.

Also compared to continuouspipe's magento2 docker image to see what settings are missing vs ubuntu.

Opcache is covered by another issue and is per-framework. Sessions I've left alone.

Full list from `continuouspipe php-fpm` to `my127 php-fpm`:
```diff
-disable_functions=pcntl_alarm,pcntl_fork,pcntl_waitpid,pcntl_wait,pcntl_wifexited,pcntl_wifstopped,pcntl_wifsignaled,pcntl_wifcontinued,pcntl_wexitstatus,pcntl_wtermsig,pcntl_wstopsig,pcntl_signal,pcntl_signal_get_handler,pcntl_signal_dispatch,pcntl_get_last_error,pcntl_strerror,pcntl_sigprocmask,pcntl_sigwaitinfo,pcntl_sigtimedwait,pcntl_exec,pcntl_getpriority,pcntl_setpriority,pcntl_async_signals,
+disable_functions=

-display_errors=Off
+display_errors=On

-enable_dl=Off
+enable_dl=On

-error_log=/var/log/php-fpm/stdout
+error_log=

-error_reporting=22527
+error_reporting=

-expose_php=Off
+expose_php=On

-log_errors=On
+log_errors=Off

-max_execution_time=600
+max_execution_time=86400

-max_input_time=60
+max_input_time=-1

-memory_limit=768M
+memory_limit=756M

-output_buffering=4096
+output_buffering=0

-realpath_cache_ttl=600
+realpath_cache_ttl=120

-register_argc_argv=Off
+register_argc_argv=On

-request_order=GP
+request_order=

-sendmail_path=/usr/sbin/sendmail -t -i #
+sendmail_path=-t -i #

-short_open_tag=Off
+short_open_tag=On

-variables_order=GPCS
+variables_order=EGPCS

-zend.assertions=-1
+zend.assertions=1

-session.gc_divisor=1000
+session.gc_divisor=100

-session.gc_probability=0
+session.gc_probability=1

-session.save_path=/var/lib/php/sessions
+session.save_path=

-session.sid_bits_per_character=5
+session.sid_bits_per_character=4

-session.sid_length=26
+session.sid_length=32

-opcache.enable_cli=On
+opcache.enable_cli=Off

-opcache.interned_strings_buffer=64
+opcache.interned_strings_buffer=8

-opcache.max_accelerated_files=130987
+opcache.max_accelerated_files=10000

-opcache.memory_consumption=512
+opcache.memory_consumption=128

-opcache.optimization_level=0X7FFFBFFF
+opcache.optimization_level=0
```