### PR TITLE
Avoid copying assets to php-fpm from console

### DIFF
--- a/src/_base/docker/image/php-fpm/Dockerfile.twig
+++ b/src/_base/docker/image/php-fpm/Dockerfile.twig
@@ -1,5 +1,6 @@
 {% if @('app.build') == 'static' %}
 FROM {{ @('docker.repository') ~ ':' ~ @('app.version') }}-console as console
+RUN if [ -d /app/tools/assets/ ]; then rm -rf /app/tools/assets/; fi
 {% endif %}
 
 FROM {{ @('docker.image.php-fpm') }}

--- a/src/_base/harness/scripts/destroy.sh
+++ b/src/_base/harness/scripts/destroy.sh
@@ -11,6 +11,7 @@ elif [[ "$USE_MUTAGEN" = "yes" ]]; then
 fi
 
 if [[ "$APP_BUILD" = "static" ]]; then
+    run "docker images --filter=since='${DOCKER_REPOSITORY}:${APP_VERSION}-console' -q | xargs --no-run-if-empty docker image rm --force"
     run "docker images --filter=reference='${DOCKER_REPOSITORY}:${APP_VERSION}-*' -q | xargs --no-run-if-empty docker image rm --force"
 fi
 


### PR DESCRIPTION
Only console should need the tools/assets/ folder, delete it during the multi-stage build for php-fpm.

Decreases large push/pull times in case of a large media or database dump.