### PR TITLE
Improve speed of permissions fixes

### DIFF
--- a/src/_base/docker/image/php-fpm/root/fix_app_permissions.sh.twig
+++ b/src/_base/docker/image/php-fpm/root/fix_app_permissions.sh.twig
@@ -25,10 +25,11 @@ function app_permissions_fix()
           echo "${DIR} does not exist. Creating ${DIR}..."
           mkdir -p "${DIR}"
         fi
-        chown -R "${APP_OWNER}":"${APP_GROUP}" "${DIR}"
-        chmod -R ug+rw,o-w "${DIR}"
-        chmod -R a+r "${DIR}"
-        echo "fixed permissions for ${DIR}"
+        echo -n "Fixing permissions for ${DIR}..."
+        find "${DIR}" \( ! -user "${APP_OWNER}" -or ! -group "${APP_GROUP}" \) -exec chown "${APP_OWNER}":"${APP_GROUP}" {} +
+        find "${DIR}" -type d ! -perm ug+rwx,o+rx,o-w -exec chmod ug+rwx,o+rx,o-w {} +
+        find "${DIR}" -type f ! -perm ug+rw,o+r,o-w -exec chmod ug+rw,o+r,o-w {} +
+        echo "Done"
       else
         echo "No directory was specified for permissions fixing."
       fi
@@ -37,19 +38,18 @@ function app_permissions_fix()
     for FILE in "${FILES[@]}"
     do
       if [ -n "${FILE}" ]; then
-       if [ ! -f "${FILE}" ]; then
-         echo "${FILE} does not exist. Creating ${FILE}..."
-         touch "${FILE}"
-       fi
+        if [ ! -f "${FILE}" ]; then
+          echo "${FILE} does not exist. Creating ${FILE}..."
+          touch "${FILE}"
+        fi
+        echo -n "Fixing permissions for ${FILE}..."
         chown "${APP_OWNER}":"${APP_GROUP}" "${FILE}"
-        chmod ug+rw,o-w "${FILE}"
-        chmod a+r "${FILE}"
-        echo "fixed permissions for ${FILE}"
+        chmod ug+rw,o+r,o-w "${FILE}"
+        echo "Done"
       else
         echo "No file was specified for permissions fixing."
       fi
     done
-
 }
 
 main


### PR DESCRIPTION
`chown` adjusts every directory/file every time via `fchmodat` after first discovering them by scanning directories.

`find` user/group/perm discovers directories/files, filters out the already-correct directories/files and then changes the remaining files only.

Managed to save 2-4 minutes on a magento2 build with console/php-fpm/cron.