### PR TITLE
Ensure latest drupal/core 8.8.5 is installed. Fix test-quality script

### DIFF
--- a/src/drupal8/application/overlay/phpcs.xml.twig
+++ b/src/drupal8/application/overlay/phpcs.xml.twig
@@ -15,9 +15,9 @@
   <arg value="np"/>
 
   <!-- Use Drupal rules -->
-  <rule ref="./vendor/drupal/coder/coder_sniffer/Drupal"/>
+  <rule ref="./docroot/modules/contrib/coder/coder_sniffer/Drupal"/>
 
-  <!-- 
+  <!--
   Don't enforce class / method comments - in PHP7.x we have return
   types, and lots of classes and methods are self expanatory. Comments
 
@@ -43,8 +43,8 @@
     <severity>0</severity>
   </rule>
 
-  <!-- 
-  Annotations should be imported, not expanded 
+  <!--
+  Annotations should be imported, not expanded
   -->
   <rule ref="Drupal.Commenting.DataTypeNamespace.DataTypeNamespace">
     <severity>0</severity>

--- a/src/drupal8/application/skeleton/composer.json
+++ b/src/drupal8/application/skeleton/composer.json
@@ -17,6 +17,7 @@
   },
   "require-dev": {
     "dmore/behat-chrome-extension": "^1.3",
+    "drupal/core-dev": "^8",
     "drupal/devel": "^2.0",
     "drupal/drupal-extension": "^3.4",
     "jangregor/phpstan-prophecy": "^0.3.0",
@@ -25,8 +26,7 @@
     "mglaman/phpstan-drupal": "^0.11.4",
     "phpcompatibility/php-compatibility": "dev-master",
     "phpstan/phpstan": "0.11.16",
-    "phpstan/phpstan-deprecation-rules": "^0.11.2",
-    "webflo/drupal-core-require-dev": "^8"
+    "phpstan/phpstan-deprecation-rules": "^0.11.2"
   },
   "require": {
     "composer/installers": "^1.0",
@@ -44,7 +44,7 @@
     "drupal/login_emailusername": "1.1",
     "drupal/menu_admin_per_menu": "1.0",
     "drupal/metatag": "1.7",
-    "drupal/pathauto": "1.3",
+    "drupal/pathauto": "^1.8",
     "drupal/redirect": "1.3",
     "drupal/roleassign": "^1.0@alpha",
     "drupal/seckit": "1.1",


### PR DESCRIPTION
`webflo/drupal-core-require-dev` is deprecated and for some reason wasn't pulling in the drupal/coder package to the right place.

Replace with the recommended replacement `drupal/core-dev`.

Upgrade `drupal/pathauto` module so it brings in latest `drupal/core` package.