### PR TITLE
Add redis-session persistent storage enabled by default

### DIFF
--- a/src/_base/harness/attributes/common.yml
+++ b/src/_base/harness/attributes/common.yml
@@ -59,6 +59,9 @@ attributes.default:
       hostname:  = @('pipeline.preview.namespace') ~ '.example.com'
       rabbitmq:
         external_host: = 'rabbitmq-' ~ @('pipeline.preview.hostname')
+      persistence:
+        redis_session:
+          enabled: false
     qa:
       enabled: no
       environment: ~

--- a/src/_base/harness/attributes/common.yml
+++ b/src/_base/harness/attributes/common.yml
@@ -271,6 +271,10 @@ attributes.default:
       enabled: false
       accessMode: ReadWriteOnce
       size: 2Gi
+    redis_session:
+      enabled: true
+      accessMode: ReadWriteOnce
+      size: 2Gi
 
   tls:
     key: |

--- a/src/_base/helm/app/templates/service/redis-session/deployment.yaml
+++ b/src/_base/helm/app/templates/service/redis-session/deployment.yaml
@@ -46,6 +46,17 @@ spec:
             port: 6379
           initialDelaySeconds: 5
           periodSeconds: 10
+        volumeMounts:
+        - name: {{ .Values.resourcePrefix }}redis-session-persistent-storage
+          mountPath: /data
       restartPolicy: Always
+      volumes:
+      - name: {{ .Values.resourcePrefix }}redis-session-persistent-storage
+{{- if .Values.persistence.redis_session.enabled }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.resourcePrefix }}redis-session-pv-claim
+{{- else }}
+        emptyDir: {}
+{{- end }}
 status: {}
 {{ end }}

--- a/src/_base/helm/app/templates/service/redis-session/pvc.yaml
+++ b/src/_base/helm/app/templates/service/redis-session/pvc.yaml
@@ -1,0 +1,31 @@
+{{ if and .Values.service.redis_session .Values.persistence.redis_session.enabled -}}
+
+{{- with .Values.persistence.redis_session -}}
+
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ $.Values.resourcePrefix }}redis-session-pv-claim
+  labels:
+    app.service: {{ $.Values.resourcePrefix }}redis-session
+spec:
+  accessModes:
+    - {{ .accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .size | quote }}
+{{- if .storageClass }}
+{{- if (eq "-" .storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: {{ .storageClass | quote }}
+{{- end }}
+{{- end }}
+{{- if .selector }}
+  selector:
+  {{- .selector | toYaml | nindent 4 }}
+{{- end }}
+
+{{- end }}
+
+{{- end }}


### PR DESCRIPTION
For magento1 and magento2 mainly. Stops session loss upon the sessions redis instance restarting/upgrading.