### PR TITLE
Run phpstan separately for drupal8

### DIFF
--- a/src/drupal8/application/skeleton/composer.json
+++ b/src/drupal8/application/skeleton/composer.json
@@ -67,7 +67,8 @@
     "test-quality": [
       "find docroot/ -type f ! -path 'docroot/core/lib/Drupal/Component/Assertion/global_namespace_php5.php' \\( -name '*.phtml' -o -name '*.php' \\) | xargs -n 1 -P 8 -i php -l {} | grep -v 'No syntax errors detected' || echo 'OK'",
       "phpcs -v ./docroot/modules/custom",
-      "drupal-check -ad ./docroot/modules/custom"
+      "phpstan analyse",
+      "drupal-check -d ./docroot/modules/custom"
     ],
     "test-unit": [
       "echo \"Please run 'ws test-unit' to run phpunit\""

--- a/src/drupal8/application/skeleton/phpstan.neon
+++ b/src/drupal8/application/skeleton/phpstan.neon
@@ -4,6 +4,6 @@ includes:
     - .my127ws/application/static/phpstan.neon
 
 parameters:
-    level: 7
+    level: max
     paths:
         - docroot/modules/custom


### PR DESCRIPTION
We can't configure parameters for phpstan when running via drupal-check:
https://github.com/mglaman/drupal-check/blob/1.1.2/src/Command/CheckCommand.php#L150

So, only run the deprecation analysis.

Raise to max level for php violations now that we can generate a baseline.