### PR TITLE
Allow automated builds to show us errors

### DIFF
--- a/src/_base/docker/image/console/root/lib/sidekick.sh
+++ b/src/_base/docker/image/console/root/lib/sidekick.sh
@@ -49,15 +49,16 @@ run()
               cat /tmp/my127ws-stdout.txt
               echo
               echo "stderr:"
+              cat /tmp/my127ws-stderr.txt
+              echo
             else
               echo "Command failed. stderr:"
+              cat /tmp/my127ws-stderr.txt
+              echo "----------------------------------"
+              echo "Full logs are accessible in the console container at path :-"
+              echo "  stdout: /tmp/my127ws-stdout.txt"
+              echo "  stderr: /tmp/my127ws-stderr.txt"
             fi
-            cat /tmp/my127ws-stderr.txt
-
-            echo "----------------------------------"
-            echo "Full Logs :-"
-            echo "  stdout: /tmp/my127ws-stdout.txt"
-            echo "  stdout: /tmp/my127ws-stderr.txt"
 
             exit 1
         else

--- a/src/_base/docker/image/console/root/lib/sidekick.sh
+++ b/src/_base/docker/image/console/root/lib/sidekick.sh
@@ -39,11 +39,19 @@ run()
         prompt
 
         echo "  > ${COMMAND[*]}"
-        setCommandIndicator $INDICATOR_RUNNING
+        setCommandIndicator "$INDICATOR_RUNNING"
 
         if ! bash -c "${COMMAND[@]}" > /tmp/my127ws-stdout.txt 2> /tmp/my127ws-stderr.txt; then
-            setCommandIndicator $INDICATOR_ERROR
+            setCommandIndicator "$INDICATOR_ERROR"
 
+            if [ "$APP_BUILD" = "static" ]; then
+              echo "Command failed. stdout:"
+              cat /tmp/my127ws-stdout.txt
+              echo
+              echo "stderr:"
+            else
+              echo "Command failed. stderr:"
+            fi
             cat /tmp/my127ws-stderr.txt
 
             echo "----------------------------------"
@@ -53,7 +61,7 @@ run()
 
             exit 1
         else
-            setCommandIndicator $INDICATOR_SUCCESS
+            setCommandIndicator "$INDICATOR_SUCCESS"
         fi
     else
         passthru "${COMMAND[@]}"


### PR DESCRIPTION
When in static mode such as in Jenkins or in init/migrate steps on a kubernetes cluster, we need to be able to see the error messages of commands running via `run` rather than just `passthru`.