### PR TITLE
Fix wrong hosts entry on startup

### DIFF
--- a/src/spryker/harness.yml
+++ b/src/spryker/harness.yml
@@ -148,9 +148,6 @@ attributes:
         port: 9000
       zed:
         port: 9001
-    entrypoint:
-      steps:
-        - echo "$(getent hosts nginx | awk '{ print $1 }') $ZED_HOST" >> /etc/hosts
 
   persistence:
     enabled: false


### PR DESCRIPTION
Fixes issue with a public IP being used for zed-<external_zed_host> inside the php-fpm container on someone's machine.

The nginx container has the appropriate hostname alias already, so will be routing fine :)