### PR TITLE
Allow using a fixed mysql port forward to the host

### DIFF
--- a/src/_base/_twig/docker-compose.yml/service/mysql.yml.twig
+++ b/src/_base/_twig/docker-compose.yml/service/mysql.yml.twig
@@ -14,4 +14,4 @@
     networks:
       - private
     ports:
-      - 3306
+      - {% if @('database.port_forward') %}{{ @('database.port_forward') }}:{% endif %}3306

--- a/src/_base/application/skeleton/README.md.twig
+++ b/src/_base/application/skeleton/README.md.twig
@@ -46,6 +46,32 @@ To watch for changes, run `ws frontend watch`.
 
 To gain access to the `console` container where the builds happen: `ws frontend console`.
 
+{% if "mysql" in @('app.services') %}
+### MySQL Access
+
+MySQL can be used either via command line tools via `ws db console` or via GUI tools.
+
+In your GUI tool, set up a new connection to localhost with the port being the returned port number from:
+```bash
+ws port mysql
+````
+
+{% if @('database.port_forward') == "" %}
+This port will change each time the project environment is started, as docker will allocate a random unused port
+on your host machine.
+
+To set a consistent port for this project, choose a port number that you think will be unique across all projects
+that your developers will encounter (e.g. not 3306!). Acceptable range of ports is 1-65535.
+
+Once you have a port number, you can define it in the workspace.yml with:
+```yaml
+attribute('database.port_forward'): portNumberHere
+```
+{% endif %}
+
+The connection username and password is listed in `docker-compose.yml` in the project root.
+{% endif %}
+
 ### Xdebug
 
 Xdebug is turned off by default as it drastically slows down requests for all developers.

--- a/src/_base/application/skeleton/README.md.twig
+++ b/src/_base/application/skeleton/README.md.twig
@@ -46,7 +46,7 @@ To watch for changes, run `ws frontend watch`.
 
 To gain access to the `console` container where the builds happen: `ws frontend console`.
 
-{% if "mysql" in @('app.services') %}
+{% if "mysql" in @('app.services') -%}
 ### MySQL Access
 
 MySQL can be used either via command line tools via `ws db console` or via GUI tools.
@@ -54,9 +54,9 @@ MySQL can be used either via command line tools via `ws db console` or via GUI t
 In your GUI tool, set up a new connection to localhost with the port being the returned port number from:
 ```bash
 ws port mysql
-````
+```
 
-{% if @('database.port_forward') == "" %}
+{% if @('database.port_forward') == "" -%}
 This port will change each time the project environment is started, as docker will allocate a random unused port
 on your host machine.
 
@@ -67,9 +67,10 @@ Once you have a port number, you can define it in the workspace.yml with:
 ```yaml
 attribute('database.port_forward'): portNumberHere
 ```
-{% endif %}
+{%- endif %}
 
-The connection username and password is listed in `docker-compose.yml` in the project root.
+The connection username and password is listed under the `mysql` service environment section in `docker-compose.yml` in
+the project root.
 {% endif %}
 
 ### Xdebug

--- a/src/_base/harness/attributes/common.yml
+++ b/src/_base/harness/attributes/common.yml
@@ -157,6 +157,7 @@ attributes.default:
     pass: app
     name: app
     root_pass: DV6RdNY3QcFsBk7V
+    port_forward: ~
     var:
       max_allowed_packet: 4M
     import:


### PR DESCRIPTION
Opt in to having a fixed port for mysql forwarded to the host machine, instead of a random one each time the environment starts.

Idea is to get projects to choose a port that will be hopefully unique to them, at least across all the other projects they work on.