### PR TITLE
Add new core Composer tools

### DIFF
--- a/src/drupal8/application/skeleton/composer.json
+++ b/src/drupal8/application/skeleton/composer.json
@@ -17,12 +17,11 @@
   },
   "require-dev": {
     "dmore/behat-chrome-extension": "^1.3",
-    "drupal/core-dev": "^8",
+    "drupal/core-dev": "~8.9",
     "drupal/devel": "^2.0",
     "drupal/drupal-extension": "^3.4",
     "jangregor/phpstan-prophecy": "^0.8",
     "mglaman/drupal-check": "^1.1",
-    "mglaman/phpstan-drupal": "^0.12",
     "mikey179/vfsstream": "^1.0",
     "mglaman/phpstan-drupal": "^0.12",
     "phpcompatibility/php-compatibility": "dev-master",
@@ -32,10 +31,10 @@
   "require": {
     "composer/installers": "^1.0",
     "cweagans/composer-patches": "^1.5.0",
-    "drupal-composer/drupal-scaffold": "^2.0.0",
     "drupal/admin_toolbar": "^1.0",
     "drupal/console": "^1.0",
-    "drupal/core": "^8",
+    "drupal/core-composer-scaffold": "~8.9",
+    "drupal/core-recommended": "~8.9",
     "drupal/ctools": "^3.0",
     "drupal/environment_indicator": "^3.0",
     "drupal/field_group": "^3.0@beta",
@@ -57,10 +56,6 @@
     "oomphinc/composer-installers-extender": "^1.1"
   },
   "scripts": {
-    "post-install-cmd": [
-      "@composer drupal-scaffold"
-    ],
-    "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
     "test": [
       "@test-quality",
       "@test-acceptance"
@@ -80,6 +75,11 @@
     "compatibility": "bin/phpcs -s --standard=vendor/phpcompatibility/php-compatibility/PHPCompatibility/ --runtime-set testVersion 7.2-"
   },
   "extra": {
+    "drupal-scaffold": {
+      "locations": {
+        "web-root": "docroot"
+      }
+    },
     "enable-patching": true,
     "composer-exit-on-patch-failure": true,
     "patches": {
@@ -104,8 +104,5 @@
         "type:drupal-library"
       ]
     }
-  },
-  "conflict": {
-    "twig/twig": "^1.40.0"
   }
 }


### PR DESCRIPTION
Replace the existing tools with the new core Composer packages - i.e.
`drupal/core-recommended`, `drupal/core-dev` and
`drupal/core-composer-scaffold`.