### PR TITLE
Enable local mail by default

### DIFF
--- a/src/_base/_twig/docker-compose.yml/application.yml.twig
+++ b/src/_base/_twig/docker-compose.yml/application.yml.twig
@@ -30,7 +30,6 @@
 {% include blocks ~ 'environment.yml.twig' %}
     networks:
       - private
-      - shared
 
   nginx:
 {% if @('app.build') == 'dynamic' %}
@@ -75,7 +74,6 @@
       - traefik.enable=false
     networks:
       - private
-      - shared
     environment:
 {{ deep_merge_to_yaml([@('services.php-base.environment'), @('services.php-fpm.environment')], 2, 6) | raw }}
 {% include blocks ~ 'environment.yml.twig' %}
@@ -83,3 +81,13 @@
 {% for pool in @('php-fpm.pools') %}
       - {{ pool.port }}
 {% endfor %}
+
+  relay:
+    build: .my127ws/docker/image/relay
+    labels:
+      - traefik.enable=false
+    networks:
+      private:
+        aliases:
+          - mailhog-relay
+      shared: {}

--- a/src/_base/_twig/docker-compose.yml/application.yml.twig
+++ b/src/_base/_twig/docker-compose.yml/application.yml.twig
@@ -30,6 +30,7 @@
 {% include blocks ~ 'environment.yml.twig' %}
     networks:
       - private
+      - shared
 
   nginx:
 {% if @('app.build') == 'dynamic' %}
@@ -74,6 +75,7 @@
       - traefik.enable=false
     networks:
       - private
+      - shared
     environment:
 {{ deep_merge_to_yaml([@('services.php-base.environment'), @('services.php-fpm.environment')], 2, 6) | raw }}
 {% include blocks ~ 'environment.yml.twig' %}

--- a/src/_base/docker/image/console/Dockerfile.twig
+++ b/src/_base/docker/image/console/Dockerfile.twig
@@ -1,7 +1,9 @@
 FROM {{ @('docker.image.console') }}
 
 COPY .my127ws/docker/image/console/root /
-RUN chown -R build:build /home/build
+RUN chown -R build:build /home/build \
+ && curl -L -o /usr/local/bin/mhsendmail -sS -f https://github.com/mailhog/mhsendmail/releases/download/v0.2.0/mhsendmail_linux_amd64 \
+ && chmod +x /usr/local/bin/mhsendmail
 
 ENV APP_MODE={{ @('app.mode') }} \
   APP_BUILD={{ @('app.build') }} \

--- a/src/_base/docker/image/php-fpm/Dockerfile.twig
+++ b/src/_base/docker/image/php-fpm/Dockerfile.twig
@@ -7,6 +7,9 @@ FROM {{ @('docker.image.php-fpm') }}
 WORKDIR /app
 COPY root  /
 
+RUN curl -L -o /usr/local/bin/mhsendmail -sS -f https://github.com/mailhog/mhsendmail/releases/download/v0.2.0/mhsendmail_linux_amd64 \
+ && chmod +x /usr/local/bin/mhsendmail
+
 {% if @('app.build') == 'static' %}
 COPY --from=console --chown=root:root /app /app
 RUN bash /fix_app_permissions.sh

--- a/src/_base/docker/image/relay/Dockerfile
+++ b/src/_base/docker/image/relay/Dockerfile
@@ -1,0 +1,2 @@
+FROM nginx:1.17-alpine
+COPY root /

--- a/src/_base/docker/image/relay/root/etc/nginx/nginx.conf
+++ b/src/_base/docker/image/relay/root/etc/nginx/nginx.conf
@@ -1,0 +1,24 @@
+user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+
+events {
+  worker_connections  1024;
+}
+
+stream {
+  server {
+    listen 1025;
+
+    proxy_pass mailhog:1025;
+  }
+
+  server {
+    listen 8025;
+
+    proxy_pass mailhog:8025;
+  }
+}

--- a/src/_base/harness.yml
+++ b/src/_base/harness.yml
@@ -4,6 +4,7 @@ harness('inviqa/php'):
   require:
     services:
       - proxy
+      - mail
     confd:
       - harness:/
 ---

--- a/src/_base/harness/attributes/common.yml
+++ b/src/_base/harness/attributes/common.yml
@@ -230,7 +230,7 @@ attributes.default:
     port: 6379
 
   smtp:
-    host: 'mailhog'
+    host: 'mailhog-relay'
     port: 1025
 
   resources:

--- a/src/_base/harness/attributes/common.yml
+++ b/src/_base/harness/attributes/common.yml
@@ -228,6 +228,10 @@ attributes.default:
     host: redis-session
     port: 6379
 
+  smtp:
+    host: 'mailhog'
+    port: 1025
+
   resources:
     cpu:
       requests: []

--- a/src/_base/harness/attributes/common.yml
+++ b/src/_base/harness/attributes/common.yml
@@ -154,6 +154,7 @@ attributes.default:
       enable_dl: Off
       opcache.enable_cli: On
       realpath_cache_ttl: 600
+      sendmail_path: = '\'/usr/local/bin/mhsendmail --smtp-addr="' ~ @('smtp.host') ~ ':' ~ @('smtp.port') ~ '"\''
       short_open_tag: Off
     ext-xdebug:
       enable: no

--- a/src/akeneo/docker/image/console/Dockerfile.twig
+++ b/src/akeneo/docker/image/console/Dockerfile.twig
@@ -1,7 +1,9 @@
 FROM {{ @('docker.image.console') }}
 
 COPY .my127ws/docker/image/console/root /
-RUN chown -R build:build /home/build
+RUN chown -R build:build /home/build \
+ && curl -L -o /usr/local/bin/mhsendmail -sS -f https://github.com/mailhog/mhsendmail/releases/download/v0.2.0/mhsendmail_linux_amd64 \
+ && chmod +x /usr/local/bin/mhsendmail
 
 # gpg: key 5072E1F5: public key "MySQL Release Engineering <mysql-build@oss.oracle.com>" imported
 RUN apt-get update \

--- a/src/akeneo/harness.yml
+++ b/src/akeneo/harness.yml
@@ -4,6 +4,7 @@ harness('inviqa/akeneo'):
   require:
     services:
       - proxy
+      - mail
     confd:
       - harness:/
 ---

--- a/src/drupal8/harness.yml
+++ b/src/drupal8/harness.yml
@@ -4,6 +4,7 @@ harness('inviqa/drupal8'):
   require:
     services:
       - proxy
+      - mail
     confd:
       - harness:/
 ---

--- a/src/magento1/harness.yml
+++ b/src/magento1/harness.yml
@@ -4,6 +4,7 @@ harness('inviqa/magento1'):
   require:
     services:
       - proxy
+      - mail
     confd:
       - harness:/
     attributes:

--- a/src/magento2/harness.yml
+++ b/src/magento2/harness.yml
@@ -4,6 +4,7 @@ harness('inviqa/magento2'):
   require:
     services:
       - proxy
+      - mail
     confd:
       - harness:/
     attributes:

--- a/src/spryker/_twig/docker-compose.yml/application.yml.twig
+++ b/src/spryker/_twig/docker-compose.yml/application.yml.twig
@@ -86,3 +86,13 @@
 {% for pool in @('php-fpm.pools') %}
       - {{ pool.port }}
 {% endfor %}
+
+  relay:
+    build: .my127ws/docker/image/relay
+    labels:
+      - traefik.enable=false
+    networks:
+      private:
+        aliases:
+          - mailhog-relay
+      shared: {}

--- a/src/spryker/_twig/docker-compose.yml/application.yml.twig
+++ b/src/spryker/_twig/docker-compose.yml/application.yml.twig
@@ -78,7 +78,6 @@
       - traefik.enable=false
     networks:
       - private
-      - shared
     environment:
 {{ deep_merge_to_yaml([@('services.php-base.environment'), @('services.php-fpm.environment')], 2, 6) | raw }}
 {% include blocks ~ 'environment.yml.twig' %}

--- a/src/spryker/harness.yml
+++ b/src/spryker/harness.yml
@@ -4,6 +4,7 @@ harness('inviqa/spryker'):
   require:
     services:
       - proxy
+      - mail
     confd:
       - harness:/
 ---
@@ -95,9 +96,6 @@ attributes:
       DE: = 'glue-de-' ~ @('hostname')
       AT: = 'glue-at-' ~ @('hostname')
       US: = 'glue-us-' ~ @('hostname')
-  smtp:
-    host: 'mailhog'
-    port: 1025
   nginx:
     global:
       conf:

--- a/src/symfony/harness.yml
+++ b/src/symfony/harness.yml
@@ -4,6 +4,7 @@ harness('inviqa/symfony'):
   require:
     services:
       - proxy
+      - mail
     confd:
       - harness:/
 ---

--- a/src/wordpress/harness.yml
+++ b/src/wordpress/harness.yml
@@ -4,6 +4,7 @@ harness('inviqa/wordpress'):
   require:
     services:
       - proxy
+      - mail
     confd:
       - harness:/
 ---


### PR DESCRIPTION
Moves the excellent work done for the spryker harness in https://github.com/inviqa/harness-base-php/pull/94 to be available to all frameworks.

Uses a NGINX TCP proxy to forward from the private network (i.e. console and php-fpm) to the shared network (mailhog)