### PR TITLE
Avoid copying vendor folder to NGINX, apart from akeneo

### DIFF
--- a/src/_base/docker/image/nginx/Dockerfile.twig
+++ b/src/_base/docker/image/nginx/Dockerfile.twig
@@ -6,7 +6,7 @@ FROM nginx:1.17-alpine
 COPY root /
 
 {% if @('app.build') == 'static' %}
-{% for copy_directory in @('nginx.copy_directories') %}
+{% for copy_directory in @('nginx.copy_directories')|filter(v => v is not empty) %}
 COPY --from=console {{ copy_directory }} {{ copy_directory }}
 {% endfor %}
 {% else %}

--- a/src/_base/harness/attributes/common.yml
+++ b/src/_base/harness/attributes/common.yml
@@ -126,10 +126,8 @@ attributes.default:
     global:
       conf: []
     # used to limit what is copied into an Nginx static-built image
-    # vendor directory needed for vendor/*/*/*/public/ resources (images etc.)
     copy_directories:
      - = @('app.web_directory')
-     - = @('app.vendor_directory')
 
   node:
     # only set this attribute if you wish to override the supplied node version, by default

--- a/src/akeneo/harness.yml
+++ b/src/akeneo/harness.yml
@@ -101,6 +101,12 @@ attributes:
     tag: 7.6.2
   mysql:
     tag: 8
+  nginx:
+    # used to limit what is copied into an Nginx static-built image
+    # vendor directory needed for vendor/*/*/*/public/ resources (images etc.)
+    copy_directories:
+     - = @('app.web_directory')
+     - = @('app.vendor_directory')
   persistence:
     enabled: false
     akeneo:


### PR DESCRIPTION
Speeds up the NGINX docker image build for at least magento2.

Allow projects to override array entries with `- ~` and not fail the build.

Hint from @tkotosz, with aim to speed up the console to nginx docker image build step.