### PR TITLE
Avoid copying node_modules to php-fpm

### DIFF
--- a/src/_base/docker/image/php-fpm/Dockerfile.twig
+++ b/src/_base/docker/image/php-fpm/Dockerfile.twig
@@ -1,6 +1,7 @@
 {% if @('app.build') == 'static' %}
 FROM {{ @('docker.repository') ~ ':' ~ @('app.version') }}-console as console
 RUN if [ -d /app/tools/assets/ ]; then rm -rf /app/tools/assets/; fi
+RUN if [ -d {{ @('frontend.path') }}/node_modules/ ]; then rm -rf {{ @('frontend.path') }}/node_modules/; fi
 {% endif %}
 
 FROM {{ @('docker.image.php-fpm') }}


### PR DESCRIPTION
Hint from @tkotosz, with aim to speed up the build for the php-fpm image from console image step.