### PR TITLE
Set host volume options to cached and make a delegated-volumes flag

### DIFF
--- a/src/_base/_twig/docker-compose.yml/application.yml.twig
+++ b/src/_base/_twig/docker-compose.yml/application.yml.twig
@@ -16,7 +16,7 @@
     entrypoint: [/entrypoint.dynamic.sh]
     command: [sleep, infinity]
     volumes:
-      - {{ (syncvolume) ? @('workspace.name') ~ '-sync:/app:nocopy' : './:/app:delegated' }}
+      - {{ (syncvolume) ? @('workspace.name') ~ '-sync:/app:nocopy' : ('./:/app' ~ @('docker.compose.host_volume_options'))  }}
       - ./.my127ws/application:/home/build/application
       - ./.my127ws/docker/image/console/root/lib/task:/lib/task
       - ./.my127ws:/.my127ws
@@ -35,7 +35,7 @@
 {% if @('app.build') == 'dynamic' %}
     build: .my127ws/docker/image/nginx
     volumes:
-      - {{ (syncvolume) ? @('workspace.name') ~ '-sync:/app:nocopy' : './:/app:delegated' }}
+      - {{ (syncvolume) ? @('workspace.name') ~ '-sync:/app:nocopy' : ('./:/app' ~ @('docker.compose.host_volume_options'))  }}
 {% else %}
     image: {{ @('docker.repository') ~ ':' ~ @('app.version') ~ '-nginx' }}
 {% endif %}
@@ -73,7 +73,7 @@
     image: {{ @('workspace.name') ~ '-php-fpm:dev' }}
 {% endif %}
     volumes:
-      - {{ (syncvolume) ? @('workspace.name') ~ '-sync:/app:nocopy' : './:/app:delegated' }}
+      - {{ (syncvolume) ? @('workspace.name') ~ '-sync:/app:nocopy' : ('./:/app' ~ @('docker.compose.host_volume_options')) }}
       - ./.my127ws:/.my127ws
 {% else %}
     image: {{ @('docker.repository') ~ ':' ~ @('app.version') ~ '-php-fpm' }}

--- a/src/_base/_twig/docker-compose.yml/service/cron.yml.twig
+++ b/src/_base/_twig/docker-compose.yml/service/cron.yml.twig
@@ -4,7 +4,7 @@
       context: ./
       dockerfile: .my127ws/docker/image/cron/Dockerfile
     volumes:
-      - {{ (syncvolume) ? @('workspace.name') ~ '-sync:/app:nocopy' : './:/app:delegated' }}
+      - {{ (syncvolume) ? @('workspace.name') ~ '-sync:/app:nocopy' : ('./:/app' ~ @('docker.compose.host_volume_options')) }}
       - ./.my127ws/application:/home/build/application
 {% else %}
     image: {{ @('docker.repository') ~ ':' ~ @('app.version') ~ '-cron' }}

--- a/src/_base/harness/attributes/common.yml
+++ b/src/_base/harness/attributes/common.yml
@@ -22,6 +22,7 @@ attributes.default:
     web_directory: /app/public
     vendor_directory: /app/vendor
 
+  delegated-volumes: no
   docker-sync: no
   mutagen: yes
 
@@ -79,6 +80,7 @@ attributes.default:
     repository: = @("workspace.name")
     compose:
       file_version: '3.7'
+      host_volume_options: "= ':' ~ (@('delegated-volumes') ? 'delegated' : 'cached')"
     config: null
     image:
       console: = 'my127/php:' ~ @('php.version') ~ '-fpm-stretch-console'

--- a/src/_base/harness/config/mutagen.yml
+++ b/src/_base/harness/config/mutagen.yml
@@ -6,19 +6,29 @@ command('mutagen (start|stop|pause|resume)'):
     #!bash(workspace:/)
     source .my127ws/harness/scripts/mutagen.sh "$COMMAND"
 
-command('switch (mutagen|docker-sync)'):
+command('switch (cached-volumes|delegated-volumes|mutagen|docker-sync)'):
   env:
     SYNC: = input.command(2)
     NAMESPACE: = @('namespace')
   exec: |
     #!bash(workspace:/)|=
     run ws disable
-    if [[ "$SYNC" = "mutagen" ]]; then
+    if [[ "$SYNC = "delegated-volumes" ]]; then
+      ws set delegated-volumes yes
+      ws set mutagen no
+      ws set docker-sync no
+    elif [[ "$SYNC" = "mutagen" ]]; then
+      ws set delegated-volumes no
       ws set mutagen yes
       ws set docker-sync no
-    else
+    elif [[ "$SYNC" = "docker-sync" ]]; then
+      ws set delegated-volumes no
       ws set mutagen no
       ws set docker-sync yes
+    else
+      ws set delegated-volumes no
+      ws set mutagen no
+      ws set docker-sync no
     fi
     run ws harness prepare
     echo 'Bringing up the environment with the new setting'

--- a/src/akeneo/_twig/docker-compose.yml/service/job-queue-consumer.yml.twig
+++ b/src/akeneo/_twig/docker-compose.yml/service/job-queue-consumer.yml.twig
@@ -4,7 +4,7 @@
       context: ./
       dockerfile: .my127ws/docker/image/job-queue-consumer/Dockerfile
     volumes:
-      - {{ (syncvolume) ? @('workspace.name') ~ '-sync:/app:nocopy' : ('./:/app' ~ @('docker.host_volume_options')) }}
+      - {{ (syncvolume) ? @('workspace.name') ~ '-sync:/app:nocopy' : ('./:/app' ~ @('docker.compose.host_volume_options')) }}
       - ./.my127ws/application:/home/build/application
 {% else %}
     image: {{ @('docker.repository') ~ ':' ~ @('app.version') ~ '-job-queue-consumer' }}

--- a/src/akeneo/_twig/docker-compose.yml/service/job-queue-consumer.yml.twig
+++ b/src/akeneo/_twig/docker-compose.yml/service/job-queue-consumer.yml.twig
@@ -4,7 +4,7 @@
       context: ./
       dockerfile: .my127ws/docker/image/job-queue-consumer/Dockerfile
     volumes:
-      - {{ (syncvolume) ? @('workspace.name') ~ '-sync:/app:nocopy' : './:/app:delegated' }}
+      - {{ (syncvolume) ? @('workspace.name') ~ '-sync:/app:nocopy' : ('./:/app' ~ @('docker.host_volume_options')) }}
       - ./.my127ws/application:/home/build/application
 {% else %}
     image: {{ @('docker.repository') ~ ':' ~ @('app.version') ~ '-job-queue-consumer' }}

--- a/src/spryker/_twig/docker-compose.yml/application.yml.twig
+++ b/src/spryker/_twig/docker-compose.yml/application.yml.twig
@@ -15,7 +15,7 @@
     entrypoint: [/entrypoint.dynamic.sh]
     command: [sleep, infinity]
     volumes:
-      - {{ (syncvolume) ? @('workspace.name') ~ '-sync:/app:nocopy' : ('./:/app' ~ @('docker.host_volume_options')) }}
+      - {{ (syncvolume) ? @('workspace.name') ~ '-sync:/app:nocopy' : ('./:/app' ~ @('docker.compose.host_volume_options')) }}
       - ./.my127ws/application:/home/build/application
       - ./.my127ws/docker/image/console/root/lib/task:/lib/task
       - ./.my127ws:/.my127ws
@@ -34,7 +34,7 @@
 {% if @('app.build') == 'dynamic' %}
     build: .my127ws/docker/image/nginx
     volumes:
-      - {{ (syncvolume) ? @('workspace.name') ~ '-sync:/app:nocopy' : ('./:/app' ~ @('docker.host_volume_options')) }}
+      - {{ (syncvolume) ? @('workspace.name') ~ '-sync:/app:nocopy' : ('./:/app' ~ @('docker.compose.host_volume_options')) }}
 {% else %}
     image: {{ @('docker.repository') ~ ':' ~ @('app.version') ~ '-nginx' }}
 {% endif %}
@@ -69,7 +69,7 @@
     entrypoint: /entrypoint.dynamic.sh
     command: [sleep, infinity]
     volumes:
-      - {{ (syncvolume) ? @('workspace.name') ~ '-sync:/app:nocopy' : ('./:/app' ~ @('docker.host_volume_options')) }}
+      - {{ (syncvolume) ? @('workspace.name') ~ '-sync:/app:nocopy' : ('./:/app' ~ @('docker.compose.host_volume_options')) }}
       - ./.my127ws:/.my127ws
 {% else %}
     image: {{ @('docker.repository') ~ ':' ~ @('app.version') ~ '-php-fpm' }}

--- a/src/spryker/_twig/docker-compose.yml/application.yml.twig
+++ b/src/spryker/_twig/docker-compose.yml/application.yml.twig
@@ -15,7 +15,7 @@
     entrypoint: [/entrypoint.dynamic.sh]
     command: [sleep, infinity]
     volumes:
-      - {{ (syncvolume) ? @('workspace.name') ~ '-sync:/app:nocopy' : './:/app:delegated' }}
+      - {{ (syncvolume) ? @('workspace.name') ~ '-sync:/app:nocopy' : ('./:/app' ~ @('docker.host_volume_options')) }}
       - ./.my127ws/application:/home/build/application
       - ./.my127ws/docker/image/console/root/lib/task:/lib/task
       - ./.my127ws:/.my127ws
@@ -34,7 +34,7 @@
 {% if @('app.build') == 'dynamic' %}
     build: .my127ws/docker/image/nginx
     volumes:
-      - {{ (syncvolume) ? @('workspace.name') ~ '-sync:/app:nocopy' : './:/app:delegated' }}
+      - {{ (syncvolume) ? @('workspace.name') ~ '-sync:/app:nocopy' : ('./:/app' ~ @('docker.host_volume_options')) }}
 {% else %}
     image: {{ @('docker.repository') ~ ':' ~ @('app.version') ~ '-nginx' }}
 {% endif %}
@@ -69,7 +69,7 @@
     entrypoint: /entrypoint.dynamic.sh
     command: [sleep, infinity]
     volumes:
-      - {{ (syncvolume) ? @('workspace.name') ~ '-sync:/app:nocopy' : './:/app:delegated' }}
+      - {{ (syncvolume) ? @('workspace.name') ~ '-sync:/app:nocopy' : ('./:/app' ~ @('docker.host_volume_options')) }}
       - ./.my127ws:/.my127ws
 {% else %}
     image: {{ @('docker.repository') ~ ':' ~ @('app.version') ~ '-php-fpm' }}

--- a/src/spryker/_twig/docker-compose.yml/service/jenkins-runner.yml.twig
+++ b/src/spryker/_twig/docker-compose.yml/service/jenkins-runner.yml.twig
@@ -6,7 +6,7 @@
     entrypoint: /entrypoint.jenkins_runner.dynamic.sh
     command: [sleep, infinity]
     volumes:
-      - {{ (syncvolume) ? @('workspace.name') ~ '-sync:/app:nocopy' : ('./:/app' ~ @('docker.host_volume_options')) }}
+      - {{ (syncvolume) ? @('workspace.name') ~ '-sync:/app:nocopy' : ('./:/app' ~ @('docker.compose.host_volume_options')) }}
       - ./.my127ws/application:/home/build/application
 {% else %}
     image: {{ @('docker.repository') ~ ':' ~ @('app.version') ~ '-jenkins-runner' }}

--- a/src/spryker/_twig/docker-compose.yml/service/jenkins-runner.yml.twig
+++ b/src/spryker/_twig/docker-compose.yml/service/jenkins-runner.yml.twig
@@ -6,7 +6,7 @@
     entrypoint: /entrypoint.jenkins_runner.dynamic.sh
     command: [sleep, infinity]
     volumes:
-      - {{ (syncvolume) ? @('workspace.name') ~ '-sync:/app:nocopy' : './:/app:delegated' }}
+      - {{ (syncvolume) ? @('workspace.name') ~ '-sync:/app:nocopy' : ('./:/app' ~ @('docker.host_volume_options')) }}
       - ./.my127ws/application:/home/build/application
 {% else %}
     image: {{ @('docker.repository') ~ ':' ~ @('app.version') ~ '-jenkins-runner' }}


### PR DESCRIPTION
Docker Desktop is bringing in mutagen natively, and so continuing to use delegated introduces a non-BC bug

The existing harness mutagen will continue to be the default mode for now, as:
a) Docker Desktop Stable release doesn't have this yet
b) There may not be feature parity in any case (global mutagen config vs per project mutagen config)