### PR TITLE
Fix simpletest usage for Drupal 8

### DIFF
--- a/src/drupal8/application/overlay/Jenkinsfile.twig
+++ b/src/drupal8/application/overlay/Jenkinsfile.twig
@@ -1,0 +1,63 @@
+pipeline {
+    agent { label "my127ws" }
+    environment {
+        MY127WS_KEY = credentials('{{ @('jenkins.credentials.my127ws_key') }}')
+        MY127WS_ENV = "pipeline"
+    }
+    triggers { cron(env.BRANCH_NAME == '{{ @('git.main_branch') }}' ? 'H H(0-6) * * *' : '') }
+    stages {
+        stage('Build') {
+            steps {
+                sh 'ws install'
+                sh 'ws exec composer install --dev --no-interaction'
+                milestone(10)
+            }
+        }
+        stage('Test')  {
+            parallel {
+                stage('quality')    { steps { sh 'ws exec composer test-quality'    } }
+                stage('unit')       { steps { sh 'ws test-unit'                     } }
+                stage('acceptance') { steps { sh 'ws exec composer test-acceptance' } }
+                stage('helm kubeval qa')  { steps { sh 'ws helm kubeval qa' } }
+            }
+        }
+{% if @('pipeline.publish.enabled') == 'yes' %}
+        stage('Publish') {
+            when { not { triggeredBy 'TimerTrigger' } }
+            steps {
+                milestone(50)
+                sh 'ws app publish'
+{% if @('pipeline.publish.chart.enabled') %}
+                sh 'ws app publish chart "${GIT_BRANCH}" "{{ @('workspace.name') }} build artifact ${GIT_COMMIT}"'
+{% endif %}
+            }
+        }
+{% endif %}
+{% if @('pipeline.qa.enabled') == 'yes' %}
+        stage('Deploy (QA)') {
+            environment {
+{% for key, value in @('pipeline.qa.environment') %}
+                {{ key }} = {{ value|raw }}
+{% endfor %}
+            }
+            when {
+                not { triggeredBy 'TimerTrigger' }
+                branch '{{ @('pipeline.qa.branch') }}'
+            }
+            steps {
+                milestone(100)
+                lock(resource: '{{ @('workspace.name') }}-qa-deploy', inversePrecedence: true) {
+                    milestone(101)
+                    sh 'ws app deploy qa'
+                }
+            }
+        }
+{% endif %}
+    }
+    post {
+        always {
+            sh 'ws destroy'
+            cleanWs()
+        }
+    }
+}

--- a/src/drupal8/application/skeleton/.gitignore
+++ b/src/drupal8/application/skeleton/.gitignore
@@ -2,6 +2,7 @@
 /.my127ws
 /.docker-sync/
 /bin/
+/docroot/sites/simpletest/
 /tools/assets/
 /vendor/
 

--- a/src/drupal8/application/skeleton/composer.json
+++ b/src/drupal8/application/skeleton/composer.json
@@ -62,16 +62,12 @@
     "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
     "test": [
       "@test-quality",
-      "@test-unit",
       "@test-acceptance"
     ],
     "test-quality": [
       "find docroot/ -type f ! -path 'docroot/core/lib/Drupal/Component/Assertion/global_namespace_php5.php' \\( -name '*.phtml' -o -name '*.php' \\) | xargs -n 1 -P 8 -i php -l {} | grep -v 'No syntax errors detected' || echo 'OK'",
       "phpcs -v ./docroot/modules/custom",
       "drupal-check -ad ./docroot/modules/custom"
-    ],
-    "test-unit": [
-      "phpunit"
     ],
     "test-acceptance": [
       "behat"

--- a/src/drupal8/application/skeleton/composer.json
+++ b/src/drupal8/application/skeleton/composer.json
@@ -69,6 +69,9 @@
       "phpcs -v ./docroot/modules/custom",
       "drupal-check -ad ./docroot/modules/custom"
     ],
+    "test-unit": [
+      "echo \"Please run 'ws test-unit' to run phpunit\""
+    ],
     "test-acceptance": [
       "behat"
     ],

--- a/src/drupal8/harness.yml
+++ b/src/drupal8/harness.yml
@@ -86,6 +86,15 @@ command('drush %'):
     #!bash(workspace:/)|=
     passthru ws exec drush --root=={ @('drupal.docroot') } ={ input.argument('%') }
 ---
+command('test-unit'):
+  env:
+    COMPOSE_PROJECT_NAME: = @('namespace')
+  exec: |
+    #!bash(workspace:/)|=
+    docker-compose exec -T -u root php-fpm bash -c 'mkdir -p /app/docroot/sites/simpletest'
+    docker-compose exec -T -u root php-fpm bash -c 'chown -R www-data:www-data /app/docroot/sites/simpletest'
+    passthru docker-compose exec -T -u www-data php-fpm bash -c 'bin/phpunit'
+---
 import:
   - harness/config/*.yml
   - harness/attributes/*.yml

--- a/test
+++ b/test
@@ -27,7 +27,7 @@ function test()
     fi
     install_environment
     check_environment_started "$harness" "$mode"
-    run_pipeline_tests
+    run_pipeline_tests "$harness"
     restart_environment
     check_environment_started "$harness" "$mode"
     if [[ "$sync" != "" ]]; then
@@ -73,6 +73,7 @@ function check_environment_started()
 
 function run_pipeline_tests()
 (
+    local harness="$1"
     cd "${path_test}"
 
     # Check if we have a composer.json so we can run tests
@@ -83,7 +84,11 @@ function run_pipeline_tests()
       ws exec composer install --no-interaction
       # Run the tests
       ws exec composer test-quality
-      ws exec composer test-unit
+      if [[ "${harness}" == "drupal8" ]]; then
+        ws test-unit
+      else
+        ws exec composer test-unit
+      fi
       ws exec composer test-acceptance
     fi
 


### PR DESCRIPTION
The container running the website (php-fpm) needs to be the container
running the simpletest phpunit run, as it does calls with basic auth
that let the sqlite database be used instead of MySQL.

Without this, drupal is detecting the lack of a sessions table in the php-fpm sqlite database (despite it present in the console sqlite database) and redirecting to the installer.