### PR TITLE
Speed up Spryker build

### DIFF
--- a/src/_base/harness/attributes/environment/pipeline.yml
+++ b/src/_base/harness/attributes/environment/pipeline.yml
@@ -7,6 +7,8 @@ attributes:
     version: =exec("git log -n 1 --pretty=format:'%H'")
     mode: production
   php:
+    ini:
+      opcache.validate_timestamps: Off
     fpm:
       ini:
         display_errors: Off

--- a/src/spryker/application/skeleton/composer-harness.json
+++ b/src/spryker/application/skeleton/composer-harness.json
@@ -3,7 +3,6 @@
   "description": "Startup template for Spryker projects.",
   "type": "project",
   "require": {
-    "spryker/web-profiler": "^1.2.3",
     "symfony/console": "^3.4.30"
   },
   "require-dev": {

--- a/src/spryker/application/skeleton/composer-harness.json
+++ b/src/spryker/application/skeleton/composer-harness.json
@@ -31,9 +31,11 @@
       "@test-acceptance"
     ],
     "test-quality": [
+      "APPLICATION_ENV=development vendor/bin/console transfer:generate",
+      "APPLICATION_ENV=development vendor/bin/console dev:ide:generate-auto-completion",
       "@phpstan",
-      "vendor/bin/console code:sniff:style",
-      "vendor/bin/console code:sniff:architecture"
+      "APPLICATION_ENV=development vendor/bin/console code:sniff:style",
+      "APPLICATION_ENV=development vendor/bin/console code:sniff:architecture"
     ],
     "test-unit": [],
     "test-acceptance": [

--- a/src/spryker/application/skeleton/composer-harness.json
+++ b/src/spryker/application/skeleton/composer-harness.json
@@ -3,6 +3,7 @@
   "description": "Startup template for Spryker projects.",
   "type": "project",
   "require": {
+    "spryker/web-profiler": "^1.2.3",
     "symfony/console": "^3.4.30"
   },
   "require-dev": {

--- a/src/spryker/application/skeleton/composer-harness.json
+++ b/src/spryker/application/skeleton/composer-harness.json
@@ -2,6 +2,9 @@
   "name": "inviqa/spryker-startup",
   "description": "Startup template for Spryker projects.",
   "type": "project",
+  "require": {
+    "symfony/console": "^3.4.30"
+  },
   "require-dev": {
     "codeception/codeception": "~2.5.6",
     "behat/behat": "^3.5",

--- a/src/spryker/application/skeleton/config/install/docker.yml.twig
+++ b/src/spryker/application/skeleton/config/install/docker.yml.twig
@@ -70,10 +70,10 @@ sections:
             command: "vendor/bin/console application:build-navigation-cache"
 
         generate-transfer-databuilders:
-            command: "vendor/bin/console transfer:databuilder:generate"
+            command: "if [ \"$APPLICATION_ENV\" = \"development\" ]; then vendor/bin/console transfer:databuilder:generate; fi"
 
         generate-ide-auto-completion:
-            command: "vendor/bin/console dev:ide:generate-auto-completion"
+            command: "if [ \"$APPLICATION_ENV\" = \"development\" ]; then vendor/bin/console dev:ide:generate-auto-completion; fi"
 
 
     cache:

--- a/src/spryker/application/skeleton/config/install/docker.yml.twig
+++ b/src/spryker/application/skeleton/config/install/docker.yml.twig
@@ -227,7 +227,7 @@ sections:
 
     queue-worker:
         run:
-            command: "vendor/bin/console queue:worker:start -vvv"
+            command: "vendor/bin/console queue:worker:start --stop-when-empty -vvv"
             stores:
                 - DE
                 - AT

--- a/src/spryker/application/skeleton/config/install/docker.yml.twig
+++ b/src/spryker/application/skeleton/config/install/docker.yml.twig
@@ -227,7 +227,7 @@ sections:
 
     queue-worker:
         run:
-            command: "vendor/bin/console queue:worker:start --stop-when-empty -vvv"
+            command: "vendor/bin/console queue:worker:start -vvv"
             stores:
                 - DE
                 - AT

--- a/src/spryker/application/skeleton/deploy/vars
+++ b/src/spryker/application/skeleton/deploy/vars
@@ -1,0 +1,1 @@
+destination_release_dir=/app

--- a/src/spryker/docker/image/console/root/lib/task/skeleton/apply.sh.twig
+++ b/src/spryker/docker/image/console/root/lib/task/skeleton/apply.sh.twig
@@ -30,9 +30,7 @@ function merge_composer_json()
     run "mv $merged_file $core_file"
 
     local new_composer_packages=""
-    new_composer_packages="$(jq -r '.["require-dev"] | keys[]' $override_file | tr '\n' ' ')"
+    new_composer_packages="$(jq -r '.["require-dev"] * .["require"] | keys[]' $override_file | tr '\n' ' ')"
 
     [ -n "$new_composer_packages" ] && passthru "COMPOSER_PROCESS_TIMEOUT=600 composer update --with-dependencies --no-interaction --profile $new_composer_packages"
-
-    passthru "COMPOSER_PROCESS_TIMEOUT=600 composer require --no-interaction --profile symfony/console:3.4.30"
 }

--- a/src/spryker/docker/image/console/root/lib/task/skeleton/apply.sh.twig
+++ b/src/spryker/docker/image/console/root/lib/task/skeleton/apply.sh.twig
@@ -11,7 +11,7 @@ function task_skeleton_apply()
 
 function fetch_demoshop()
 {
-    run "git clone -b 201903.0-p1 {{ @('spryker.demoshop-url') }} /tmp/spryker"
+    run "git clone --depth 1 --branch 201903.0-p1 {{ @('spryker.demoshop-url') }} /tmp/spryker"
     run "shopt -s dotglob && mv /tmp/spryker/* /app"
     run "rm -rf /tmp/spryker"
     run "rm -rf /app/.git"
@@ -29,9 +29,10 @@ function merge_composer_json()
     run "jq -s '.[0] * .[1]' $core_file $override_file > $merged_file"
     run "mv $merged_file $core_file"
 
-    local new_composer_packages="$(jq -r '.["require-dev"] | keys[]' $override_file | tr '\n' ' ')"
+    local new_composer_packages=""
+    new_composer_packages="$(jq -r '.["require-dev"] | keys[]' $override_file | tr '\n' ' ')"
 
-    [ ! -z "$new_composer_packages" ] && passthru "COMPOSER_PROCESS_TIMEOUT=600 composer update --with-dependencies --no-interaction --profile $new_composer_packages"
+    [ -n "$new_composer_packages" ] && passthru "COMPOSER_PROCESS_TIMEOUT=600 composer update --with-dependencies --no-interaction --profile $new_composer_packages"
 
     passthru "COMPOSER_PROCESS_TIMEOUT=600 composer require --no-interaction --profile symfony/console:3.4.30"
 }

--- a/src/spryker/docker/image/console/root/lib/task/spryker/build.sh.twig
+++ b/src/spryker/docker/image/console/root/lib/task/spryker/build.sh.twig
@@ -3,7 +3,7 @@
 function task_spryker_build()
 {
     {% if @('app.mode') == 'development' %}
-        passthru "composer install --no-interaction --dev --optimize-autoloader"
+        passthru "composer install --no-interaction --optimize-autoloader"
     {% else %}
         passthru "composer install --no-interaction --no-dev --optimize-autoloader"
     {% endif %}

--- a/src/spryker/docker/image/console/root/lib/task/spryker/init.sh
+++ b/src/spryker/docker/image/console/root/lib/task/spryker/init.sh
@@ -4,6 +4,5 @@ function task_spryker_init()
 {
     run "vendor/bin/console propel:install -o"
     passthru "vendor/bin/install -r docker -s queue-flush"
-    passthru "PGPASSWORD=$DB_PASS vendor/bin/install -r docker -s queue-worker"
     passthru "PGPASSWORD=$DB_PASS vendor/bin/install -r docker -s jenkins-up"
 }

--- a/src/spryker/docker/image/console/root/lib/task/spryker/init.sh
+++ b/src/spryker/docker/image/console/root/lib/task/spryker/init.sh
@@ -3,6 +3,5 @@
 function task_spryker_init()
 {
     run "vendor/bin/console propel:install -o"
-    passthru "vendor/bin/install -r docker -s queue-flush"
     passthru "PGPASSWORD=$DB_PASS vendor/bin/install -r docker -s jenkins-up"
 }

--- a/src/spryker/harness.yml
+++ b/src/spryker/harness.yml
@@ -29,6 +29,8 @@ attributes:
     mode: development
   php:
     version: 7.2
+    ini:
+      opcache.max_accelerated_files: 32531
   database:
     platform: postgres
     host: postgres

--- a/src/spryker/harness.yml
+++ b/src/spryker/harness.yml
@@ -30,7 +30,7 @@ attributes:
   php:
     version: 7.2
     ini:
-      opcache.max_accelerated_files: 32531
+      opcache.max_accelerated_files: 65407
   database:
     platform: postgres
     host: postgres

--- a/src/spryker/harness/attributes/environment/pipeline.yml
+++ b/src/spryker/harness/attributes/environment/pipeline.yml
@@ -14,3 +14,5 @@ attributes:
         display_errors: Off
         error_reporting: "E_ALL & ~E_DEPRECATED & ~E_STRICT"
         zend.assertions: -1
+    ini:
+      opcache.validate_timestamps: Off

--- a/test
+++ b/test
@@ -16,6 +16,10 @@ function test()
     local mode="$2"
     local sync="$3"
 
+    if [[ "$mode" == "static" ]]; then
+      export MY127WS_ENV=pipeline
+    fi
+
     # Test default mode of static or dynamic harnesses
     # For dynamic this means a mountpoint for the application code
     # or mutagen, or docker-sync


### PR DESCRIPTION
* Use pipeline/production mode for static tests
* Turn off opcache validate_timestamps when in production mode
* Use shallow clone of the b2c demoshop repo
* Fix cronjobs not running correctly out of the box in production mode
* Remove need to run two composer updates by merging symfony/console as root requirement in `composer-harness.json`. Updates to latest of 3.4 in case of security fixes.
* Tune opcache for spryker

Production mode builds gets a fail whale on all Zed/Yves endpoints as https://github.com/spryker-shop/b2c-demo-shop/blob/201903.0-p1/src/Pyz/Zed/Application/ApplicationDependencyProvider.php#L76 is enabled even if `spryker/web-profiler` is not present - it's only present for require-dev.

This is fixed in a more recent version of the b2c demo shop, which I believe was on the radar for upgrading to.

This PR gives from 0 to 5 minute speedup each build, saving a maximum total of 15 minutes across the three suites.