### PR TITLE
Let production mode work for magento2 

### DIFF
--- a/src/magento2/harness.yml
+++ b/src/magento2/harness.yml
@@ -71,6 +71,8 @@ attributes:
             run "mv app/etc/env.php app/etc/env-backup.php"
             passthru "bin/magento setup:static-content:deploy -f"
             run "mv app/etc/env-backup.php app/etc/env.php"
+          else
+            echo -n "$(date +%s)" > pub/static/deployed_version.txt
           fi
     install:
       steps:


### PR DESCRIPTION
Even if we can't do `setup:static-content:deploy` due to missing configuration, we should still let a behat run work in the pipeline.