### PR TITLE
Use less executors at once in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,6 +17,16 @@ pipeline {
                     }
                 }
                 stages {
+                    stage('Test (mode=static)') {
+                        agent { label "my127ws" }
+                        steps { sh './build && ./test $FRAMEWORK static' }
+                        post {
+                            always {
+                                sh 'ws destroy || true'
+                                cleanWs()
+                            }
+                        }
+                    }
                     stage('Test (mode=dynamic)') {
                         agent { label "my127ws" }
                         steps { sh './build && ./test $FRAMEWORK dynamic' }
@@ -27,9 +37,9 @@ pipeline {
                             }
                         }
                     }
-                    stage('Test (mode=static)') {
+                    stage('Test (mode=dynamic, sync=mutagen)') {
                         agent { label "my127ws" }
-                        steps { sh './build && ./test $FRAMEWORK static' }
+                        steps { sh './build && ./test $FRAMEWORK dynamic mutagen' }
                         post {
                             always {
                                 sh 'ws destroy || true'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,189 +8,33 @@ pipeline {
     }
     triggers { cron(env.BRANCH_NAME ==~ /^\d+\.\d+\.x$/ ? 'H H(0-6) * * *' : '') }
     stages {
-        stage('Test Matrix') {
-            parallel {
-
-                // Akeneo 4
-
-                stage('akeneo (mode=dynamic)') {
-                    agent { label "my127ws" }
-                    steps { sh './build && ./test akeneo dynamic' }
-                    post {
-                        always {
-                            sh 'ws destroy || true'
-                            cleanWs()
-                        }
+        stage('BuildAndTest') {
+            matrix {
+                axes {
+                    axis {
+                        name 'FRAMEWORK'
+                        values 'akeneo', 'drupal8', 'magento1', 'magento2', 'php', 'spryker', 'symfony', 'wordpress'
                     }
                 }
-                stage('akeneo (mode=static)')  {
-                    agent { label "my127ws" }
-                    steps { sh './build && ./test akeneo static' }
-                    post {
-                        always {
-                            sh 'ws destroy || true'
-                            cleanWs()
+                stages {
+                    stage('Test (mode=dynamic)') {
+                        agent { label "my127ws" }
+                        steps { sh './build && ./test $FRAMEWORK dynamic' }
+                        post {
+                            always {
+                                sh 'ws destroy || true'
+                                cleanWs()
+                            }
                         }
                     }
-                }
-
-                // Drupal 8
-
-                stage('drupal8 (mode=dynamic)') {
-                    agent { label "my127ws" }
-                    steps { sh './build && ./test drupal8 dynamic' }
-                    post {
-                        always {
-                            sh 'ws destroy || true'
-                            cleanWs()
-                        }
-                    }
-                }
-                stage('drupal8 (mode=static)')  {
-                    agent { label "my127ws" }
-                    steps { sh './build && ./test drupal8 static' }
-                    post {
-                        always {
-                            sh 'ws destroy || true'
-                            cleanWs()
-                        }
-                    }
-                }
-
-                // Magento 1
-
-                stage('magento1 (mode=dynamic)') {
-                    agent { label "my127ws" }
-                    steps { sh './build && ./test magento1 dynamic' }
-                    post {
-                        always {
-                            sh 'ws destroy || true'
-                            cleanWs()
-                        }
-                    }
-                }
-                stage('magento1 (mode=static)') {
-                    agent { label "my127ws" }
-                    steps { sh './build && ./test magento1 static' }
-                    post {
-                        always {
-                            sh 'ws destroy || true'
-                            cleanWs()
-                        }
-                    }
-                }
-
-                // Magento 2
-
-                stage('magento2 (mode=dynamic)') {
-                    agent { label "my127ws" }
-                    steps { sh './build && ./test magento2 dynamic' }
-                    post {
-                        always {
-                            sh 'ws destroy || true'
-                            cleanWs()
-                        }
-                    }
-                }
-                stage('magento2 (mode=static)') {
-                    agent { label "my127ws" }
-                    steps { sh './build && ./test magento2 static' }
-                    post {
-                        always {
-                            sh 'ws destroy || true'
-                            cleanWs()
-                        }
-                    }
-                }
-
-                // PHP
-
-                stage('php (mode=dynamic)') {
-                    agent { label "my127ws" }
-                    steps { sh './build && ./test php dynamic' }
-                    post {
-                        always {
-                            sh 'ws destroy || true'
-                            cleanWs()
-                        }
-                    }
-                }
-                stage('php (mode=static)')  {
-                    agent { label "my127ws" }
-                    steps { sh './build && ./test php static' }
-                    post {
-                        always {
-                            sh 'ws destroy || true'
-                            cleanWs()
-                        }
-                    }
-                }
-
-                // Spryker
-
-                stage('spryker (mode=dynamic)') {
-                    agent { label "my127ws" }
-                    steps { sh './build && ./test spryker dynamic' }
-                    post {
-                        always {
-                            sh 'ws destroy || true'
-                            cleanWs()
-                        }
-                    }
-                }
-                stage('spryker (mode=static)') {
-                    agent { label "my127ws" }
-                    steps { sh './build && ./test spryker static' }
-                    post {
-                        always {
-                            sh 'ws destroy || true'
-                            cleanWs()
-                        }
-                    }
-                }
-
-                // Symfony
-
-                stage('symfony (mode=dynamic)') {
-                    agent { label "my127ws" }
-                    steps { sh './build && ./test symfony dynamic' }
-                    post {
-                        always {
-                            sh 'ws destroy || true'
-                            cleanWs()
-                        }
-                    }
-                }
-                stage('symfony (mode=static)') {
-                    agent { label "my127ws" }
-                    steps { sh './build && ./test symfony static' }
-                    post {
-                        always {
-                            sh 'ws destroy || true'
-                            cleanWs()
-                        }
-                    }
-                }
-
-                // Wordpress
-
-                stage('wordpress (mode=dynamic)') {
-                    agent { label "my127ws" }
-                    steps { sh './build && ./test wordpress dynamic' }
-                    post {
-                        always {
-                            sh 'ws destroy || true'
-                            cleanWs()
-                        }
-                    }
-                }
-                stage('wordpress (mode=static)') {
-                    agent { label "my127ws" }
-                    steps { sh './build && ./test wordpress static' }
-                    post {
-                        always {
-                            sh 'ws destroy || true'
-                            cleanWs()
+                    stage('Test (mode=static)') {
+                        agent { label "my127ws" }
+                        steps { sh './build && ./test $FRAMEWORK static' }
+                        post {
+                            always {
+                                sh 'ws destroy || true'
+                                cleanWs()
+                            }
                         }
                     }
                 }

--- a/test
+++ b/test
@@ -7,37 +7,33 @@ export path_test="./tmp-test"
 
 function main()
 {
-    test "$1" "$2"
+    test "$1" "$2" "${3:-}"
 }
 
 function test()
 (
     local harness="$1"
     local mode="$2"
+    local sync="$3"
 
     # Test default mode of static or dynamic harnesses
     # For dynamic this means a mountpoint for the application code
+    # or mutagen, or docker-sync
     setup "$harness" "$mode"
-    setup_dynamic_mountpoint
+    if [[ "$sync" == "" ]]; then
+      setup_dynamic_mountpoint
+    elif [[ "$sync" == "mutagen" ]]; then
+      setup_dynamic_mutagen
+    fi
     install_environment
     check_environment_started "$harness" "$mode"
     run_pipeline_tests
     restart_environment
     check_environment_started "$harness" "$mode"
-    teardown
-
-    if [[ "$mode" == "dynamic" ]]; then
-      # Test additional dynamic harness modes such as mutagen and docker-sync
-      setup "$harness" "$mode"
-      setup_dynamic_mutagen
-      install_environment
-      check_environment_started "$harness" "$mode"
-      run_pipeline_tests
-      restart_environment
-      check_environment_started "$harness" "$mode"
+    if [[ "$sync" != "" ]]; then
       wait_for_vendor_directory
-      teardown
     fi
+    teardown
 )
 
 function setup()


### PR DESCRIPTION
By running the dynamic then static build in sequence, but with each framework running in parallel, we use half as many Jenkins nodes.

Well, that's the theory anyway :smile: 