### PR TITLE
Fail init job completely if the first attempt fails

### DIFF
--- a/src/_base/helm/app/templates/application/app-init.yaml
+++ b/src/_base/helm/app/templates/application/app-init.yaml
@@ -9,8 +9,10 @@ metadata:
     argocd.argoproj.io/hook-delete-policy: "BeforeHookCreation"
     argocd.argoproj.io/sync-wave: "5"
 spec:
+  backoffLimit: 0
   template:
     spec:
+      restartPolicy: Never
       containers:
       - env:
         {{- range $key, $value := index .Values.docker.services "php-base" "environment" }}


### PR DESCRIPTION
In the screenshot below, the first init job pod `magento2app-init-ktnmf` failed due to bug with resource prefixes and the redis service reference - `setup:upgrade` couldn't talk to `redis`:
![Screenshot from 2020-05-21 17-18-26](https://user-images.githubusercontent.com/1554709/82568251-34fb5c00-9b87-11ea-9704-cd965c2910fd.png)

The job controller saw this failure and created a new pod from the job `magento2app-init-88gfc`, but as the database asset was applied already, the extra steps post-database apply got skipped.

The migrate jobs then tried setup:upgrade too, and failed again, but the migrate step shouldn't have been tried if init failed.

This PR stops this retry from happening.

The downside is that this might stop deployments to existing environments in their tracks where there's a wobble in mysql service availability. Previously we would have retried up to 6 times with increasing backoff, but now we fail outright.

