### PR TITLE
Indicate that confd(harness:/) isn't part of the public api

### DIFF
--- a/src/_base/harness/config/confd.yml
+++ b/src/_base/harness/config/confd.yml
@@ -1,4 +1,4 @@
-
+# this file is not considered part of the public API so changes aren't considered breaking
 confd('harness:/'):
   # base templates
   - { src: docker/image/console/Dockerfile }

--- a/src/akeneo/harness/config/confd.yml
+++ b/src/akeneo/harness/config/confd.yml
@@ -1,4 +1,4 @@
-
+# this file is not considered part of the public API so changes aren't considered breaking
 confd('harness:/'):
   # base templates
   - { src: docker/image/console/Dockerfile }

--- a/src/drupal8/harness/config/confd.yml
+++ b/src/drupal8/harness/config/confd.yml
@@ -1,4 +1,4 @@
-
+# this file is not considered part of the public API so changes aren't considered breaking
 confd('harness:/'):
   # base templates
   - { src: docker/image/console/Dockerfile }

--- a/src/magento1/harness/config/confd.yml
+++ b/src/magento1/harness/config/confd.yml
@@ -1,4 +1,4 @@
-
+# this file is not considered part of the public API so changes aren't considered breaking
 confd('harness:/'):
   # base templates
   - { src: docker/image/console/Dockerfile }

--- a/src/magento2/harness/config/confd.yml
+++ b/src/magento2/harness/config/confd.yml
@@ -1,4 +1,4 @@
-
+# this file is not considered part of the public API so changes aren't considered breaking
 confd('harness:/'):
   # base templates
   - { src: docker/image/console/Dockerfile }

--- a/src/spryker/harness/config/confd.yml
+++ b/src/spryker/harness/config/confd.yml
@@ -1,4 +1,4 @@
-
+# this file is not considered part of the public API so changes aren't considered breaking
 confd('harness:/'):
   # base templates
   - { src: docker/image/console/Dockerfile }

--- a/src/wordpress/harness/config/confd.yml
+++ b/src/wordpress/harness/config/confd.yml
@@ -1,4 +1,4 @@
-
+# this file is not considered part of the public API so changes aren't considered breaking
 confd('harness:/'):
   # base templates
   - { src: docker/image/console/Dockerfile }


### PR DESCRIPTION
so project's shouldn't change it

With https://github.com/my127/workspace/pull/44 it'll be easier than before to do project overlay confd runs, so that should be the way projects add additional templating

This should discourage overlaying harness/config/confd.yml and allow harnesses to produce more bugfix and minor releases rather than major releases