### PR TITLE
Remove spryker console dev image when destroying ws environment

### DIFF
--- a/src/_base/harness/scripts/destroy.sh
+++ b/src/_base/harness/scripts/destroy.sh
@@ -13,6 +13,7 @@ fi
 if [[ "$APP_BUILD" = "static" ]]; then
     run "docker images --filter=since='${DOCKER_REPOSITORY}:${APP_VERSION}-console' -q | xargs --no-run-if-empty docker image rm --force"
     run "docker images --filter=reference='${DOCKER_REPOSITORY}:${APP_VERSION}-*' -q | xargs --no-run-if-empty docker image rm --force"
+    run "docker images --filter=reference='${NAMESPACE}-console:dev' -q | xargs --no-run-if-empty docker image rm --force"
 fi
 
 run rm -f .my127ws/.flag-built

--- a/src/_base/harness/scripts/destroy.sh
+++ b/src/_base/harness/scripts/destroy.sh
@@ -13,7 +13,7 @@ fi
 if [[ "$APP_BUILD" = "static" ]]; then
     run "docker images --filter=since='${DOCKER_REPOSITORY}:${APP_VERSION}-console' -q | xargs --no-run-if-empty docker image rm --force"
     run "docker images --filter=reference='${DOCKER_REPOSITORY}:${APP_VERSION}-*' -q | xargs --no-run-if-empty docker image rm --force"
-    run "docker images --filter=reference='${NAMESPACE}-console:dev' -q | xargs --no-run-if-empty docker image rm --force"
+    run "docker images --filter=reference='${NAMESPACE}-*:dev' -q | xargs --no-run-if-empty docker image rm --force"
 fi
 
 run rm -f .my127ws/.flag-built


### PR DESCRIPTION
`ci-spryker-sample-dynamic-console:dev` is left behind in Jenkins