### PR TITLE
Resource Prefix support for Magento 1 & 2

### DIFF
--- a/src/_base/harness/attributes/common.yml
+++ b/src/_base/harness/attributes/common.yml
@@ -180,7 +180,9 @@ attributes.default:
       steps: []
 
   elasticsearch:
+    host: elasticsearch
     image: elasticsearch
+    port: 9200
     tag: 7.1.1
 
   domain: my127.site
@@ -200,6 +202,14 @@ attributes.default:
   mysql:
     image: mysql
     tag: 5.7
+
+  redis:
+    host: redis
+    port: 6379
+
+  redis_session:
+    host: redis-session
+    port: 6379
 
   resources:
     cpu:

--- a/src/_base/harness/attributes/docker-base.yml
+++ b/src/_base/harness/attributes/docker-base.yml
@@ -56,10 +56,10 @@ attributes:
           environment:
             APP_HOST: = @('pipeline.base.hostname')
             DB_HOST: = '{{ .Values.resourcePrefix }}' ~ @('database.host')
-            ELASTICSEARCH_HOST: = '{{ if .Values.service.elasticsearch }}{{ .Values.resourcePrefix  }}' ~ @('elasticsearch.host') ~ '{{ end }}'
-            ES_HOST: = '{{ if .Values.service.elasticsearch }}{{ .Values.resourcePrefix }}' ~ @('elasticsearch.host') ~ ':' ~ @('elasticsearch.port') ~ '{{ end }}'
-            REDIS_HOST: = '{{ if .Values.service.redis }}{{ .Values.resourcePrefix }}' ~ @('redis.host') ~ '{{ end }}'
-            REDIS_SESSION_HOST: = '{{ if .Values.service.redis_session }}{{ .Values.resourcePrefix }}' ~ @('redis_session.host') ~ '{{ end }}'
+            ELASTICSEARCH_HOST: '{{ if .Values.service.elasticsearch }}{{ .Values.resourcePrefix  }}elasticsearch{{ end }}'
+            ES_HOST: '{{ if .Values.service.elasticsearch }}{{ .Values.resourcePrefix }}elasticsearch:9200{{ end }}'
+            REDIS_HOST: '{{ if .Values.service.redis }}{{ .Values.resourcePrefix }}redis{{ end }}'
+            REDIS_SESSION_HOST: '{{ if .Values.service.redis_session }}{{ .Values.resourcePrefix }}redis-session{{ end }}'
             PHP_IDE_CONFIG: = ''
         nginx:
           environment:

--- a/src/_base/harness/attributes/docker-base.yml
+++ b/src/_base/harness/attributes/docker-base.yml
@@ -10,6 +10,10 @@ attributes:
         DB_USER: = @('database.user')
         DB_PASS: = @('database.pass')
         DB_NAME: = @('database.name')
+        ELASTICSEARCH_HOST: = @('elasticsearch.host')
+        ELASTICSEARCH_PORT: = @('elasticsearch.port')
+        REDIS_HOST: = @('redis.host')
+        REDIS_PORT: = @('redis.port')
         PHP_IDE_CONFIG: "serverName=workspace"
     nginx:
       ingress:
@@ -22,7 +26,7 @@ attributes:
         DB_ADMIN_USER: root
         DB_ADMIN_PASS: = @('database.root_pass')
     php-fpm:
-      environment: 
+      environment:
         AUTOSTART_PHP_FPM: "true"
     php-fpm-exporter:
       environment:
@@ -48,9 +52,12 @@ attributes:
       services:
         php-base:
           environment:
-            ES_HOST: "{{ if .Values.service.elasticsearch }}{{ .Values.resourcePrefix }}elasticsearch:9200{{ end }}"
-            DB_HOST: = '{{ .Values.resourcePrefix }}' ~ @('database.host')
             APP_HOST: = @('pipeline.base.hostname')
+            DB_HOST: = '{{ .Values.resourcePrefix }}' ~ @('database.host')
+            ELASTICSEARCH_HOST: = '{{ if .Values.service.elasticsearch }}{{ .Values.resourcePrefix  }}' ~ @('elasticsearch.host') ~ '{{ end }}'
+            ES_HOST: "{{ if .Values.service.elasticsearch }}{{ .Values.resourcePrefix }}"elasticsearch":9200{{ end }}"
+            REDIS_HOST: = '{{ if .Values.service.redis }}{{ .Values.resourcePrefix }}redis{{ end }}'
+            REDIS_SESSION_HOST: = '{{ if .Values.service.redis-session }}{{ .Values.resourcePrefix }}redis-session{{ end }}'
             PHP_IDE_CONFIG: = ''
         nginx:
           environment:

--- a/src/_base/harness/attributes/docker-base.yml
+++ b/src/_base/harness/attributes/docker-base.yml
@@ -14,6 +14,8 @@ attributes:
         ELASTICSEARCH_PORT: = @('elasticsearch.port')
         REDIS_HOST: = @('redis.host')
         REDIS_PORT: = @('redis.port')
+        REDIS_SESSION_HOST: = @('redis_session.host')
+        REDIS_SESSION_PORT: = @('redis_session.port')
         PHP_IDE_CONFIG: "serverName=workspace"
     nginx:
       ingress:
@@ -57,7 +59,7 @@ attributes:
             ELASTICSEARCH_HOST: = '{{ if .Values.service.elasticsearch }}{{ .Values.resourcePrefix  }}' ~ @('elasticsearch.host') ~ '{{ end }}'
             ES_HOST: "{{ if .Values.service.elasticsearch }}{{ .Values.resourcePrefix }}"elasticsearch":9200{{ end }}"
             REDIS_HOST: = '{{ if .Values.service.redis }}{{ .Values.resourcePrefix }}redis{{ end }}'
-            REDIS_SESSION_HOST: = '{{ if .Values.service.redis-session }}{{ .Values.resourcePrefix }}redis-session{{ end }}'
+            REDIS_SESSION_HOST: = '{{ if .Values.service.redis_session }}{{ .Values.resourcePrefix }}redis-session{{ end }}'
             PHP_IDE_CONFIG: = ''
         nginx:
           environment:

--- a/src/_base/harness/attributes/docker-base.yml
+++ b/src/_base/harness/attributes/docker-base.yml
@@ -56,10 +56,10 @@ attributes:
           environment:
             APP_HOST: = @('pipeline.base.hostname')
             DB_HOST: = '{{ .Values.resourcePrefix }}' ~ @('database.host')
-            ELASTICSEARCH_HOST: '{{ if .Values.service.elasticsearch }}{{ .Values.resourcePrefix  }}' ~ @('elasticsearch.host') ~ '{{ end }}'
-            ES_HOST: = "{{ if .Values.service.elasticsearch }}{{ .Values.resourcePrefix }}" ~ @('elasticsearch.host') ~ ":" ~ @('elasticsearch.port') ~ "{{ end }}"
-            REDIS_HOST: '{{ if .Values.service.redis }}{{ .Values.resourcePrefix }}redis{{ end }}'
-            REDIS_SESSION_HOST: '{{ if .Values.service.redis_session }}{{ .Values.resourcePrefix }}redis-session{{ end }}'
+            ELASTICSEARCH_HOST: = '{{ if .Values.service.elasticsearch }}{{ .Values.resourcePrefix  }}' ~ @('elasticsearch.host') ~ '{{ end }}'
+            ES_HOST: = '{{ if .Values.service.elasticsearch }}{{ .Values.resourcePrefix }}' ~ @('elasticsearch.host') ~ ':' ~ @('elasticsearch.port') ~ '{{ end }}'
+            REDIS_HOST: = '{{ if .Values.service.redis }}{{ .Values.resourcePrefix }}' ~ @('redis.host') ~ '{{ end }}'
+            REDIS_SESSION_HOST: = '{{ if .Values.service.redis_session }}{{ .Values.resourcePrefix }}' ~ @('redis_session.host') ~ '{{ end }}'
             PHP_IDE_CONFIG: = ''
         nginx:
           environment:

--- a/src/_base/harness/attributes/docker-base.yml
+++ b/src/_base/harness/attributes/docker-base.yml
@@ -56,10 +56,10 @@ attributes:
           environment:
             APP_HOST: = @('pipeline.base.hostname')
             DB_HOST: = '{{ .Values.resourcePrefix }}' ~ @('database.host')
-            ELASTICSEARCH_HOST: = '{{ if .Values.service.elasticsearch }}{{ .Values.resourcePrefix  }}' ~ @('elasticsearch.host') ~ '{{ end }}'
-            ES_HOST: "{{ if .Values.service.elasticsearch }}{{ .Values.resourcePrefix }}"elasticsearch":9200{{ end }}"
-            REDIS_HOST: = '{{ if .Values.service.redis }}{{ .Values.resourcePrefix }}redis{{ end }}'
-            REDIS_SESSION_HOST: = '{{ if .Values.service.redis_session }}{{ .Values.resourcePrefix }}redis-session{{ end }}'
+            ELASTICSEARCH_HOST: '{{ if .Values.service.elasticsearch }}{{ .Values.resourcePrefix  }}' ~ @('elasticsearch.host') ~ '{{ end }}'
+            ES_HOST: = "{{ if .Values.service.elasticsearch }}{{ .Values.resourcePrefix }}" ~ @('elasticsearch.host') ~ ":" ~ @('elasticsearch.port') ~ "{{ end }}"
+            REDIS_HOST: '{{ if .Values.service.redis }}{{ .Values.resourcePrefix }}redis{{ end }}'
+            REDIS_SESSION_HOST: '{{ if .Values.service.redis_session }}{{ .Values.resourcePrefix }}redis-session{{ end }}'
             PHP_IDE_CONFIG: = ''
         nginx:
           environment:

--- a/src/magento1/application/overlay/public/app/etc/_twig/local.xml/session/redis.twig
+++ b/src/magento1/application/overlay/public/app/etc/_twig/local.xml/session/redis.twig
@@ -1,7 +1,7 @@
 <session_save><![CDATA[db]]></session_save>
 <redis_session>
-    <host><![CDATA[redis-session]]></host>
-    <port><![CDATA[6379]]></port>
+    <host><![CDATA[{{ @('redis_session.host') }}]]></host>
+    <port><![CDATA[{{ @('redis_session.port') }}]]></port>
     <password><![CDATA[]]></password><!-- Specify if your Redis server requires authentication -->
     <timeout><![CDATA[2.5]]></timeout>
     <persistent><![CDATA[c]]></persistent> <!-- Specify unique string to enable persistent connections. E.g.: sess-db0; bugs with phpredis and php-fpm are known: https://github.com/nicolasff/phpredis/issues/70 -->

--- a/src/magento1/application/overlay/public/app/etc/local.xml.twig
+++ b/src/magento1/application/overlay/public/app/etc/local.xml.twig
@@ -42,35 +42,33 @@
         {% include 'application/overlay/public/app/etc/_twig/local.xml/session/' ~ @('magento.config.session.save') ~ '.twig' %}
         <session_cache_limiter><![CDATA[nocache]]></session_cache_limiter><!-- see http://php.net/manual/en/function.session-cache-limiter.php#82174 for possible values -->
         <cache>
-             <backend><![CDATA[Cm_Cache_Backend_Redis]]></backend><!-- apc / memcached / xcache / Cm_Cache_Backend_Redis empty=file -->
-                <backend_options>
-                    <server><![CDATA[redis]]></server> <!-- or absolute path to unix socket for better performance -->
-                     <port><![CDATA[6379]]></port>
-                     <database><![CDATA[0]]></database>
-                     <force_standalone><![CDATA[1]]></force_standalone><!-- 0 for phpredis, 1 for standalone PHP -->
-                     <automatic_cleaning_factor><![CDATA[0]]></automatic_cleaning_factor> <!-- Disabled by default -->
-                     <compress_data><![CDATA[1]]></compress_data><!-- 0-9 for compression level, recommended: 0 or 1 -->
-                     <compress_tags><![CDATA[1]]></compress_tags><!-- 0-9 for compression level, recommended: 0 or 1 -->
-                     <compress_threshold><![CDATA[2048]]></compress_threshold><!-- Strings below this size will not be compressed -->
-                     <compression_lib><![CDATA[gzip]]></compression_lib> <!-- Supports gzip, lzf and snappy -->
-                </backend_options>
-
+            <backend><![CDATA[Cm_Cache_Backend_Redis]]></backend><!-- apc / memcached / xcache / Cm_Cache_Backend_Redis empty=file -->
+            <backend_options>
+                <server><![CDATA[{{ @('redis.host') }}]]></server> <!-- or absolute path to unix socket for better performance -->
+                <port><![CDATA[{{ @('redis.port') }}]]></port>
+                <database><![CDATA[0]]></database>
+                <force_standalone><![CDATA[1]]></force_standalone><!-- 0 for phpredis, 1 for standalone PHP -->
+                <automatic_cleaning_factor><![CDATA[0]]></automatic_cleaning_factor> <!-- Disabled by default -->
+                <compress_data><![CDATA[1]]></compress_data><!-- 0-9 for compression level, recommended: 0 or 1 -->
+                <compress_tags><![CDATA[1]]></compress_tags><!-- 0-9 for compression level, recommended: 0 or 1 -->
+                <compress_threshold><![CDATA[2048]]></compress_threshold><!-- Strings below this size will not be compressed -->
+                <compression_lib><![CDATA[gzip]]></compression_lib> <!-- Supports gzip, lzf and snappy -->
+            </backend_options>
         </cache>
 
         <full_page_cache>
-             <backend><![CDATA[Cm_Cache_Backend_Redis]]></backend><!-- apc / memcached / xcache / Cm_Cache_Backend_Redis empty=file -->
-                 <backend_options>
-                    <server><![CDATA[redis]]></server> <!-- or absolute path to unix socket for better performance -->
-                     <port><![CDATA[6379]]></port>
-                     <database><![CDATA[1]]></database>
-                     <force_standalone><![CDATA[1]]></force_standalone><!-- 0 for phpredis, 1 for standalone PHP -->
-                     <automatic_cleaning_factor><![CDATA[0]]></automatic_cleaning_factor> <!-- Disabled by default -->
-                     <compress_data><![CDATA[1]]></compress_data><!-- 0-9 for compression level, recommended: 0 or 1 -->
-                     <compress_tags><![CDATA[1]]></compress_tags><!-- 0-9 for compression level, recommended: 0 or 1 -->
-                     <compress_threshold><![CDATA[2048]]></compress_threshold><!-- Strings below this size will not be compressed -->
-                     <compression_lib><![CDATA[gzip]]></compression_lib> <!-- Supports gzip, lzf and snappy -->
-                 </backend_options>
-
+            <backend><![CDATA[Cm_Cache_Backend_Redis]]></backend><!-- apc / memcached / xcache / Cm_Cache_Backend_Redis empty=file -->
+            <backend_options>
+                <server><![CDATA[{{ @('redis.host') }}]]></server> <!-- or absolute path to unix socket for better performance -->
+                <port><![CDATA[{{ @('redis.port') }}]]></port>
+                <database><![CDATA[1]]></database>
+                <force_standalone><![CDATA[1]]></force_standalone><!-- 0 for phpredis, 1 for standalone PHP -->
+                <automatic_cleaning_factor><![CDATA[0]]></automatic_cleaning_factor> <!-- Disabled by default -->
+                <compress_data><![CDATA[1]]></compress_data><!-- 0-9 for compression level, recommended: 0 or 1 -->
+                <compress_tags><![CDATA[1]]></compress_tags><!-- 0-9 for compression level, recommended: 0 or 1 -->
+                <compress_threshold><![CDATA[2048]]></compress_threshold><!-- Strings below this size will not be compressed -->
+                <compression_lib><![CDATA[gzip]]></compression_lib> <!-- Supports gzip, lzf and snappy -->
+            </backend_options>
         </full_page_cache>
     </global>
     <admin>

--- a/src/magento2/application/overlay/app/etc/env.php.twig
+++ b/src/magento2/application/overlay/app/etc/env.php.twig
@@ -40,17 +40,17 @@ return [
             'default' => [
                 'backend' => 'Cm_Cache_Backend_Redis',
                 'backend_options' => [
-                    'server' => 'redis',
+                    'server' => getenv('REDIS_HOST')?:'redis',
                     'database' => '2',
-                    'port' => '6379'
+                    'port' => getenv('REDIS_PORT')?:'6379'
                 ]
             ],
             'page_cache' => [
                 'backend' => 'Cm_Cache_Backend_Redis',
                 'backend_options' => [
-                    'server' => 'redis',
+                    'server' => getenv('REDIS_HOST')?:'redis',
                     'database' => '3',
-                    'port' => '6379',
+                    'port' => getenv('REDIS_PORT')?:'6379',
                     'compress_data' => '0'
                 ]
             ]

--- a/src/magento2/harness.yml
+++ b/src/magento2/harness.yml
@@ -96,18 +96,18 @@ attributes:
             --db-password=${DB_PASS} \
             \
             --session-save=redis \
-            --session-save-redis-host=redis \
-            --session-save-redis-port=6379 \
+            --session-save-redis-host=${REDIS_SESSION_HOST} \
+            --session-save-redis-port=${REDIS_SESSION_PORT} \
             --session-save-redis-db=1 \
             \
             --cache-backend=redis \
-            --cache-backend-redis-server=redis \
-            --cache-backend-redis-port=6379 \
+            --cache-backend-redis-server=${REDIS_HOST} \
+            --cache-backend-redis-port=${REDIS_PORT} \
             --cache-backend-redis-db=2 \
             \
             --page-cache=redis \
-            --page-cache-redis-server=redis \
-            --page-cache-redis-port=6379 \
+            --page-cache-redis-server=${REDIS_HOST} \
+            --page-cache-redis-port=${REDIS_PORT} \
             --page-cache-redis-db=3"
           # magento doesn't respond with an exit code when it fails so we check
           # if the install succeeded or not here.

--- a/src/spryker/harness.yml
+++ b/src/spryker/harness.yml
@@ -67,13 +67,9 @@ attributes:
       console: = 'my127/spryker:' ~ @('php.version') ~ '-fpm-stretch-console'
       php-fpm: = 'my127/spryker:' ~ @('php.version') ~ '-fpm-stretch'
   elasticsearch:
-    host: elasticsearch
-    port: 9200
     image: elasticsearch
     tag: 5.6
   redis:
-    host: redis
-    port: 6379
     protocol: redis
   rabbitmq:
     host: rabbitmq

--- a/src/spryker/harness/attributes/docker.yml
+++ b/src/spryker/harness/attributes/docker.yml
@@ -4,10 +4,6 @@ attributes:
       environment:
         APPLICATION_ENV: = @('spryker.mode')
         SPRYKER_SALT: = @('spryker.salt')
-        ELASTICSEARCH_HOST: = @('elasticsearch.host')
-        ELASTICSEARCH_PORT: = @('elasticsearch.port')
-        REDIS_HOST: = @('redis.host')
-        REDIS_PORT: = @('redis.port')
         REDIS_PROTOCOL: = @('redis.protocol')
         RABBITMQ_HOST: = @('rabbitmq.host')
         RABBITMQ_PORT: = @('rabbitmq.port')
@@ -37,8 +33,6 @@ attributes:
     base:
       services:
         php-base:
-          ELASTICSEARCH_HOST: = '{{ .Values.resourcePrefix  }}' ~ @('elasticsearch.host')
-          REDIS_HOST: = '{{ .Values.resourcePrefix  }}' ~ @('redis.host')
           RABBITMQ_HOST: = '{{ .Values.resourcePrefix  }}' ~ @('rabbitmq.host')
           JENKINS_HOST: = '{{ .Values.resourcePrefix  }}' ~ @('jenkins.host')
     preview:


### PR DESCRIPTION
* Move redis and elasticsearch host/port environment variables to base harness from spryker
* Update magento 1 local.xml to use twig values
* Update magento 2 env.php to use environment variables

Should fix a resourcePrefix setting causing an init failure where `redis` is attempted to be connected to instead of `magento2-redis`