### PR TITLE
Make use of twig includes for docker build cache

### DIFF
--- a/src/_base/_twig/docker-compose.yml/application.yml.twig
+++ b/src/_base/_twig/docker-compose.yml/application.yml.twig
@@ -9,10 +9,10 @@
 {% set hostnames = hostnames|merge(@('hostname_aliases')|map(alias => "#{alias}." ~ @('domain'))) %}
 
   console:
-{% if @('app.build') == 'dynamic' %}
     build:
       context: ./
       dockerfile: .my127ws/docker/image/console/Dockerfile
+{% if @('app.build') == 'dynamic' %}
     entrypoint: [/entrypoint.dynamic.sh]
     command: [sleep, infinity]
     volumes:
@@ -32,8 +32,8 @@
       - private
 
   nginx:
-{% if @('app.build') == 'dynamic' %}
     build: .my127ws/docker/image/nginx
+{% if @('app.build') == 'dynamic' %}
     volumes:
       - {{ (syncvolume) ? @('workspace.name') ~ '-sync:/app:nocopy' : './:/app:delegated' }}
 {% else %}
@@ -67,11 +67,8 @@
       shared: {}
 
   php-fpm:
-{% if @('app.build') == 'dynamic' %}
     build: .my127ws/docker/image/php-fpm
-{% if ("cron" in @('app.services')) %}
-    image: {{ @('workspace.name') ~ '-php-fpm:dev' }}
-{% endif %}
+{% if @('app.build') == 'dynamic' %}
     volumes:
       - {{ (syncvolume) ? @('workspace.name') ~ '-sync:/app:nocopy' : './:/app:delegated' }}
       - ./.my127ws:/.my127ws

--- a/src/_base/_twig/docker-compose.yml/service/cron.yml.twig
+++ b/src/_base/_twig/docker-compose.yml/service/cron.yml.twig
@@ -1,8 +1,8 @@
   cron:
-{% if @('app.build') == 'dynamic' %}
     build:
       context: ./
       dockerfile: .my127ws/docker/image/cron/Dockerfile
+{% if @('app.build') == 'dynamic' %}
     volumes:
       - {{ (syncvolume) ? @('workspace.name') ~ '-sync:/app:nocopy' : './:/app:delegated' }}
       - ./.my127ws/application:/home/build/application

--- a/src/_base/docker/image/console/Dockerfile.twig
+++ b/src/_base/docker/image/console/Dockerfile.twig
@@ -1,4 +1,4 @@
-FROM {{ @('docker.image.console') }}
+FROM {{ @('docker.image.console') }} as console
 
 COPY .my127ws/docker/image/console/root /
 RUN chown -R build:build /home/build \

--- a/src/_base/docker/image/cron/Dockerfile.twig
+++ b/src/_base/docker/image/cron/Dockerfile.twig
@@ -1,8 +1,5 @@
-{% if @('app.build') == 'static' %}
-FROM {{ @('docker.repository') ~ ':' ~ @('app.version') }}-php-fpm
-{% else %}
-FROM {{ @('workspace.name') ~ '-php-fpm:dev' }}
-{% endif %}
+{# build from php-fpm Dockerfile #}
+{% include 'docker/image/php-fpm/Dockerfile.twig' %}
 
 # Install cron
 RUN apt-get update -qq \

--- a/src/_base/docker/image/nginx/Dockerfile.twig
+++ b/src/_base/docker/image/nginx/Dockerfile.twig
@@ -1,5 +1,5 @@
 {% if @('app.build') == 'static' %}
-FROM {{ @('docker.repository') ~ ':' ~ @('app.version') }}-console as console
+{% include 'docker/image/console/Dockerfile.twig' %}
 {% endif %}
 
 FROM nginx:1.17-alpine

--- a/src/_base/docker/image/php-fpm/Dockerfile.twig
+++ b/src/_base/docker/image/php-fpm/Dockerfile.twig
@@ -1,5 +1,5 @@
 {% if @('app.build') == 'static' %}
-FROM {{ @('docker.repository') ~ ':' ~ @('app.version') }}-console as console
+{% include 'docker/image/console/Dockerfile.twig' %}
 RUN if [ -d /app/tools/assets/ ]; then rm -rf /app/tools/assets/; fi
 {% endif %}
 

--- a/src/_base/harness/config/pipeline.yml
+++ b/src/_base/harness/config/pipeline.yml
@@ -1,39 +1,15 @@
 
 command('app build'):
-  env:
-    HAS_CRON: "= ('cron' in @('app.services') ? 'true' : 'false')"
-    HAS_VARNISH: "= ('varnish' in @('app.services') ? 'true' : 'false')"
   exec: |
     #!bash(workspace:/)|@
-    ws app build console
-    ws app build php-fpm
-    ws app build nginx
-    if [[ "${HAS_CRON}" == "true" ]]; then
-      ws app build cron
-    fi
-    if [[ "${HAS_VARNISH}" == "true" ]]; then
-      ws app build tls-offload
-    fi
+    passthru docker-compose build
 
-command('app build console'): |
-  #!bash(workspace:/)|@
-  passthru docker build --pull -t @('docker.repository'):@('app.version')-console -f .my127ws/docker/image/console/Dockerfile .
-
-command('app build cron'): |
-  #!bash(workspace:/)|@
-  passthru docker build -t @('docker.repository'):@('app.version')-cron -f .my127ws/docker/image/cron/Dockerfile .
-
-command('app build php-fpm'): |
-  #!bash(harness:/docker/image/php-fpm)|@
-  passthru docker build -t @('docker.repository'):@('app.version')-php-fpm .
-
-command('app build nginx'): |
-  #!bash(harness:/docker/image/nginx)|@
-  passthru docker build -t @('docker.repository'):@('app.version')-nginx .
-
-command('app build tls-offload'): |
-  #!bash(harness:/docker/image/tls-offload)|@
-  passthru docker build -t @('docker.repository'):@('app.version')-tls-offload .
+command('app build <service>'):
+  env:
+    SERVICE:    = input.argument('message')
+  exec: |
+    #!bash(workspace:/)|@
+    passthru docker-compose build "${SERVICE}"
 
 command('app publish'):
   env:
@@ -41,11 +17,9 @@ command('app publish'):
   exec: |
     #!bash(workspace:/)|@
     echo "@('docker.password')" | run docker login --username="@('docker.username')" --password-stdin @('docker.repository')
-    run docker push @('docker.repository'):@('app.version')-console
-    run docker push @('docker.repository'):@('app.version')-php-fpm
-    run docker push @('docker.repository'):@('app.version')-nginx
+    run docker-compose push console php-fpm nginx
     if [[ "${HAS_CRON}" == "true" ]]; then
-      run docker push @('docker.repository'):@('app.version')-cron
+      run docker-compose push cron
     fi
     run docker logout @('docker.repository')
 

--- a/src/_base/harness/config/pipeline.yml
+++ b/src/_base/harness/config/pipeline.yml
@@ -2,7 +2,7 @@
 command('app build'):
   exec: |
     #!bash(workspace:/)|@
-  passthru docker-compose build
+    passthru docker-compose build
 
 command('app build <service>'):
   env:

--- a/src/_base/harness/config/pipeline.yml
+++ b/src/_base/harness/config/pipeline.yml
@@ -2,11 +2,11 @@
 command('app build'):
   exec: |
     #!bash(workspace:/)|@
-    passthru docker-compose build
+  passthru docker-compose build
 
 command('app build <service>'):
   env:
-    SERVICE:    = input.argument('message')
+    SERVICE: = input.argument('message')
   exec: |
     #!bash(workspace:/)|@
     passthru docker-compose build "${SERVICE}"

--- a/src/_base/harness/scripts/destroy.sh
+++ b/src/_base/harness/scripts/destroy.sh
@@ -11,7 +11,6 @@ elif [[ "$USE_MUTAGEN" = "yes" ]]; then
 fi
 
 if [[ "$APP_BUILD" = "static" ]]; then
-    run "docker images --filter=since='${DOCKER_REPOSITORY}:${APP_VERSION}-console' -q | xargs --no-run-if-empty docker image rm --force"
     run "docker images --filter=reference='${DOCKER_REPOSITORY}:${APP_VERSION}-*' -q | xargs --no-run-if-empty docker image rm --force"
 fi
 

--- a/src/_base/harness/scripts/enable.sh.twig
+++ b/src/_base/harness/scripts/enable.sh.twig
@@ -39,18 +39,16 @@ dynamic()
         passthru ws mutagen pause
     fi
 
-    {% if ("cron" in @('app.services')) %}
-        passthru "docker-compose config --services | grep -v php-fpm | xargs docker-compose pull"
-        passthru "docker-compose config --services | grep -v cron | xargs docker-compose build --pull"
-        passthru docker-compose build cron
+    passthru docker-compose pull
+    passthru docker-compose build --pull
+
+    if docker-compose config --services | grep cron >/dev/null; then
         # Bring up all but cron
         passthru "docker-compose config --services | grep -v cron | xargs docker-compose up -d"
-    {% else %}
-        passthru docker-compose pull
-        passthru docker-compose build --pull
+    else
         # Bring up all services
         passthru docker-compose up -d
-    {% endif %}
+    fi
 
     passthru docker-compose exec -T -u build console app build
     passthru docker-compose exec -T -u build console app init
@@ -63,13 +61,13 @@ static()
 {
     ws app build
 
-    {% if ("cron" in @('app.services')) %}
+    if docker-compose config --services | grep cron >/dev/null; then
         # Bring up all but cron
         passthru "docker-compose config --services | grep -v cron | xargs docker-compose up -d"
-    {% else %}
+    else
         # Bring up all services
         passthru docker-compose up -d
-    {% endif %}
+    fi
 
     passthru docker-compose exec -T -u build console app init
     # Bring up all services

--- a/src/akeneo/_twig/docker-compose.yml/service/job-queue-consumer.yml.twig
+++ b/src/akeneo/_twig/docker-compose.yml/service/job-queue-consumer.yml.twig
@@ -1,8 +1,8 @@
   job-queue-consumer:
-{% if @('app.build') == 'dynamic' %}
     build:
       context: ./
       dockerfile: .my127ws/docker/image/job-queue-consumer/Dockerfile
+{% if @('app.build') == 'dynamic' %}
     volumes:
       - {{ (syncvolume) ? @('workspace.name') ~ '-sync:/app:nocopy' : './:/app:delegated' }}
       - ./.my127ws/application:/home/build/application

--- a/src/akeneo/docker/image/console/Dockerfile.twig
+++ b/src/akeneo/docker/image/console/Dockerfile.twig
@@ -1,4 +1,4 @@
-FROM {{ @('docker.image.console') }}
+FROM {{ @('docker.image.console') }} as console
 
 COPY .my127ws/docker/image/console/root /
 RUN chown -R build:build /home/build \

--- a/src/akeneo/docker/image/job-queue-consumer/Dockerfile.twig
+++ b/src/akeneo/docker/image/job-queue-consumer/Dockerfile.twig
@@ -1,8 +1,5 @@
-{% if @('app.build') == 'static' %}
-FROM {{ @('docker.repository') ~ ':' ~ @('app.version') }}-php-fpm
-{% else %}
-FROM {{ @('workspace.name') ~ '-php-fpm:dev' }}
-{% endif %}
+{# build from php-fpm Dockerfile #}
+{% include 'docker/image/php-fpm/Dockerfile.twig' %}
 
 WORKDIR /app
 COPY .my127ws/docker/image/job-queue-consumer/root /

--- a/src/akeneo/harness/config/q-akeneo-pipeline.yml
+++ b/src/akeneo/harness/config/q-akeneo-pipeline.yml
@@ -1,23 +1,6 @@
 
-command('app build'): |
-  #!bash(workspace:/)|@
-  ws app build console
-  ws app build php-fpm
-  ws app build job-queue-consumer
-  ws app build cron
-  ws app build nginx
-
-command('app build job-queue-consumer'): |
-  #!bash(workspace:/)|@
-  passthru docker build -t @('docker.repository'):@('app.version')-job-queue-consumer -f .my127ws/docker/image/job-queue-consumer/Dockerfile .
-
 command('app publish'): |
   #!bash(workspace:/)|@
   echo "@('docker.password')" | run docker login --username="@('docker.username')" --password-stdin @('docker.repository')
-  run docker push @('docker.repository'):@('app.version')-console
-  run docker push @('docker.repository'):@('app.version')-php-fpm
-  run docker push @('docker.repository'):@('app.version')-job-queue-consumer
-  run docker push @('docker.repository'):@('app.version')-cron
-  run docker push @('docker.repository'):@('app.version')-nginx
+  run docker-compose build console php-fpm job-queue-consumer cron nginx
   run docker logout @('docker.repository')
-

--- a/src/akeneo/harness/scripts/enable.sh.twig
+++ b/src/akeneo/harness/scripts/enable.sh.twig
@@ -39,9 +39,8 @@ dynamic()
         passthru ws mutagen pause
     fi
 
-    passthru "docker-compose config --services | grep -v php-fpm | xargs docker-compose pull"
-    passthru "docker-compose config --services | grep -v cron | grep -v job-queue-consumer | xargs docker-compose build --pull"
-    passthru docker-compose build cron job-queue-consumer
+    passthru docker-compose pull
+    passthru docker-compose build --pull
 
     # Bring up all but cron and job-queue-consumer
     passthru "docker-compose config --services | grep -v cron | grep -v job-queue-consumer | xargs docker-compose up -d"
@@ -57,13 +56,13 @@ static()
 {
     ws app build
 
-    {% if ("cron" in @('app.services')) %}
+    if docker-compose config --services | grep 'cron\|job-queue-consumer' >/dev/null; then
         # Bring up all but cron and job-queue-consumer
         passthru "docker-compose config --services | grep -v cron | grep -v job-queue-consumer | xargs docker-compose up -d"
-    {% else %}
+    else
         # Bring up all but job-queue-consumer
         passthru "docker-compose config --services | grep -v job-queue-consumer | xargs docker-compose up -d"
-    {% endif %}
+    fi
 
     passthru docker-compose exec -T -u build console app init
 

--- a/src/magento2/docker/image/console/Dockerfile.twig
+++ b/src/magento2/docker/image/console/Dockerfile.twig
@@ -1,4 +1,4 @@
-FROM {{ @('docker.image.console') }}
+FROM {{ @('docker.image.console') }} as console
 
 COPY .my127ws/docker/image/console/root /
 RUN chown -R build:build /home/build \

--- a/src/spryker/_twig/docker-compose.yml/application.yml.twig
+++ b/src/spryker/_twig/docker-compose.yml/application.yml.twig
@@ -7,11 +7,10 @@
 {% endif %}
 
   console:
-{% if @('app.build') == 'dynamic' %}
     build:
       context: ./
       dockerfile: .my127ws/docker/image/console/Dockerfile
-    image: {{ @('workspace.name') ~ '-console:dev' }}
+{% if @('app.build') == 'dynamic' %}
     entrypoint: [/entrypoint.dynamic.sh]
     command: [sleep, infinity]
     volumes:
@@ -31,8 +30,8 @@
       - private
 
   nginx:
-{% if @('app.build') == 'dynamic' %}
     build: .my127ws/docker/image/nginx
+{% if @('app.build') == 'dynamic' %}
     volumes:
       - {{ (syncvolume) ? @('workspace.name') ~ '-sync:/app:nocopy' : './:/app:delegated' }}
 {% else %}
@@ -64,8 +63,8 @@
       shared: {}
 
   php-fpm:
-{% if @('app.build') == 'dynamic' %}
     build: .my127ws/docker/image/php-fpm
+{% if @('app.build') == 'dynamic' %}
     entrypoint: /entrypoint.dynamic.sh
     command: [sleep, infinity]
     volumes:

--- a/src/spryker/_twig/docker-compose.yml/service/jenkins-runner.yml.twig
+++ b/src/spryker/_twig/docker-compose.yml/service/jenkins-runner.yml.twig
@@ -1,8 +1,8 @@
   jenkins-runner:
-{% if @('app.build') == 'dynamic' %}
     build:
       context: ./
       dockerfile: .my127ws/docker/image/jenkins-runner/Dockerfile
+{% if @('app.build') == 'dynamic' %}
     entrypoint: /entrypoint.jenkins_runner.dynamic.sh
     command: [sleep, infinity]
     volumes:

--- a/src/spryker/docker/image/jenkins-runner/Dockerfile.twig
+++ b/src/spryker/docker/image/jenkins-runner/Dockerfile.twig
@@ -1,8 +1,5 @@
-{% if @('app.build') == 'static' %}
-FROM {{ @('docker.repository') ~ ':' ~ @('app.version') }}-console
-{% else %}
-FROM {{ @('workspace.name') ~ '-console:dev' }}
-{% endif %}
+{# build from console Dockerfile #}
+{% include 'docker/image/console/Dockerfile.twig' %}
 
 # Install Java Runtime
 # ----------------------------

--- a/src/spryker/harness/config/spryker-pipeline.yml
+++ b/src/spryker/harness/config/spryker-pipeline.yml
@@ -1,20 +1,6 @@
 
-command('app build'): |
-  #!bash(workspace:/)|@
-  ws app build console
-  ws app build php-fpm
-  ws app build nginx
-  ws app build jenkins-runner
-
 command('app publish'): |
   #!bash(workspace:/)|@
-  echo "@('docker.password')" | run docker login --username="@('docker.username')" --password-stdin @('docker.repository')
-  run docker push @('docker.repository'):@('app.version')-console
-  run docker push @('docker.repository'):@('app.version')-php-fpm
-  run docker push @('docker.repository'):@('app.version')-nginx
-  run docker push @('docker.repository'):@('app.version')-jenkins-runner
+  echo "@('docker.password')" | run docker login --user name="@('docker.username')" --password-stdin @('docker.repository')
+  run docker-compose push console php-fpm nginx jenkins-runner
   run docker logout @('docker.repository')
-
-command('app build jenkins-runner'): |
-  #!bash(workspace:/)|@
-  passthru docker build -t @('docker.repository'):@('app.version')-jenkins-runner -f .my127ws/docker/image/jenkins-runner/Dockerfile .

--- a/src/spryker/harness/scripts/enable.sh.twig
+++ b/src/spryker/harness/scripts/enable.sh.twig
@@ -39,15 +39,8 @@ dynamic()
         passthru ws mutagen pause
     fi
 
-    {% if ("cron" in @('app.services')) %}
-        passthru "docker-compose config --services | grep -v php-fpm | grep -v console | xargs docker-compose pull"
-        passthru "docker-compose config --services | grep -v cron | grep -v jenkins-runner | xargs docker-compose build --pull"
-        passthru docker-compose build cron
-    {% else %}
-        passthru "docker-compose config --services | grep -v console | xargs docker-compose pull"
-        passthru "docker-compose config --services | grep -v jenkins-runner | xargs docker-compose build --pull"
-    {% endif %}
-    passthru docker-compose build jenkins-runner
+    docker-compose pull
+    docker-compose build --pull
 
     # Bring up all but cron
     passthru "docker-compose config --services | grep -v cron | xargs docker-compose up -d"
@@ -63,13 +56,13 @@ static()
 {
     ws app build
 
-    {% if ("cron" in @('app.services')) %}
+    if docker-compose config --services | grep cron >/dev/null; then
         # Bring up all but cron
         passthru "docker-compose config --services | grep -v cron | xargs docker-compose up -d"
-    {% else %}
+    else
         # Bring up all services
         passthru docker-compose up -d
-    {% endif %}
+    fi
 
     passthru docker-compose exec -T -u build console app init
 


### PR DESCRIPTION
To avoid intermediate image tags, and simplify the build process to allow any one service to be built by itself, making order of service builds unimportant

Also use docker-compose for build and push