### PR TITLE
Use the production DI for magento2 in phpspec/phpstan

### DIFF
--- a/src/magento2/application/skeleton/composer.json.twig
+++ b/src/magento2/application/skeleton/composer.json.twig
@@ -14,8 +14,6 @@
         "bex/behat-magento2-extension": "^2.1",
         "dmore/behat-chrome-extension": "^1.3",
         "dmore/chrome-mink-driver": "^2.7",
-        "inviqa/phpstan-magento2": "^0.1",
-        "nagno/phpspec-bootstrap-magento2": "^3.1",
         "phpcompatibility/php-compatibility": "dev-master",
         "phpmd/phpmd": "^2.7",
         "phpspec/phpspec": "^6.0",

--- a/src/magento2/application/skeleton/phpspec.yml
+++ b/src/magento2/application/skeleton/phpspec.yml
@@ -1,6 +1,3 @@
-bootstrap: app/autoload.php
+bootstrap: tools/devtools-bootstrap.php
 
 formatter.name: pretty
-
-extensions:
-  Nagno\Phpspec\BootstrapMagento2\Bootstrap: ~

--- a/src/magento2/application/skeleton/phpstan.neon
+++ b/src/magento2/application/skeleton/phpstan.neon
@@ -1,8 +1,9 @@
 includes:
-    - vendor/inviqa/phpstan-magento2/extension.neon
     - .my127ws/application/static/phpstan.neon
 parameters:
     level: max
+    bootstrapFiles:
+        - tools/devtools-bootstrap.php
     paths:
         - src
     excludes_analyse:

--- a/src/magento2/application/skeleton/tools/devtools-bootstrap.php
+++ b/src/magento2/application/skeleton/tools/devtools-bootstrap.php
@@ -1,0 +1,13 @@
+<?php
+
+require __DIR__ . '/../app/bootstrap.php';
+
+if (!in_array('phar', stream_get_wrappers()) && extension_loaded('phar')) {
+    stream_wrapper_restore('phar');
+}
+
+// if DI is not compiled then we need the object manager to generate classes for us
+if (!file_exists(__DIR__ . '/../generated/metadata/global.php')) {
+    $bootstrap = \Magento\Framework\App\Bootstrap::create(BP, $_SERVER);
+    $bootstrap->getObjectManager();
+}


### PR DESCRIPTION
Debugged by @tkotosz for a project.

Uses the production mode `generated/` folder and the shared DI in redis when running phpspec, phpstan.

The phpspec/phpstan configuration which used the object manager directly rather than the generated/ folder was continuously interfering with the in-parallel behat run.