### PR TITLE
Add missing php-fpm pool overrides to pool config

### DIFF
--- a/src/_base/docker/image/php-fpm/root/usr/local/etc/php-fpm.d/pool.conf.template.twig
+++ b/src/_base/docker/image/php-fpm/root/usr/local/etc/php-fpm.d/pool.conf.template.twig
@@ -13,6 +13,12 @@ pm.max_spare_servers = 3
 
 pm.status_path = /status
 
-clear_env = no
-catch_workers_output = yes
+; if we send this to /proc/self/fd/1, it never appears
+access.log = /proc/self/fd/2
 
+clear_env = no
+
+catch_workers_output = yes
+{% if version_compare(@('php.version'), '7.3.0', '>=') %}
+decorate_workers_output = no
+{% endif %}

--- a/src/_base/harness/config/confd.yml
+++ b/src/_base/harness/config/confd.yml
@@ -23,6 +23,7 @@ confd('harness:/'):
   - { src: docker/image/php-fpm/root/fix_app_permissions.sh }
   - { src: docker/image/php-fpm/root/usr/local/etc/php/php.ini }
   - { src: docker/image/php-fpm/root/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini }
+  - { src: docker/image/php-fpm/root/usr/local/etc/php-fpm.d/pool.conf.template }
   - { src: docker/image/cron/Dockerfile }
   - { src: docker/image/cron/root/crontab }
   - { src: application/overlay/Jenkinsfile }

--- a/src/_base/harness/config/functions.yml
+++ b/src/_base/harness/config/functions.yml
@@ -85,6 +85,6 @@ function('version_compare', [version1, version2, operator]): |
   #!php
   $count1 = substr_count($version1, '.');
   $count2 = substr_count($version2, '.');
-  $version1 .= $count1 == 1 ? '.0' : '';
-  $version2 .= $count2 == 1 ? '.0' : '';
+  $version1 .= str_repeat('.0', max(0, $count2 - $count1));
+  $version2 .= str_repeat('.0', max(0, $count1 - $count2));
   = version_compare($version1, $version2, $operator);

--- a/src/_base/harness/config/functions.yml
+++ b/src/_base/harness/config/functions.yml
@@ -80,3 +80,7 @@ function('php_fpm_exporter_scrape_url', [hostname, pools]): |
       )
     );
   = $text;
+
+function('version_compare', [version1, version2, operator]): |
+  #!php
+  = version_compare($version1, $version2, $operator);

--- a/src/_base/harness/config/functions.yml
+++ b/src/_base/harness/config/functions.yml
@@ -83,4 +83,8 @@ function('php_fpm_exporter_scrape_url', [hostname, pools]): |
 
 function('version_compare', [version1, version2, operator]): |
   #!php
+  $count1 = substr_count($version1, '.');
+  $count2 = substr_count($version2, '.');
+  $version1 .= $count1 == 1 ? '.0' : '';
+  $version2 .= $count2 == 1 ? '.0' : '';
   = version_compare($version1, $version2, $operator);

--- a/src/akeneo/harness/config/confd.yml
+++ b/src/akeneo/harness/config/confd.yml
@@ -23,6 +23,7 @@ confd('harness:/'):
   - { src: docker/image/php-fpm/root/fix_app_permissions.sh }
   - { src: docker/image/php-fpm/root/usr/local/etc/php/php.ini }
   - { src: docker/image/php-fpm/root/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini }
+  - { src: docker/image/php-fpm/root/usr/local/etc/php-fpm.d/pool.conf.template }
   - { src: docker/image/cron/Dockerfile }
   - { src: docker/image/cron/root/crontab }
   - { src: application/overlay/Jenkinsfile }

--- a/src/drupal8/harness/config/confd.yml
+++ b/src/drupal8/harness/config/confd.yml
@@ -23,6 +23,7 @@ confd('harness:/'):
   - { src: docker/image/php-fpm/root/fix_app_permissions.sh }
   - { src: docker/image/php-fpm/root/usr/local/etc/php/php.ini }
   - { src: docker/image/php-fpm/root/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini }
+  - { src: docker/image/php-fpm/root/usr/local/etc/php-fpm.d/pool.conf.template }
   - { src: docker/image/cron/Dockerfile }
   - { src: docker/image/cron/root/crontab }
   - { src: application/overlay/Jenkinsfile }

--- a/src/magento1/harness/config/confd.yml
+++ b/src/magento1/harness/config/confd.yml
@@ -23,6 +23,7 @@ confd('harness:/'):
   - { src: docker/image/php-fpm/root/fix_app_permissions.sh }
   - { src: docker/image/php-fpm/root/usr/local/etc/php/php.ini }
   - { src: docker/image/php-fpm/root/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini }
+  - { src: docker/image/php-fpm/root/usr/local/etc/php-fpm.d/pool.conf.template }
   - { src: docker/image/cron/Dockerfile }
   - { src: docker/image/cron/root/crontab }
   - { src: application/overlay/Jenkinsfile }

--- a/src/magento2/harness/config/confd.yml
+++ b/src/magento2/harness/config/confd.yml
@@ -23,6 +23,7 @@ confd('harness:/'):
   - { src: docker/image/php-fpm/root/fix_app_permissions.sh }
   - { src: docker/image/php-fpm/root/usr/local/etc/php/php.ini }
   - { src: docker/image/php-fpm/root/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini }
+  - { src: docker/image/php-fpm/root/usr/local/etc/php-fpm.d/pool.conf.template }
   - { src: docker/image/cron/Dockerfile }
   - { src: docker/image/cron/root/crontab }
   - { src: application/overlay/Jenkinsfile }

--- a/src/spryker/harness/config/confd.yml
+++ b/src/spryker/harness/config/confd.yml
@@ -23,6 +23,7 @@ confd('harness:/'):
   - { src: docker/image/php-fpm/root/fix_app_permissions.sh }
   - { src: docker/image/php-fpm/root/usr/local/etc/php/php.ini }
   - { src: docker/image/php-fpm/root/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini }
+  - { src: docker/image/php-fpm/root/usr/local/etc/php-fpm.d/pool.conf.template }
   - { src: docker/image/cron/Dockerfile }
   - { src: docker/image/cron/root/crontab }
   - { src: application/overlay/Jenkinsfile }

--- a/src/wordpress/harness/config/confd.yml
+++ b/src/wordpress/harness/config/confd.yml
@@ -23,6 +23,7 @@ confd('harness:/'):
   - { src: docker/image/php-fpm/root/fix_app_permissions.sh }
   - { src: docker/image/php-fpm/root/usr/local/etc/php/php.ini }
   - { src: docker/image/php-fpm/root/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini }
+  - { src: docker/image/php-fpm/root/usr/local/etc/php-fpm.d/pool.conf.template }
   - { src: docker/image/cron/Dockerfile }
   - { src: docker/image/cron/root/crontab }
   - { src: application/overlay/Jenkinsfile }


### PR DESCRIPTION
This only affected pools other than www, as the www pool has this additional configuration in /usr/local/etc/php-fpm.d/docker.conf