### PR TITLE
Fix drupal8 build

### DIFF
--- a/src/drupal8/application/skeleton/composer.json
+++ b/src/drupal8/application/skeleton/composer.json
@@ -82,9 +82,6 @@
     "enable-patching": true,
     "composer-exit-on-patch-failure": true,
     "patches": {
-      "drupal/core": {
-        "2259489 - Use strong validator for ETag and leverage symfony for HTTP revalidation": "https://www.drupal.org/files/issues/2019-06-05/2259489-try-symfonys-is-not-modified-method-26.patch"
-      }
     },
     "installer-paths": {
       "docroot/core": [


### PR DESCRIPTION
Remove https://www.drupal.org/project/drupal/issues/2259489 patch for now as the PageCacheTest.php change does not apply from https://www.drupal.org/files/issues/2019-06-05/2259489-try-symfonys-is-not-modified-method-26.patch

This is due to 8.9.0 changing the test file in https://github.com/drupal/core/blame/8.9.x/modules/page_cache/tests/src/Functional/PageCacheTest.php#L214