### PR TITLE
Add ability to define env vars from k8s secrets

### DIFF
--- a/src/_base/_twig/docker-compose.yml/application.yml.twig
+++ b/src/_base/_twig/docker-compose.yml/application.yml.twig
@@ -26,7 +26,13 @@
     labels:
       - traefik.enable=false
     environment:
-{{ deep_merge_to_yaml([@('services.php-base.environment'), @('services.console.environment')], 2, 6) | raw }}
+{{ deep_merge_to_yaml(
+  [
+    @('services.php-base.environment'),
+    @('services.console.environment'),
+    @('services.php-base.environment_secrets'),
+    @('services.console.environment_secrets')
+  ], 2, 6) | raw }}
 {% include blocks ~ 'environment.yml.twig' %}
     networks:
       - private
@@ -83,7 +89,13 @@
     networks:
       - private
     environment:
-{{ deep_merge_to_yaml([@('services.php-base.environment'), @('services.php-fpm.environment')], 2, 6) | raw }}
+{{ deep_merge_to_yaml(
+  [
+    @('services.php-base.environment'),
+    @('services.php-fpm.environment'),
+    @('services.php-base.environment_secrets'),
+    @('services.php-fpm.environment_secrets')
+  ], 2, 6) | raw }}
 {% include blocks ~ 'environment.yml.twig' %}
     expose:
 {% for pool in @('php-fpm.pools') %}

--- a/src/_base/_twig/docker-compose.yml/application.yml.twig
+++ b/src/_base/_twig/docker-compose.yml/application.yml.twig
@@ -25,14 +25,12 @@
 {% endif %}
     labels:
       - traefik.enable=false
-    environment:
-{{ deep_merge_to_yaml(
-  [
-    @('services.php-base.environment'),
-    @('services.console.environment'),
-    @('services.php-base.environment_secrets'),
-    @('services.console.environment_secrets')
-  ], 2, 6) | raw }}
+    environment: {{ to_nice_yaml(deep_merge([
+        @('services.php-base.environment'),
+        @('services.console.environment'),
+        @('services.php-base.environment_secrets'),
+        @('services.console.environment_secrets')
+      ]), 2, 6) | raw }}
 {% include blocks ~ 'environment.yml.twig' %}
     networks:
       - private
@@ -54,10 +52,10 @@
 {% else %}
       - traefik.enable=false
 {% endif %}
-{% if @('services.nginx.environment') %}
-    environment:
-{{ to_nice_yaml(@('services.nginx.environment'), 2, 6) | raw }}
-{% endif %}
+    environment: {{ to_nice_yaml(deep_merge([
+        @('services.nginx.environment'),
+        @('services.nginx.environment_secrets')
+      ]), 2, 6) | raw }}
     links:
       - php-fpm:php-fpm
     networks:
@@ -88,14 +86,12 @@
       - traefik.enable=false
     networks:
       - private
-    environment:
-{{ deep_merge_to_yaml(
-  [
-    @('services.php-base.environment'),
-    @('services.php-fpm.environment'),
-    @('services.php-base.environment_secrets'),
-    @('services.php-fpm.environment_secrets')
-  ], 2, 6) | raw }}
+    environment: {{ to_nice_yaml(deep_merge([
+        @('services.php-base.environment'),
+        @('services.php-fpm.environment'),
+        @('services.php-base.environment_secrets'),
+        @('services.php-fpm.environment_secrets')
+      ]), 2, 6) | raw }}
 {% include blocks ~ 'environment.yml.twig' %}
     expose:
 {% for pool in @('php-fpm.pools') %}

--- a/src/_base/_twig/docker-compose.yml/service/cron.yml.twig
+++ b/src/_base/_twig/docker-compose.yml/service/cron.yml.twig
@@ -9,14 +9,12 @@
 {% else %}
     image: {{ @('docker.repository') ~ ':' ~ @('app.version') ~ '-cron' }}
 {% endif %}
-    environment:
-{{ deep_merge_to_yaml(
-  [
-    @('services.php-base.environment'),
-    @('services.cron.environment'),
-    @('services.php-base.environment_secrets'),
-    @('services.cron.environment_secrets')
-  ], 2, 6) | raw }}
+    environment: {{ to_nice_yaml(deep_merge([
+        @('services.php-base.environment'),
+        @('services.cron.environment'),
+        @('services.php-base.environment_secrets'),
+        @('services.cron.environment_secrets')
+      ]), 2, 6) | raw }}
 {% include blocks ~ 'environment.yml.twig' %}
     networks:
       - private

--- a/src/_base/_twig/docker-compose.yml/service/cron.yml.twig
+++ b/src/_base/_twig/docker-compose.yml/service/cron.yml.twig
@@ -10,7 +10,13 @@
     image: {{ @('docker.repository') ~ ':' ~ @('app.version') ~ '-cron' }}
 {% endif %}
     environment:
-{{ deep_merge_to_yaml([@('services.php-base.environment'),@('services.cron.environment')], 2, 6) | raw }}
+{{ deep_merge_to_yaml(
+  [
+    @('services.php-base.environment'),
+    @('services.cron.environment'),
+    @('services.php-base.environment_secrets'),
+    @('services.cron.environment_secrets')
+  ], 2, 6) | raw }}
 {% include blocks ~ 'environment.yml.twig' %}
     networks:
       - private

--- a/src/_base/_twig/docker-compose.yml/service/mysql.yml.twig
+++ b/src/_base/_twig/docker-compose.yml/service/mysql.yml.twig
@@ -10,7 +10,11 @@
     command: {{ command|join(' ') }}
 {% endif %}
     environment:
-{{ to_nice_yaml(@('services.mysql.environment'), 2, 6) | raw }}
+{{ deep_merge_to_yaml(
+  [
+    @('services.mysql.environment'),
+    @('services.mysql.environment_secrets')
+  ], 2, 6) | raw }}
     networks:
       - private
     ports:

--- a/src/_base/_twig/docker-compose.yml/service/mysql.yml.twig
+++ b/src/_base/_twig/docker-compose.yml/service/mysql.yml.twig
@@ -9,12 +9,10 @@
 {% if command|length %}
     command: {{ command|join(' ') }}
 {% endif %}
-    environment:
-{{ deep_merge_to_yaml(
-  [
-    @('services.mysql.environment'),
-    @('services.mysql.environment_secrets')
-  ], 2, 6) | raw }}
+    environment: {{ to_nice_yaml(deep_merge([
+        @('services.mysql.environment'),
+        @('services.mysql.environment_secrets')
+      ]), 2, 6) | raw }}
     networks:
       - private
     ports:

--- a/src/_base/_twig/docker-compose.yml/service/php-fpm-exporter.yml.twig
+++ b/src/_base/_twig/docker-compose.yml/service/php-fpm-exporter.yml.twig
@@ -1,7 +1,9 @@
   php-fpm-exporter:
     image: hipages/php-fpm_exporter
-    environment: 
-{{ to_nice_yaml(@('services.php-fpm-exporter.environment'), 2, 6) | raw }}
+    environment: {{ to_nice_yaml(deep_merge([
+        @('services.php-fpm-exporter.environment'),
+        @('services.php-fpm-exporter.environment_secrets')
+      ]), 2, 6) | raw }}
     labels:
       - traefik.enable=false
     depends_on:

--- a/src/_base/_twig/docker-compose.yml/service/postgres.yml.twig
+++ b/src/_base/_twig/docker-compose.yml/service/postgres.yml.twig
@@ -2,12 +2,10 @@
     image: postgres:9.6
     labels:
       - traefik.enable=false
-    environment:
-{{ deep_merge_to_yaml(
-  [
-    @('services.postgres.environment'),
-    @('services.postgres.environment_secrets')
-  ], 2, 6) | raw }}
+    environment: {{ to_nice_yaml(deep_merge([
+        @('services.postgres.environment'),
+        @('services.postgres.environment_secrets')
+      ]), 2, 6) | raw }}
     networks:
       - private
     ports:

--- a/src/_base/_twig/docker-compose.yml/service/postgres.yml.twig
+++ b/src/_base/_twig/docker-compose.yml/service/postgres.yml.twig
@@ -3,7 +3,11 @@
     labels:
       - traefik.enable=false
     environment:
-{{ to_nice_yaml(@('services.postgres.environment'), 2, 6) | raw }}
+{{ deep_merge_to_yaml(
+  [
+    @('services.postgres.environment'),
+    @('services.postgres.environment_secrets')
+  ], 2, 6) | raw }}
     networks:
       - private
     ports:

--- a/src/_base/_twig/docker-compose.yml/service/rabbitmq.yml.twig
+++ b/src/_base/_twig/docker-compose.yml/service/rabbitmq.yml.twig
@@ -1,11 +1,9 @@
   rabbitmq:
     image: {{ @('rabbitmq.image') }}:{{ @('rabbitmq.tag') }}
-    environment:
-{{ deep_merge_to_yaml(
-  [
-    @('services.rabbitmq.environment'),
-    @('services.rabbitmq.environment_secrets')
-  ], 2, 6) | raw }}
+    environment: {{ to_nice_yaml(deep_merge([
+        @('services.rabbitmq.environment'),
+        @('services.rabbitmq.environment_secrets')
+      ]), 2, 6) | raw }}
     networks:
       - private
       - shared

--- a/src/_base/_twig/docker-compose.yml/service/rabbitmq.yml.twig
+++ b/src/_base/_twig/docker-compose.yml/service/rabbitmq.yml.twig
@@ -1,7 +1,11 @@
   rabbitmq:
     image: {{ @('rabbitmq.image') }}:{{ @('rabbitmq.tag') }}
     environment:
-{{ to_nice_yaml(@('services.rabbitmq.environment'), 2, 6) | raw }}
+{{ deep_merge_to_yaml(
+  [
+    @('services.rabbitmq.environment'),
+    @('services.rabbitmq.environment_secrets')
+  ], 2, 6) | raw }}
     networks:
       - private
       - shared

--- a/src/_base/_twig/docker-compose.yml/service/varnish.yml.twig
+++ b/src/_base/_twig/docker-compose.yml/service/varnish.yml.twig
@@ -8,10 +8,10 @@
       - traefik.frontend.rule=Host:{{ hostnames|join(',') }}
       - traefik.docker.network=my127ws
       - traefik.port=80
-{% if @('services.varnish.environment') %}
-    environment:
-{{ to_nice_yaml(@('services.varnish.environment'), 2, 6) | raw }}
-{% endif %}
+    environment: {{ to_nice_yaml(deep_merge([
+      @('services.varnish.environment'),
+      @('services.varnish.environment_secrets')
+      ]), 2, 6) | raw }}
     links:
       - nginx:nginx
     volumes:

--- a/src/_base/harness/attributes/docker-base.yml
+++ b/src/_base/harness/attributes/docker-base.yml
@@ -8,14 +8,12 @@ attributes:
         DB_PLATFORM: = @('database.platform')
         DB_HOST: = @('database.host')
         DB_USER: = @('database.user')
-        DB_PASS: = @('database.pass')
         DB_NAME: = @('database.name')
         ELASTICSEARCH_HOST: = @('elasticsearch.host')
         ELASTICSEARCH_PORT: = @('elasticsearch.port')
         RABBITMQ_API_PORT: = @('rabbitmq.api_port')
         RABBITMQ_EXTERNAL_HOST: = @('rabbitmq.external_host')
         RABBITMQ_HOST: = @('rabbitmq.host')
-        RABBITMQ_PASSWORD: = @('rabbitmq.password')
         RABBITMQ_PORT: = @('rabbitmq.port')
         RABBITMQ_USER: = @('rabbitmq.user')
         RABBITMQ_VHOST: = @('rabbitmq.vhosts.default')
@@ -25,6 +23,9 @@ attributes:
         REDIS_SESSION_PORT: = @('redis_session.port')
         PHP_IDE_CONFIG: "serverName=workspace"
         VARNISH_HOSTNAME_TEMPLATE: "varnish-%d.varnish-headless"
+      environment_secrets:
+        DB_PASS: = @('database.pass')
+        RABBITMQ_PASSWORD: = @('rabbitmq.password')
     nginx:
       ingress:
         annotations: {}
@@ -34,8 +35,9 @@ attributes:
       enabled: true
       environment:
         DB_ADMIN_USER: root
-        DB_ADMIN_PASS: = @('database.root_pass')
         HAS_VARNISH: "= ('varnish' in @('app.services') ? 'true' : 'false')"
+      environment_secrets:
+        DB_ADMIN_PASS: = @('database.root_pass')
     php-fpm:
       environment:
         AUTOSTART_PHP_FPM: "true"
@@ -45,21 +47,24 @@ attributes:
     mysql:
       environment:
         MYSQL_DATABASE: = @('database.name')
+        MYSQL_USER: = @('database.user')
+      environment_secrets:
         MYSQL_PASSWORD: = @('database.pass')
         MYSQL_ROOT_PASSWORD: = @('database.root_pass')
-        MYSQL_USER: = @('database.user')
     rabbitmq:
       environment:
         RABBITMQ_DEFAULT_USER: = @('rabbitmq.user')
-        RABBITMQ_DEFAULT_PASS: = @('rabbitmq.password')
         RABBITMQ_DEFAULT_VHOST: = @('rabbitmq.vhosts.default')
+      environment_secrets:
+        RABBITMQ_DEFAULT_PASS: = @('rabbitmq.password')
         RABBITMQ_ERLANG_COOKIE: = @('rabbitmq.erlang_cookie')
     postgres:
       environment:
         POSTGRES_DB: = @('database.name')
-        POSTGRES_PASSWORD: = @('database.pass')
         POSTGRES_USER: = @('database.user')
         PGDATA: /var/lib/postgresql/data/pgdata
+      environment_secrets:
+        POSTGRES_PASSWORD: = @('database.pass')
     cron:
       environment: []
     varnish:

--- a/src/_base/harness/attributes/docker-base.yml
+++ b/src/_base/harness/attributes/docker-base.yml
@@ -27,8 +27,6 @@ attributes:
         DB_PASS: = @('database.pass')
         RABBITMQ_PASSWORD: = @('rabbitmq.password')
     nginx:
-      ingress:
-        annotations: {}
       environment:
         FPM_HOST: php-fpm
     console:
@@ -90,6 +88,8 @@ attributes:
         nginx:
           environment:
             FPM_HOST: localhost
+          ingress:
+            annotations: {}
           metricsEnabled: false
           metricsEndpoints:
             - port: http

--- a/src/_base/harness/config/functions.yml
+++ b/src/_base/harness/config/functions.yml
@@ -1,17 +1,55 @@
-function('to_yaml', [text]): |
+function('to_yaml', [data]): |
   #!php
-  = preg_replace('/^/m', '  ', \Symfony\Component\Yaml\Yaml::dump($text, 100, 2));
+  $yaml = \Symfony\Component\Yaml\Yaml::dump($data, 100, 2));
+  if (is_array($data) && count($data) > 0) {
+    $yaml = "\n" . rtrim(preg_replace('/^/m', '  ', $yaml), "\n");
+  }
+  = $yaml;
 
-function('to_nice_yaml', [text, indentation, nesting]): |
+function('to_nice_yaml', [data, indentation, nesting]): |
   #!php
-  = preg_replace('/^/m', str_repeat(' ', $nesting ?: 2), \Symfony\Component\Yaml\Yaml::dump($text, 100, $indentation ?: 2));
+  $yaml = \Symfony\Component\Yaml\Yaml::dump($data, 100, $indentation ?: 2);
+  if (is_array($data) && count($data) > 0) {
+    $yaml = "\n" . rtrim(preg_replace('/^/m', str_repeat(' ', $nesting ?: 2), $yaml), "\n");
+  }
+  = $yaml;
 
 function('indent', [text, indentation]): |
   #!php
   = preg_replace('/^/m', str_repeat(' ', $indentation ?: 2), $text);
 
+function('deep_merge', [arrays]): |
+  #!php
+  // source https://api.drupal.org/api/drupal/includes%21bootstrap.inc/function/drupal_array_merge_deep_array/7.x
+  $deepMerge = function ($arrays) use (&$deepMerge) {
+    $result = array();
+    foreach ($arrays as $array) {
+        if ($array === null) { continue; }
+        foreach ($array as $key => $value) {
+            // Renumber integer keys as array_merge_recursive() does. Note that PHP
+            // automatically converts array keys that are integer strings (e.g., '1')
+            // to integers.
+            if (is_integer($key)) {
+                $result[] = $value;
+            }
+            elseif (isset($result[$key]) && is_array($result[$key]) && is_array($value)) {
+                $result[$key] = $deepMerge(array(
+                    $result[$key],
+                    $value,
+                ));
+            }
+            else {
+                $result[$key] = $value;
+            }
+        }
+    }
+    return $result;
+  };
+  = $deepMerge($arrays);
+
 function('deep_merge_to_yaml', [arrays, indentation, nesting]): |
   #!php
+  trigger_error('deep_merge_to_yaml is deprecated, please use separate deep_merge and to_nice_yaml functions', E_USER_DEPRECATED);
   // source https://api.drupal.org/api/drupal/includes%21bootstrap.inc/function/drupal_array_merge_deep_array/7.x
   $deepMerge = function ($arrays) use (&$deepMerge) {
     $result = array();

--- a/src/_base/harness/config/functions.yml
+++ b/src/_base/harness/config/functions.yml
@@ -40,6 +40,24 @@ function('deep_merge_to_yaml', [arrays, indentation, nesting]): |
   $text = $deepMerge($arrays);
   = preg_replace('/^/m', str_repeat(' ', $nesting ?: 2), \Symfony\Component\Yaml\Yaml::dump($text, 100, $indentation ?: 2));
 
+function('filter_local_services', [services]): |
+  #!php
+  $filteredServices = [];
+  foreach ($services as $serviceName => $service) {
+    $filteredService = [];
+    foreach ($service as $key => $value) {
+      switch ($key) {
+        case 'environment':
+        case 'enabled':
+          $filteredService[$key] = $value;
+      }
+    }
+    if (count($filteredService) > 0) {
+      $filteredServices[$serviceName] = $filteredService;
+    }
+  }
+  = $filteredServices;
+
 function('get_docker_external_networks'): |
   #!php
   $configRaw = shell_exec('docker-compose config');

--- a/src/_base/harness/config/secrets.yml
+++ b/src/_base/harness/config/secrets.yml
@@ -6,16 +6,25 @@ command('secret image-pull-config'):
     SEALED_SECRETS_CONTROLLER_NAMESPACE: = @('helm.sealed_secrets.controller_namespace')
   exec: |
     #!bash
-    echo 'Paste in the docker configuration, defaults to workspace docker push credentials if empty' >&2
-    read DOCKER_CONFIG
+    if [ "$SEALED_SECRETS" == 'yes' ] && ! command -v kubeseal >/dev/null; then
+      echo 'kubeseal is needed in order to use this command' >&2
+      exit 1
+    fi
+
+    if [ -t 1 ] ; then
+      # Use an editor with a temp file to allow longer terminal input
+      TMPFILE="$(mktemp -t tmp.XXXXXXXXX)"
+      "${EDITOR:-vi}" "${TMPFILE}"
+      DOCKER_CONFIG="$(cat "${TMPFILE}")"
+      rm -f "${TMPFILE}"
+    else
+      # read from stdin until EOF
+      DOCKER_CONFIG="$(cat)"
+    fi
+
     DOCKER_CONFIG="${DOCKER_CONFIG:-${DEFAULT_CONFIG}}"
 
     if [ "$SEALED_SECRETS" == 'yes' ]; then
-      if ! command -v kubeseal; then
-        echo 'kubeseal is needed in order to use this command' >&2
-        exit 1
-      fi
-
       echo 'Encrypting as a sealed-secret value with certificate from current kubectl context' >&2
       KUBESEAL_OPTS=(
         --name "image-pull-config"

--- a/src/_base/harness/config/secrets.yml
+++ b/src/_base/harness/config/secrets.yml
@@ -47,3 +47,53 @@ command('secret image-pull-config'):
       echo "If storing within workspace attributes, use `ws secret encrypt` first" >&2
       echo "${DOCKER_CONFIG}" | base64
     fi
+
+command('sealed-secret encrypt (string|blob) <secret-name>'):
+  env:
+    INPUT_TYPE: = input.command(3)
+    SEALED_SECRETS_CONTROLLER_NAME: = @('helm.sealed_secrets.controller_name')
+    SEALED_SECRETS_CONTROLLER_NAMESPACE: = @('helm.sealed_secrets.controller_namespace')
+    SECRET_NAME: = input.argument('secret-name')
+  exec: |
+    #!bash
+    if ! command -v kubeseal >/dev/null; then
+      echo 'kubeseal is needed in order to use this command' >&2
+      exit 1
+    fi
+
+    echo "Enter the secret ${INPUT_TYPE} to encrypt" >&2
+    case "${INPUT_TYPE}" in
+      string)
+        read DATA # read a single line
+        ;;
+      blob)
+        if [ -t 1 ] ; then
+          # Use an editor with a temp file to allow longer terminal input
+          TMPFILE="$(mktemp -t tmp.XXXXXXXXX)"
+          "${EDITOR:-vi}" "${TMPFILE}"
+          DATA="$(cat "${TMPFILE}")"
+          rm -f "${TMPFILE}"
+        else
+          # read from stdin until EOF
+          DATA="$(cat)"
+        fi
+        ;;
+    esac
+
+    echo 'Encrypting as a sealed-secret value with certificate from current kubectl context' >&2
+    KUBESEAL_OPTS=(
+      --name "${SECRET_NAME}"
+      --scope cluster-wide 
+    )
+    if [ -n "${SEALED_SECRETS_CONTROLLER_NAME:-}" ]; then
+      KUBESEAL_OPTS+=(
+        --controller-name "${SEALED_SECRETS_CONTROLLER_NAME}"
+      )
+    fi
+    if [ -n "${SEALED_SECRETS_CONTROLLER_NAMESPACE:-}" ]; then
+      KUBESEAL_OPTS+=(
+        --controller-namespace "${SEALED_SECRETS_CONTROLLER_NAMESPACE}"
+      )
+    fi
+
+    echo "${DATA}" | kubeseal --raw "${KUBESEAL_OPTS[@]}"

--- a/src/_base/helm/app/templates/_base_helper.tpl
+++ b/src/_base/helm/app/templates/_base_helper.tpl
@@ -18,3 +18,23 @@
 {{- template "application.volumeMounts.all" . -}}
 {{- end -}}
 {{- end }}
+
+{{- define "service.environment.secret" }}
+{{ if .service.environment_secrets }}
+{{ if $.Values.feature.sealed_secrets }}
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+{{ else }}
+apiVersion: v1
+kind: Secret
+{{ end }}
+metadata:
+  name: {{ .Values.resourcePrefix }}{{ .service_name }}
+{{ if $.Values.feature.sealed_secrets }}
+  encryptedData:
+{{ else }}
+  data:
+{{ index .service.environment_secrets | toYaml | nindent 2 -}}
+{{ end }}
+{{ end }}
+{{- end }}

--- a/src/_base/helm/app/templates/_base_helper.tpl
+++ b/src/_base/helm/app/templates/_base_helper.tpl
@@ -31,6 +31,8 @@ kind: Secret
 metadata:
   name: {{ .Values.resourcePrefix }}{{ .service_name }}
 {{ if $.Values.feature.sealed_secrets }}
+  annotations:
+    sealedsecrets.bitnami.com/cluster-wide: "true"
 spec:
   encryptedData:
 {{ index .service.environment_secrets | toYaml | nindent 4 -}}

--- a/src/_base/helm/app/templates/_base_helper.tpl
+++ b/src/_base/helm/app/templates/_base_helper.tpl
@@ -21,7 +21,7 @@
 
 {{- define "service.environment.secret" }}
 {{ if .service.environment_secrets }}
-{{ if $.Values.feature.sealed_secrets }}
+{{ if .Values.feature.sealed_secrets }}
 apiVersion: bitnami.com/v1alpha1
 kind: SealedSecret
 {{ else }}
@@ -30,7 +30,7 @@ kind: Secret
 {{ end }}
 metadata:
   name: {{ .Values.resourcePrefix }}{{ .service_name }}
-{{ if $.Values.feature.sealed_secrets }}
+{{ if .Values.feature.sealed_secrets }}
   annotations:
     sealedsecrets.bitnami.com/cluster-wide: "true"
 spec:

--- a/src/_base/helm/app/templates/_base_helper.tpl
+++ b/src/_base/helm/app/templates/_base_helper.tpl
@@ -35,7 +35,7 @@ spec:
   encryptedData:
 {{ index .service.environment_secrets | toYaml | nindent 4 -}}
 {{ else }}
-data:
+stringData:
 {{ index .service.environment_secrets | toYaml | nindent 2 -}}
 {{ end }}
 {{ end }}

--- a/src/_base/helm/app/templates/_base_helper.tpl
+++ b/src/_base/helm/app/templates/_base_helper.tpl
@@ -31,9 +31,11 @@ kind: Secret
 metadata:
   name: {{ .Values.resourcePrefix }}{{ .service_name }}
 {{ if $.Values.feature.sealed_secrets }}
+spec:
   encryptedData:
+{{ index .service.environment_secrets | toYaml | nindent 4 -}}
 {{ else }}
-  data:
+data:
 {{ index .service.environment_secrets | toYaml | nindent 2 -}}
 {{ end }}
 {{ end }}

--- a/src/_base/helm/app/templates/application/app-init.yaml
+++ b/src/_base/helm/app/templates/application/app-init.yaml
@@ -1,3 +1,7 @@
+{{- $service := merge
+  (dict "environment" .Values.environment)
+  (index .Values.docker.services "console")
+  (index .Values.docker.services "php-base") -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -15,7 +19,7 @@ spec:
       restartPolicy: Never
       containers:
       - env:
-        {{- range $key, $value := index .Values.docker.services "php-base" "environment" }}
+        {{- range $key, $value := $service.environment }}
         {{- $tp := typeOf $value }}
         - name: {{ $key | quote }}
         {{- if eq $tp "string" }}
@@ -24,18 +28,10 @@ spec:
           value: {{ $value | quote }}
         {{- end }}
         {{- end }}
-        {{- range $key, $value := .Values.docker.services.console.environment }}
-        {{- $tp := typeOf $value }}
-        - name: {{ $key | quote }}
-        {{- if eq $tp "string" }}
-          value: {{ tpl $value $ | quote }}
-        {{- else }}
-          value: {{ $value | quote }}
-        {{- end }}
-        {{- end }}
-        {{- range $key, $value := .Values.environment }}
-        - name: {{ $key | quote }}
-          value: {{ $value | quote }}
+        {{- if $service.environment_secrets }}
+        envFrom:
+          - secretRef:
+              name: {{ .Values.resourcePrefix }}console
         {{- end }}
         image: {{ .Values.docker.image.console }}
         imagePullPolicy: Always

--- a/src/_base/helm/app/templates/application/app-init.yaml
+++ b/src/_base/helm/app/templates/application/app-init.yaml
@@ -1,4 +1,4 @@
-{{- $service := merge (dict "environment" .Values.environment) (index .Values.docker.services "console") (index .Values.docker.services "php-base") -}}
+{{- $service := mergeOverwrite (dict) (index .Values.docker.services "php-base") (index .Values.docker.services "console") (dict "environment" .Values.environment) -}}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/src/_base/helm/app/templates/application/app-init.yaml
+++ b/src/_base/helm/app/templates/application/app-init.yaml
@@ -1,7 +1,4 @@
-{{- $service := merge
-  (dict "environment" .Values.environment)
-  (index .Values.docker.services "console")
-  (index .Values.docker.services "php-base") -}}
+{{- $service := merge (dict "environment" .Values.environment) (index .Values.docker.services "console") (index .Values.docker.services "php-base") -}}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/src/_base/helm/app/templates/application/app-migrate.yaml
+++ b/src/_base/helm/app/templates/application/app-migrate.yaml
@@ -1,4 +1,4 @@
-{{- $service := merge (dict "environment" .Values.environment) (index .Values.docker.services "console") (index .Values.docker.services "php-base") -}}
+{{- $service := mergeOverwrite (dict) (index .Values.docker.services "php-base") (index .Values.docker.services "console") (dict "environment" .Values.environment) -}}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/src/_base/helm/app/templates/application/app-migrate.yaml
+++ b/src/_base/helm/app/templates/application/app-migrate.yaml
@@ -1,3 +1,7 @@
+{{- $service := merge
+  (dict "environment" .Values.environment)
+  (index .Values.docker.services "console")
+  (index .Values.docker.services "php-base") -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -13,7 +17,7 @@ spec:
     spec:
       containers:
       - env:
-        {{- range $key, $value := index .Values.docker.services "php-base" "environment" }}
+        {{- range $key, $value := $service.environment }}
         {{- $tp := typeOf $value }}
         - name: {{ $key | quote }}
         {{- if eq $tp "string" }}
@@ -22,18 +26,10 @@ spec:
           value: {{ $value | quote }}
         {{- end }}
         {{- end }}
-        {{- range $key, $value := .Values.docker.services.console.environment }}
-        {{- $tp := typeOf $value }}
-        - name: {{ $key | quote }}
-        {{- if eq $tp "string" }}
-          value: {{ tpl $value $ | quote }}
-        {{- else }}
-          value: {{ $value | quote }}
-        {{- end }}
-        {{- end }}
-        {{- range $key, $value := .Values.environment }}
-        - name: {{ $key | quote }}
-          value: {{ $value | quote }}
+        {{- if $service.environment_secrets }}
+        envFrom:
+          - secretRef:
+              name: {{ .Values.resourcePrefix }}console
         {{- end }}
         image: {{ .Values.docker.image.console }}
         imagePullPolicy: Always

--- a/src/_base/helm/app/templates/application/app-migrate.yaml
+++ b/src/_base/helm/app/templates/application/app-migrate.yaml
@@ -1,7 +1,4 @@
-{{- $service := merge
-  (dict "environment" .Values.environment)
-  (index .Values.docker.services "console")
-  (index .Values.docker.services "php-base") -}}
+{{- $service := merge (dict "environment" .Values.environment) (index .Values.docker.services "console") (index .Values.docker.services "php-base") -}}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/src/_base/helm/app/templates/application/console/deployment.yaml
+++ b/src/_base/helm/app/templates/application/console/deployment.yaml
@@ -1,5 +1,5 @@
-{{ if .Values.docker.services.console.enabled }}
-{{- $service := merge (dict "environment" .Values.environment) (index .Values.docker.services "console") (index .Values.docker.services "php-base") -}}
+{{- if .Values.docker.services.console.enabled -}}
+{{- $service := mergeOverwrite (dict) (index .Values.docker.services "php-base") (index .Values.docker.services "console") (dict "environment" .Values.environment) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/src/_base/helm/app/templates/application/console/deployment.yaml
+++ b/src/_base/helm/app/templates/application/console/deployment.yaml
@@ -1,8 +1,5 @@
 {{ if .Values.docker.services.console.enabled }}
-{{- $service := merge
-  (dict "environment" .Values.environment)
-  (index .Values.docker.services "console")
-  (index .Values.docker.services "php-base") -}}
+{{- $service := merge (dict "environment" .Values.environment) (index .Values.docker.services "console") (index .Values.docker.services "php-base") -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/src/_base/helm/app/templates/application/console/deployment.yaml
+++ b/src/_base/helm/app/templates/application/console/deployment.yaml
@@ -1,4 +1,8 @@
 {{ if .Values.docker.services.console.enabled }}
+{{- $service := merge
+  (dict "environment" .Values.environment)
+  (index .Values.docker.services "console")
+  (index .Values.docker.services "php-base") -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -20,7 +24,7 @@ spec:
     spec:
       containers:
       - env:
-        {{- range $key, $value := index .Values.docker.services "php-base" "environment" }}
+        {{- range $key, $value := $service.environment }}
         {{- $tp := typeOf $value }}
         - name: {{ $key | quote }}
         {{- if eq $tp "string" }}
@@ -29,18 +33,10 @@ spec:
           value: {{ $value | quote }}
         {{- end }}
         {{- end }}
-        {{- range $key, $value := .Values.docker.services.console.environment }}
-        {{- $tp := typeOf $value }}
-        - name: {{ $key | quote }}
-        {{- if eq $tp "string" }}
-          value: {{ tpl $value $ | quote }}
-        {{- else}}
-          value: {{ $value | quote }}
-        {{- end }}
-        {{- end }}
-        {{- range $key, $value := .Values.environment }}
-        - name: {{ $key | quote }}
-          value: {{ $value | quote }}
+        {{- if $service.environment_secrets }}
+        envFrom:
+          - secretRef:
+              name: {{ .Values.resourcePrefix }}console
         {{- end }}
         image: {{ .Values.docker.image.console }}
         imagePullPolicy: Always

--- a/src/_base/helm/app/templates/application/console/secret.yaml
+++ b/src/_base/helm/app/templates/application/console/secret.yaml
@@ -1,2 +1,2 @@
 {{- $service := merge (index .Values.docker.services "console") (index .Values.docker.services "php-base") -}}
-{{ template "service.environment.secret" (dict "service_name" "console" "service" $service) }}
+{{ template "service.environment.secret" (dict "service_name" "console" "service" $service "Values" .Values) }}

--- a/src/_base/helm/app/templates/application/console/secret.yaml
+++ b/src/_base/helm/app/templates/application/console/secret.yaml
@@ -1,0 +1,7 @@
+{{ template "service.environment.secret" (dict
+    "service_name" "console"
+    "service" (merge 
+      (index .Values.docker.services "console")
+      (index .Values.docker.services "php-base")
+    )
+  ) }}

--- a/src/_base/helm/app/templates/application/console/secret.yaml
+++ b/src/_base/helm/app/templates/application/console/secret.yaml
@@ -1,7 +1,2 @@
-{{ template "service.environment.secret" (dict
-    "service_name" "console"
-    "service" (merge 
-      (index .Values.docker.services "console")
-      (index .Values.docker.services "php-base")
-    )
-  ) }}
+{{- $service := merge (index .Values.docker.services "console") (index .Values.docker.services "php-base") -}}
+{{ template "service.environment.secret" (dict "service_name" "console" "service" $service) }}

--- a/src/_base/helm/app/templates/application/console/secret.yaml
+++ b/src/_base/helm/app/templates/application/console/secret.yaml
@@ -1,2 +1,2 @@
-{{- $service := merge (index .Values.docker.services "console") (index .Values.docker.services "php-base") -}}
+{{- $service := mergeOverwrite (dict) (index .Values.docker.services "php-base") (index .Values.docker.services "console") -}}
 {{ template "service.environment.secret" (dict "service_name" "console" "service" $service "Values" .Values) }}

--- a/src/_base/helm/app/templates/application/cron/deployment.yaml
+++ b/src/_base/helm/app/templates/application/cron/deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.service.cron -}}
-{{- $service := mergeOverwrite (dict) (index .Values.docker.services "php-base") (index .Values.docker.services "console") (dict "environment" .Values.environment) -}}
+{{- $service := mergeOverwrite (dict) (index .Values.docker.services "php-base") (index .Values.docker.services "cron") (dict "environment" .Values.environment) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/src/_base/helm/app/templates/application/cron/deployment.yaml
+++ b/src/_base/helm/app/templates/application/cron/deployment.yaml
@@ -1,4 +1,8 @@
 {{ if .Values.service.cron }}
+{{- $service := merge
+  (dict "environment" .Values.environment)
+  (index .Values.docker.services "console")
+  (index .Values.docker.services "php-base") -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -37,7 +41,7 @@ spec:
       containers:
       - name: cron
         env:
-        {{- range $key, $value := index .Values.docker.services "php-base" "environment" }}
+        {{- range $key, $value := $service.environment }}
         {{- $tp := typeOf $value }}
         - name: {{ $key | quote }}
         {{- if eq $tp "string" }}
@@ -46,18 +50,10 @@ spec:
           value: {{ $value | quote }}
         {{- end }}
         {{- end }}
-        {{- range $key, $value := index .Values.docker.services "cron" "environment" }}
-        {{- $tp := typeOf $value }}
-        - name: {{ $key | quote }}
-        {{- if eq $tp "string" }}
-          value: {{ tpl $value $ | quote }}
-        {{- else}}
-          value: {{ $value | quote }}
-        {{- end }}
-        {{- end }}
-        {{- range $key, $value := .Values.environment }}
-        - name: {{ $key | quote }}
-          value: {{ $value | quote }}
+        {{- if $service.environment_secrets }}
+        envFrom:
+          - secretRef:
+              name: {{ .Values.resourcePrefix }}cron
         {{- end }}
         image: {{ .Values.docker.image.cron }}
         imagePullPolicy: Always

--- a/src/_base/helm/app/templates/application/cron/deployment.yaml
+++ b/src/_base/helm/app/templates/application/cron/deployment.yaml
@@ -1,8 +1,5 @@
 {{ if .Values.service.cron }}
-{{- $service := merge
-  (dict "environment" .Values.environment)
-  (index .Values.docker.services "console")
-  (index .Values.docker.services "php-base") -}}
+{{- $service := merge (dict "environment" .Values.environment) (index .Values.docker.services "console") (index .Values.docker.services "php-base") -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/src/_base/helm/app/templates/application/cron/deployment.yaml
+++ b/src/_base/helm/app/templates/application/cron/deployment.yaml
@@ -1,5 +1,5 @@
-{{ if .Values.service.cron }}
-{{- $service := merge (dict "environment" .Values.environment) (index .Values.docker.services "console") (index .Values.docker.services "php-base") -}}
+{{- if .Values.service.cron -}}
+{{- $service := mergeOverwrite (dict) (index .Values.docker.services "php-base") (index .Values.docker.services "console") (dict "environment" .Values.environment) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/src/_base/helm/app/templates/application/cron/secret.yaml
+++ b/src/_base/helm/app/templates/application/cron/secret.yaml
@@ -1,2 +1,2 @@
-{{- $service := merge (index .Values.docker.services "cron") (index .Values.docker.services "php-base") -}}
+{{- $service := mergeOverwrite (dict) (index .Values.docker.services "php-base") (index .Values.docker.services "cron") -}}
 {{ template "service.environment.secret" (dict "service_name" "cron" "service" $service "Values" .Values) }}

--- a/src/_base/helm/app/templates/application/cron/secret.yaml
+++ b/src/_base/helm/app/templates/application/cron/secret.yaml
@@ -1,2 +1,2 @@
 {{- $service := merge (index .Values.docker.services "cron") (index .Values.docker.services "php-base") -}}
-{{ template "service.environment.secret" (dict "service_name" "cron" "service" $service) }}
+{{ template "service.environment.secret" (dict "service_name" "cron" "service" $service "Values" .Values) }}

--- a/src/_base/helm/app/templates/application/cron/secret.yaml
+++ b/src/_base/helm/app/templates/application/cron/secret.yaml
@@ -1,0 +1,7 @@
+{{ template "service.environment.secret" (dict
+    "service_name" "cron"
+    "service" (merge 
+      (index .Values.docker.services "cron")
+      (index .Values.docker.services "php-base")
+    )
+  ) }}

--- a/src/_base/helm/app/templates/application/cron/secret.yaml
+++ b/src/_base/helm/app/templates/application/cron/secret.yaml
@@ -1,7 +1,2 @@
-{{ template "service.environment.secret" (dict
-    "service_name" "cron"
-    "service" (merge 
-      (index .Values.docker.services "cron")
-      (index .Values.docker.services "php-base")
-    )
-  ) }}
+{{- $service := merge (index .Values.docker.services "cron") (index .Values.docker.services "php-base") -}}
+{{ template "service.environment.secret" (dict "service_name" "cron" "service" $service) }}

--- a/src/_base/helm/app/templates/application/webapp/deployment.yaml
+++ b/src/_base/helm/app/templates/application/webapp/deployment.yaml
@@ -1,4 +1,4 @@
-{{- $service_php_fpm := merge (dict "environment" .Values.environment) (index .Values.docker.services "console") (index .Values.docker.services "php-fpm") -}}
+{{- $service_php_fpm := merge (dict "environment" .Values.environment) (index .Values.docker.services "php-fpm") (index .Values.docker.services "php-base") -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/src/_base/helm/app/templates/application/webapp/deployment.yaml
+++ b/src/_base/helm/app/templates/application/webapp/deployment.yaml
@@ -1,4 +1,4 @@
-{{- $service_php_fpm := merge (dict "environment" .Values.environment) (index .Values.docker.services "php-fpm") (index .Values.docker.services "php-base") -}}
+{{- $service_php_fpm := mergeOverwrite (dict) (index .Values.docker.services "php-base") (index .Values.docker.services "php-fpm") (dict "environment" .Values.environment) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/src/_base/helm/app/templates/application/webapp/deployment.yaml
+++ b/src/_base/helm/app/templates/application/webapp/deployment.yaml
@@ -1,3 +1,7 @@
+{{- $service_php_fpm := merge
+  (dict "environment" .Values.environment)
+  (index .Values.docker.services "console")
+  (index .Values.docker.services "php-fpm")  -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -45,6 +49,11 @@ spec:
           value: {{ $value | quote }}
         {{- end }}
         {{- end }}
+        {{- if .Values.docker.services.nginx.environment_secrets }}
+        envFrom:
+          - secretRef:
+              name: {{ .Values.resourcePrefix }}nginx
+        {{- end }}
         image: {{ .Values.docker.image.nginx }}
         imagePullPolicy: Always
         ports:
@@ -68,7 +77,7 @@ spec:
 
       - name: php-fpm
         env:
-        {{- range $key, $value := index .Values.docker.services "php-base" "environment" }}
+        {{- range $key, $value := $service_php_fpm.environment }}
         {{- $tp := typeOf $value }}
         - name: {{ $key | quote }}
         {{- if eq $tp "string" }}
@@ -77,18 +86,10 @@ spec:
           value: {{ $value | quote }}
         {{- end }}
         {{- end }}
-        {{- range $key, $value := index .Values.docker.services "php-fpm" "environment" }}
-        {{- $tp := typeOf $value }}
-        - name: {{ $key | quote }}
-        {{- if eq $tp "string" }}
-          value: {{ tpl $value $ | quote }}
-        {{- else}}
-          value: {{ $value | quote }}
-        {{- end }}
-        {{- end }}
-        {{- range $key, $value := .Values.environment }}
-        - name: {{ $key | quote }}
-          value: {{ $value | quote }}
+        {{- if $service_php_fpm.environment_secrets }}
+        envFrom:
+          - secretRef:
+              name: {{ .Values.resourcePrefix }}php-fpm
         {{- end }}
         image: {{ .Values.docker.image.fpm }}
         imagePullPolicy: Always

--- a/src/_base/helm/app/templates/application/webapp/deployment.yaml
+++ b/src/_base/helm/app/templates/application/webapp/deployment.yaml
@@ -1,7 +1,4 @@
-{{- $service_php_fpm := merge
-  (dict "environment" .Values.environment)
-  (index .Values.docker.services "console")
-  (index .Values.docker.services "php-fpm")  -}}
+{{- $service_php_fpm := merge (dict "environment" .Values.environment) (index .Values.docker.services "console") (index .Values.docker.services "php-fpm") -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/src/_base/helm/app/templates/application/webapp/secret-nginx.yaml
+++ b/src/_base/helm/app/templates/application/webapp/secret-nginx.yaml
@@ -1,0 +1,1 @@
+{{ template "service.environment.secret" (dict "service_name" "nginx" "service" .Values.docker.services.nginx) }}

--- a/src/_base/helm/app/templates/application/webapp/secret-nginx.yaml
+++ b/src/_base/helm/app/templates/application/webapp/secret-nginx.yaml
@@ -1,1 +1,1 @@
-{{ template "service.environment.secret" (dict "service_name" "nginx" "service" .Values.docker.services.nginx) }}
+{{ template "service.environment.secret" (dict "service_name" "nginx" "service" .Values.docker.services.nginx "Values" .Values) }}

--- a/src/_base/helm/app/templates/application/webapp/secret-php-fpm.yaml
+++ b/src/_base/helm/app/templates/application/webapp/secret-php-fpm.yaml
@@ -1,0 +1,7 @@
+{{ template "service.environment.secret" (dict
+    "service_name" "php-fpm"
+    "service" (merge 
+      (index .Values.docker.services "php-fpm")
+      (index .Values.docker.services "php-base")
+    )
+  ) }}

--- a/src/_base/helm/app/templates/application/webapp/secret-php-fpm.yaml
+++ b/src/_base/helm/app/templates/application/webapp/secret-php-fpm.yaml
@@ -1,2 +1,2 @@
-{{- $service := merge (index .Values.docker.services "php-fpm") (index .Values.docker.services "php-base") -}}
+{{- $service := mergeOverwrite (dict) (index .Values.docker.services "php-base") (index .Values.docker.services "php-fpm") -}}
 {{ template "service.environment.secret" (dict "service_name" "php-fpm" "service" $service "Values" .Values) }}

--- a/src/_base/helm/app/templates/application/webapp/secret-php-fpm.yaml
+++ b/src/_base/helm/app/templates/application/webapp/secret-php-fpm.yaml
@@ -1,7 +1,2 @@
-{{ template "service.environment.secret" (dict
-    "service_name" "php-fpm"
-    "service" (merge 
-      (index .Values.docker.services "php-fpm")
-      (index .Values.docker.services "php-base")
-    )
-  ) }}
+{{- $service := merge (index .Values.docker.services "php-fpm") (index .Values.docker.services "php-base") -}}
+{{ template "service.environment.secret" (dict "service_name" "php-fpm" "service" $service) }}

--- a/src/_base/helm/app/templates/application/webapp/secret-php-fpm.yaml
+++ b/src/_base/helm/app/templates/application/webapp/secret-php-fpm.yaml
@@ -1,2 +1,2 @@
 {{- $service := merge (index .Values.docker.services "php-fpm") (index .Values.docker.services "php-base") -}}
-{{ template "service.environment.secret" (dict "service_name" "php-fpm" "service" $service) }}
+{{ template "service.environment.secret" (dict "service_name" "php-fpm" "service" $service "Values" .Values) }}

--- a/src/_base/helm/app/templates/service/mysql/deployment.yaml
+++ b/src/_base/helm/app/templates/service/mysql/deployment.yaml
@@ -21,6 +21,11 @@ spec:
         - name: {{ $key | quote }}
           value: {{ $value | quote }}
         {{- end }}
+        {{- if .Values.docker.services.mysql.environment_secrets }}
+        envFrom:
+          - secretRef:
+              name: {{ .Values.resourcePrefix }}mysql
+        {{- end }}
         image: {{ .Values.docker.image.mysql }}
         imagePullPolicy: Always
         name: mysql

--- a/src/_base/helm/app/templates/service/mysql/secret.yaml
+++ b/src/_base/helm/app/templates/service/mysql/secret.yaml
@@ -1,4 +1,1 @@
-{{ template "service.environment.secret" (dict
-    "service_name" "mysql"
-    "service" .Values.docker.services.mysql
-  ) }}
+{{ template "service.environment.secret" (dict "service_name" "mysql" "service" .Values.docker.services.mysql) }}

--- a/src/_base/helm/app/templates/service/mysql/secret.yaml
+++ b/src/_base/helm/app/templates/service/mysql/secret.yaml
@@ -1,0 +1,4 @@
+{{ template "service.environment.secret" (dict
+    "service_name" "mysql"
+    "service" .Values.docker.services.mysql
+  ) }}

--- a/src/_base/helm/app/templates/service/mysql/secret.yaml
+++ b/src/_base/helm/app/templates/service/mysql/secret.yaml
@@ -1,1 +1,1 @@
-{{ template "service.environment.secret" (dict "service_name" "mysql" "service" .Values.docker.services.mysql) }}
+{{ template "service.environment.secret" (dict "service_name" "mysql" "service" .Values.docker.services.mysql "Values" .Values) }}

--- a/src/_base/helm/app/templates/service/postgres/deployment.yaml
+++ b/src/_base/helm/app/templates/service/postgres/deployment.yaml
@@ -21,6 +21,11 @@ spec:
         - name: {{ $key | quote }}
           value: {{ $value | quote }}
         {{- end }}
+        {{- if .Values.docker.services.postgres.environment_secrets }}
+        envFrom:
+          - secretRef:
+              name: {{ .Values.resourcePrefix }}postgres
+        {{- end }}
         image: postgres:9.6
         imagePullPolicy: Always
         name: postgres

--- a/src/_base/helm/app/templates/service/postgres/secret.yaml
+++ b/src/_base/helm/app/templates/service/postgres/secret.yaml
@@ -1,1 +1,1 @@
-{{ template "service.environment.secret" (dict "service_name" "postgres" "service" .Values.docker.services.postgres) }}
+{{ template "service.environment.secret" (dict "service_name" "postgres" "service" .Values.docker.services.postgres "Values" .Values) }}

--- a/src/_base/helm/app/templates/service/postgres/secret.yaml
+++ b/src/_base/helm/app/templates/service/postgres/secret.yaml
@@ -1,4 +1,1 @@
-{{ template "service.environment.secret" (dict
-    "service_name" "postgres"
-    "service" .Values.docker.services.postgres
-  ) }}
+{{ template "service.environment.secret" (dict "service_name" "postgres" "service" .Values.docker.services.postgres) }}

--- a/src/_base/helm/app/templates/service/postgres/secret.yaml
+++ b/src/_base/helm/app/templates/service/postgres/secret.yaml
@@ -1,0 +1,4 @@
+{{ template "service.environment.secret" (dict
+    "service_name" "postgres"
+    "service" .Values.docker.services.postgres
+  ) }}

--- a/src/_base/helm/app/templates/service/rabbitmq/deployment.yaml
+++ b/src/_base/helm/app/templates/service/rabbitmq/deployment.yaml
@@ -23,6 +23,11 @@ spec:
         - name: {{ $key | quote }}
           value: {{ $value | quote }}
         {{- end }}
+        {{- if .Values.docker.services.rabbitmq.environment_secrets }}
+        envFrom:
+          - secretRef:
+              name: {{ .Values.resourcePrefix }}rabbitmq
+        {{- end }}
         image: {{ .Values.docker.image.rabbitmq }}
         imagePullPolicy: Always
         name: rabbitmq

--- a/src/_base/helm/app/templates/service/rabbitmq/secret.yaml
+++ b/src/_base/helm/app/templates/service/rabbitmq/secret.yaml
@@ -1,0 +1,4 @@
+{{ template "service.environment.secret" (dict
+    "service_name" "rabbitmq"
+    "service" .Values.docker.services.rabbitmq 
+  ) }}

--- a/src/_base/helm/app/templates/service/rabbitmq/secret.yaml
+++ b/src/_base/helm/app/templates/service/rabbitmq/secret.yaml
@@ -1,1 +1,1 @@
-{{ template "service.environment.secret" (dict "service_name" "rabbitmq" "service" .Values.docker.services.rabbitmq) }}
+{{ template "service.environment.secret" (dict "service_name" "rabbitmq" "service" .Values.docker.services.rabbitmq "Values" .Values) }}

--- a/src/_base/helm/app/templates/service/rabbitmq/secret.yaml
+++ b/src/_base/helm/app/templates/service/rabbitmq/secret.yaml
@@ -1,4 +1,1 @@
-{{ template "service.environment.secret" (dict
-    "service_name" "rabbitmq"
-    "service" .Values.docker.services.rabbitmq 
-  ) }}
+{{ template "service.environment.secret" (dict "service_name" "rabbitmq" "service" .Values.docker.services.rabbitmq) }}

--- a/src/_base/helm/app/values-preview.yaml.twig
+++ b/src/_base/helm/app/values-preview.yaml.twig
@@ -1,14 +1,11 @@
 {% if @('pipeline.preview.services') %}
 docker:
-  services:
-{{ to_nice_yaml(@('pipeline.preview.services'), 2, 4) | raw }}  
+  services: {{ to_nice_yaml(@('pipeline.preview.services'), 2, 4) | raw }}  
 {% endif %}
 {% if @('pipeline.preview.persistence') %}
-persistence:
-{{ to_nice_yaml(@('pipeline.preview.persistence'), 2, 2) | raw }}
+persistence: {{ to_nice_yaml(@('pipeline.preview.persistence'), 2, 2) | raw }}
 {% endif %}
 
 {% if @('pipeline.preview.resources') %}
-resources:
-{{ to_nice_yaml(@('pipeline.preview.resources'), 2, 2) | raw }}
+resources: {{ to_nice_yaml(@('pipeline.preview.resources'), 2, 2) | raw }}
 {% endif %}

--- a/src/_base/helm/app/values-production.yaml.twig
+++ b/src/_base/helm/app/values-production.yaml.twig
@@ -12,15 +12,12 @@ service:
 
 {% if @('pipeline.production.services') %}
 docker:
-  services:
-{{ to_nice_yaml(@('pipeline.production.services'), 2, 4) | raw }}  
+  services: {{ to_nice_yaml(@('pipeline.production.services'), 2, 4) | raw }}  
 {% endif %}
 {% if @('pipeline.production.persistence') %}
-persistence:
-{{ to_nice_yaml(@('pipeline.production.persistence'), 2, 2) | raw }}
+persistence: {{ to_nice_yaml(@('pipeline.production.persistence'), 2, 2) | raw }}
 {% endif %}
 
  {% if @('pipeline.production.resources') %}
-resources:
-{{ to_nice_yaml(@('pipeline.production.resources'), 2, 2) | raw }}
+resources: {{ to_nice_yaml(@('pipeline.production.resources'), 2, 2) | raw }}
 {% endif %}

--- a/src/_base/helm/app/values.yaml.twig
+++ b/src/_base/helm/app/values.yaml.twig
@@ -3,8 +3,7 @@
 environment:
 {% include blocks ~ 'environment.yml.twig' %}
 
-feature:
-{{ to_nice_yaml(@('helm.feature'), 2, 2) | raw }}
+feature: {{ to_nice_yaml(@('helm.feature'), 2, 2) | raw }}
 
 ingress:
   target_service: {{ ("varnish" in @('app.services') ? 'varnish' : 'webapp') }}
@@ -21,12 +20,10 @@ docker:
     nginx: {{ @('docker.repository') ~ ':' ~ @('app.version') ~ '-nginx' }}
     rabbitmq: {{ @('rabbitmq.image') ~ ':' ~ @('rabbitmq.tag') }}
     php_fpm_exporter: {{ @('docker.repository') ~ ':' ~ @('app.version') ~ '-php-fpm-exporter' }}
-  services:
-{{ deep_merge_to_yaml(
-  [
-    filter_local_services(@('services')),
-    @('pipeline.base.services')
-  ], 2, 4) | raw }}
+  services: {{ to_nice_yaml(deep_merge([
+      filter_local_services(@('services')),
+      @('pipeline.base.services')
+    ]), 2, 4) | raw }}
 
 service:
   elasticsearch: {{ ("elasticsearch" in @('app.services')) ? 'true' : 'false' }}
@@ -40,19 +37,15 @@ service:
   php_fpm_exporter: {{ ("php-fpm-exporter" in @('app.services')) ? 'true' : 'false' }}
   varnish: {{ ("varnish" in @('app.services')) ? 'true' : 'false' }}
 
-replicas:
-{{ to_nice_yaml(@('replicas'), 2, 2) | raw }}
+replicas: {{ to_nice_yaml(@('replicas'), 2, 2) | raw }}
 
 resources:
 {% include blocks ~ 'resources.yml.twig' %}
 
-persistence:
-{{ to_nice_yaml(@('pipeline.base.persistence'), 2, 2) | raw }}
+persistence: {{ to_nice_yaml(@('pipeline.base.persistence'), 2, 2) | raw }}
 
-prometheus:
-{{ to_nice_yaml(@('pipeline.base.prometheus'), 2, 2) | raw }}
+prometheus: {{ to_nice_yaml(@('pipeline.base.prometheus'), 2, 2) | raw }}
 
 resourcePrefix: {{ @('pipeline.base.resourcePrefix') | json_encode | raw }}
 
-istio:
-{{ to_nice_yaml(@('pipeline.base.istio'), 2, 2) | raw }}
+istio: {{ to_nice_yaml(@('pipeline.base.istio'), 2, 2) | raw }}

--- a/src/_base/helm/app/values.yaml.twig
+++ b/src/_base/helm/app/values.yaml.twig
@@ -22,7 +22,11 @@ docker:
     rabbitmq: {{ @('rabbitmq.image') ~ ':' ~ @('rabbitmq.tag') }}
     php_fpm_exporter: {{ @('docker.repository') ~ ':' ~ @('app.version') ~ '-php-fpm-exporter' }}
   services:
-{{ deep_merge_to_yaml([@('services'), @('pipeline.base.services')], 2, 4) | raw }}
+{{ deep_merge_to_yaml(
+  [
+    filter_local_services(@('services')),
+    @('pipeline.base.services')
+  ], 2, 4) | raw }}
 
 service:
   elasticsearch: {{ ("elasticsearch" in @('app.services')) ? 'true' : 'false' }}

--- a/src/_base/helm/qa/values.yaml.twig
+++ b/src/_base/helm/qa/values.yaml.twig
@@ -2,10 +2,8 @@
   resourcePrefix: {{ @('pipeline.qa.resourcePrefix') | json_encode | raw }}
 {% if @('pipeline.qa.services') %}
   docker:
-    services:
-{{ to_nice_yaml(@('pipeline.qa.services'), 2, 6) | raw }}
+    services: {{ to_nice_yaml(@('pipeline.qa.services'), 2, 6) | raw }}
 {% endif %}
 {% if @('pipeline.qa.persistence') %}
-  persistence:
-{{ to_nice_yaml(@('pipeline.qa.persistence'), 2, 4) | raw }}
+  persistence: {{ to_nice_yaml(@('pipeline.qa.persistence'), 2, 4) | raw }}
 {% endif %}

--- a/src/akeneo/_twig/docker-compose.yml/service/job-queue-consumer.yml.twig
+++ b/src/akeneo/_twig/docker-compose.yml/service/job-queue-consumer.yml.twig
@@ -10,7 +10,13 @@
     image: {{ @('docker.repository') ~ ':' ~ @('app.version') ~ '-job-queue-consumer' }}
 {% endif %}
     environment:
-{{ deep_merge_to_yaml([@('services.php-base.environment'),@('services.job-queue-consumer.environment')], 2, 6) | raw }}
+{{ deep_merge_to_yaml(
+  [
+    @('services.php-base.environment'),
+    @('services.job-queue-consumer.environment'),
+    @('services.php-base.environment_secrets'),
+    @('services.job-queue-consumer.environment_secrets')
+  ], 2, 6) | raw }}
 {% include blocks ~ 'environment.yml.twig' %}
     networks:
       - private

--- a/src/akeneo/_twig/docker-compose.yml/service/job-queue-consumer.yml.twig
+++ b/src/akeneo/_twig/docker-compose.yml/service/job-queue-consumer.yml.twig
@@ -9,14 +9,12 @@
 {% else %}
     image: {{ @('docker.repository') ~ ':' ~ @('app.version') ~ '-job-queue-consumer' }}
 {% endif %}
-    environment:
-{{ deep_merge_to_yaml(
-  [
-    @('services.php-base.environment'),
-    @('services.job-queue-consumer.environment'),
-    @('services.php-base.environment_secrets'),
-    @('services.job-queue-consumer.environment_secrets')
-  ], 2, 6) | raw }}
+    environment: {{ to_nice_yaml(deep_merge([
+        @('services.php-base.environment'),
+        @('services.job-queue-consumer.environment'),
+        @('services.php-base.environment_secrets'),
+        @('services.job-queue-consumer.environment_secrets')
+      ]), 2, 6) | raw }}
 {% include blocks ~ 'environment.yml.twig' %}
     networks:
       - private

--- a/src/akeneo/harness/attributes/docker.yml
+++ b/src/akeneo/harness/attributes/docker.yml
@@ -7,7 +7,7 @@ attributes:
       job_queue_consumer: "1024Mi"
   services:
     php-base:
-      environment:
+      environment_secrets:
         AKENEO_SECRET: = @('akeneo.secret')
     job-queue-consumer:
       environment:

--- a/src/akeneo/helm/app/templates/application/job-queue-consumer/deployment.yaml
+++ b/src/akeneo/helm/app/templates/application/job-queue-consumer/deployment.yaml
@@ -1,4 +1,4 @@
-{{- $service := merge (index .Values.docker.services "console") (index .Values.docker.services "job-queue-consumer") (dict "environment" .Values.environment) -}}
+{{- $service := merge (index .Values.docker.services "job-queue-consumer") (index .Values.docker.services "php-base") (dict "environment" .Values.environment) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/src/akeneo/helm/app/templates/application/job-queue-consumer/deployment.yaml
+++ b/src/akeneo/helm/app/templates/application/job-queue-consumer/deployment.yaml
@@ -1,7 +1,4 @@
-{{- $service := merge
-  (index .Values.docker.services "console")
-  (index .Values.docker.services "job-queue-consumer")
-  (dict "environment" .Values.environment) -}}
+{{- $service := merge (index .Values.docker.services "console") (index .Values.docker.services "job-queue-consumer") (dict "environment" .Values.environment) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/src/akeneo/helm/app/templates/application/job-queue-consumer/deployment.yaml
+++ b/src/akeneo/helm/app/templates/application/job-queue-consumer/deployment.yaml
@@ -1,3 +1,7 @@
+{{- $service := merge
+  (index .Values.docker.services "console")
+  (index .Values.docker.services "job-queue-consumer")
+  (dict "environment" .Values.environment) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -36,7 +40,7 @@ spec:
       containers:
       - name: job-queue-consumer
         env:
-        {{- range $key, $value := index .Values.docker.services "php-base" "environment" }}
+        {{- range $key, $value := $service.environment }}
         {{- $tp := typeOf $value }}
         - name: {{ $key | quote }}
         {{- if eq $tp "string" }}
@@ -45,18 +49,10 @@ spec:
           value: {{ $value | quote }}
         {{- end }}
         {{- end }}
-        {{- range $key, $value := index .Values.docker.services "job-queue-consumer" "environment" }}
-        {{- $tp := typeOf $value }}
-        - name: {{ $key | quote }}
-        {{- if eq $tp "string" }}
-          value: {{ tpl $value $ | quote }}
-        {{- else}}
-          value: {{ $value | quote }}
-        {{- end }}
-        {{- end }}
-        {{- range $key, $value := .Values.environment }}
-        - name: {{ $key | quote }}
-          value: {{ $value | quote }}
+        {{- if $service.environment_secrets }}
+        envFrom:
+          - secretRef:
+              name: {{ .Values.resourcePrefix }}job-queue-consumer
         {{- end }}
         image: {{ .Values.docker.image.job_queue_consumer }}
         imagePullPolicy: Always

--- a/src/akeneo/helm/app/templates/application/job-queue-consumer/deployment.yaml
+++ b/src/akeneo/helm/app/templates/application/job-queue-consumer/deployment.yaml
@@ -1,4 +1,4 @@
-{{- $service := merge (index .Values.docker.services "job-queue-consumer") (index .Values.docker.services "php-base") (dict "environment" .Values.environment) -}}
+{{- $service := mergeOverwrite (dict) (index .Values.docker.services "php-base") (index .Values.docker.services "job-queue-consumer") (dict "environment" .Values.environment) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/src/akeneo/helm/app/templates/application/job-queue-consumer/secret.yaml
+++ b/src/akeneo/helm/app/templates/application/job-queue-consumer/secret.yaml
@@ -1,2 +1,2 @@
 {{- $service := merge (index .Values.docker.services "job-queue-consumer") (index .Values.docker.services "php-base") -}}
-{{ template "service.environment.secret" (dict "service_name" "job-queue-consumer" "service" $service) }}
+{{ template "service.environment.secret" (dict "service_name" "job-queue-consumer" "service" $service "Values" .Values) }}

--- a/src/akeneo/helm/app/templates/application/job-queue-consumer/secret.yaml
+++ b/src/akeneo/helm/app/templates/application/job-queue-consumer/secret.yaml
@@ -1,2 +1,2 @@
-{{- $service := merge (index .Values.docker.services "job-queue-consumer") (index .Values.docker.services "php-base") -}}
+{{- $service := mergeOverwrite (dict) (index .Values.docker.services "php-base") (index .Values.docker.services "job-queue-consumer") -}}
 {{ template "service.environment.secret" (dict "service_name" "job-queue-consumer" "service" $service "Values" .Values) }}

--- a/src/akeneo/helm/app/templates/application/job-queue-consumer/secret.yaml
+++ b/src/akeneo/helm/app/templates/application/job-queue-consumer/secret.yaml
@@ -1,0 +1,7 @@
+{{ template "service.environment.secret" (dict
+    "service_name" "job-queue-consumer"
+    "service" (merge
+      (index .Values.docker.services "job-queue-consumer")
+      (index .Values.docker.services "php-base")
+    )
+  ) }}

--- a/src/akeneo/helm/app/templates/application/job-queue-consumer/secret.yaml
+++ b/src/akeneo/helm/app/templates/application/job-queue-consumer/secret.yaml
@@ -1,7 +1,2 @@
-{{ template "service.environment.secret" (dict
-    "service_name" "job-queue-consumer"
-    "service" (merge
-      (index .Values.docker.services "job-queue-consumer")
-      (index .Values.docker.services "php-base")
-    )
-  ) }}
+{{- $service := merge (index .Values.docker.services "job-queue-consumer") (index .Values.docker.services "php-base") -}}
+{{ template "service.environment.secret" (dict "service_name" "job-queue-consumer" "service" $service) }}

--- a/src/akeneo/helm/app/values.yaml.twig
+++ b/src/akeneo/helm/app/values.yaml.twig
@@ -3,8 +3,7 @@
 environment:
 {% include blocks ~ 'environment.yml.twig' %}
 
-feature:
-{{ to_nice_yaml(@('helm.feature'), 2, 2) | raw }}
+feature: {{ to_nice_yaml(@('helm.feature'), 2, 2) | raw }}
 
 ingress:
   target_service: {{ ("varnish" in @('app.services') ? 'varnish' : 'webapp') }}
@@ -22,12 +21,10 @@ docker:
     nginx: {{ @('docker.repository') ~ ':' ~ @('app.version') ~ '-nginx' }}
     rabbitmq: {{ @('rabbitmq.image') ~ ':' ~ @('rabbitmq.tag') }}
     php_fpm_exporter: {{ @('docker.repository') ~ ':' ~ @('app.version') ~ '-php-fpm-exporter' }}
-  services:
-{{ deep_merge_to_yaml(
-  [
-    filter_local_services(@('services')),
-    @('pipeline.base.services')
-  ], 2, 4) | raw }}
+  services: {{ to_nice_yaml(deep_merge([
+      filter_local_services(@('services')),
+      @('pipeline.base.services')
+    ]), 2, 4) | raw }}
 
 service:
   elasticsearch: {{ ("elasticsearch" in @('app.services')) ? 'true' : 'false' }}
@@ -42,19 +39,15 @@ service:
   php_fpm_exporter: {{ ("php-fpm-exporter" in @('app.services')) ? 'true' : 'false' }}
   varnish: {{ ("varnish" in @('app.services')) ? 'true' : 'false' }}
 
-replicas:
-{{ to_nice_yaml(@('replicas'), 2, 2) | raw }}
+replicas: {{ to_nice_yaml(@('replicas'), 2, 2) | raw }}
 
 resources:
 {% include blocks ~ 'resources.yml.twig' %}
 
-persistence:
-{{ to_nice_yaml(@('pipeline.base.persistence'), 2, 2) | raw }}
+persistence: {{ to_nice_yaml(@('pipeline.base.persistence'), 2, 2) | raw }}
 
-prometheus:
-{{ to_nice_yaml(@('pipeline.base.prometheus'), 2, 2) | raw }}
+prometheus: {{ to_nice_yaml(@('pipeline.base.prometheus'), 2, 2) | raw }}
 
 resourcePrefix: {{ @('pipeline.base.resourcePrefix') | json_encode | raw }}
 
-istio:
-{{ to_nice_yaml(@('pipeline.base.istio'), 2, 2) | raw }}
+istio: {{ to_nice_yaml(@('pipeline.base.istio'), 2, 2) | raw }}

--- a/src/akeneo/helm/app/values.yaml.twig
+++ b/src/akeneo/helm/app/values.yaml.twig
@@ -23,7 +23,11 @@ docker:
     rabbitmq: {{ @('rabbitmq.image') ~ ':' ~ @('rabbitmq.tag') }}
     php_fpm_exporter: {{ @('docker.repository') ~ ':' ~ @('app.version') ~ '-php-fpm-exporter' }}
   services:
-{{ deep_merge_to_yaml([@('services'), @('pipeline.base.services')], 2, 4) | raw }}
+{{ deep_merge_to_yaml(
+  [
+    filter_local_services(@('services')),
+    @('pipeline.base.services')
+  ], 2, 4) | raw }}
 
 service:
   elasticsearch: {{ ("elasticsearch" in @('app.services')) ? 'true' : 'false' }}

--- a/src/drupal8/harness/attributes/docker.yml
+++ b/src/drupal8/harness/attributes/docker.yml
@@ -3,6 +3,7 @@ attributes:
     php-base:
       environment:
         DRUPAL_DOCROOT: = @('drupal.docroot')
+      environment_secrets:
         DRUPAL_SALT: = @('drupal.salt')
   pipeline:
     preview:

--- a/src/magento2/harness/attributes/docker.yml
+++ b/src/magento2/harness/attributes/docker.yml
@@ -2,8 +2,9 @@ attributes:
   services:
     php-base:
       environment:
-        MAGENTO_CRYPT_KEY: = @('magento.crypt.key')
         MAGE_MODE: "= (@('app.mode') == 'production' ? 'production' : 'developer')"
+      environment_secrets:
+        MAGENTO_CRYPT_KEY: = @('magento.crypt.key')
   pipeline:
     preview:
       persistence:

--- a/src/spryker/_twig/docker-compose.yml/application.yml.twig
+++ b/src/spryker/_twig/docker-compose.yml/application.yml.twig
@@ -25,7 +25,13 @@
     labels:
       - traefik.enable=false
     environment:
-{{ deep_merge_to_yaml([@('services.php-base.environment'),@('services.console.environment')], 2, 6) | raw }}
+{{ deep_merge_to_yaml(
+  [
+    @('services.php-base.environment'),
+    @('services.console.environment'),
+    @('services.php-base.environment_secrets'),
+    @('services.console.environment_secrets')
+  ], 2, 6) | raw }}
 {% include blocks ~ 'environment.yml.twig' %}
     networks:
       - private
@@ -79,7 +85,13 @@
     networks:
       - private
     environment:
-{{ deep_merge_to_yaml([@('services.php-base.environment'), @('services.php-fpm.environment')], 2, 6) | raw }}
+{{ deep_merge_to_yaml(
+  [
+    @('services.php-base.environment'),
+    @('services.php-fpm.environment'),
+    @('services.php-base.environment_secrets'),
+    @('services.php-fpm.environment_secrets')
+  ], 2, 6) | raw }}
 {% include blocks ~ 'environment.yml.twig' %}
     expose:
 {% for pool in @('php-fpm.pools') %}

--- a/src/spryker/_twig/docker-compose.yml/application.yml.twig
+++ b/src/spryker/_twig/docker-compose.yml/application.yml.twig
@@ -24,14 +24,12 @@
 {% endif %}
     labels:
       - traefik.enable=false
-    environment:
-{{ deep_merge_to_yaml(
-  [
-    @('services.php-base.environment'),
-    @('services.console.environment'),
-    @('services.php-base.environment_secrets'),
-    @('services.console.environment_secrets')
-  ], 2, 6) | raw }}
+    environment: {{ to_nice_yaml(deep_merge([
+        @('services.php-base.environment'),
+        @('services.console.environment'),
+        @('services.php-base.environment_secrets'),
+        @('services.console.environment_secrets')
+      ]), 2, 6) | raw }}
 {% include blocks ~ 'environment.yml.twig' %}
     networks:
       - private
@@ -84,14 +82,12 @@
       - traefik.enable=false
     networks:
       - private
-    environment:
-{{ deep_merge_to_yaml(
-  [
-    @('services.php-base.environment'),
-    @('services.php-fpm.environment'),
-    @('services.php-base.environment_secrets'),
-    @('services.php-fpm.environment_secrets')
-  ], 2, 6) | raw }}
+    environment: {{ to_nice_yaml(deep_merge([
+        @('services.php-base.environment'),
+        @('services.php-fpm.environment'),
+        @('services.php-base.environment_secrets'),
+        @('services.php-fpm.environment_secrets')
+      ]), 2, 6) | raw }}
 {% include blocks ~ 'environment.yml.twig' %}
     expose:
 {% for pool in @('php-fpm.pools') %}

--- a/src/spryker/_twig/docker-compose.yml/service/jenkins-runner.yml.twig
+++ b/src/spryker/_twig/docker-compose.yml/service/jenkins-runner.yml.twig
@@ -14,14 +14,12 @@
     depends_on:
       - console
       - jenkins
-    environment:
-{{ deep_merge_to_yaml(
-  [
-    @('services.php-base.environment'),
-    @('services.jenkins-runner.environment'),
-    @('services.php-base.environment_secrets'),
-    @('services.jenkins-runner.environment_secrets')
-  ], 2, 6) | raw }}
+    environment: {{ to_nice_yaml(deep_merge([
+        @('services.php-base.environment'),
+        @('services.jenkins-runner.environment'),
+        @('services.php-base.environment_secrets'),
+        @('services.jenkins-runner.environment_secrets')
+      ]), 2, 6) | raw }}
 {% include blocks ~ 'environment.yml.twig' %}
     networks:
       - private

--- a/src/spryker/_twig/docker-compose.yml/service/jenkins-runner.yml.twig
+++ b/src/spryker/_twig/docker-compose.yml/service/jenkins-runner.yml.twig
@@ -15,7 +15,13 @@
       - console
       - jenkins
     environment:
-{{ deep_merge_to_yaml([@('services.php-base.environment'),@('services.jenkins-runner.environment')], 2, 6) | raw }}
+{{ deep_merge_to_yaml(
+  [
+    @('services.php-base.environment'),
+    @('services.jenkins-runner.environment'),
+    @('services.php-base.environment_secrets'),
+    @('services.jenkins-runner.environment_secrets')
+  ], 2, 6) | raw }}
 {% include blocks ~ 'environment.yml.twig' %}
     networks:
       - private

--- a/src/spryker/harness/attributes/docker.yml
+++ b/src/spryker/harness/attributes/docker.yml
@@ -3,7 +3,6 @@ attributes:
     php-base:
       environment:
         APPLICATION_ENV: = @('spryker.mode')
-        SPRYKER_SALT: = @('spryker.salt')
         REDIS_PROTOCOL: = @('redis.protocol')
         SMTP_HOST: = @('smtp.host')
         SMTP_PORT: = @('smtp.port')
@@ -12,6 +11,8 @@ attributes:
         JENKINS_URL: = 'http://' ~ @('jenkins.host') ~ ':' ~ @('jenkins.port') ~ '/'
         JENKINS_EXTERNAL_HOST: = @('jenkins.external_host')
         ZED_HOST: = @('zed.external_host')
+      environment_secrets:
+        SPRYKER_SALT: = @('spryker.salt')
     jenkins-runner:
       environment:
         JENKINS_RUNNER_NAME: backend
@@ -20,8 +21,9 @@ attributes:
         ZED_HOST: = @('zed.external_host')
     rabbitmq:
       environment:
-        RABBITMQ_DEFAULT_PASS: spryker
         RABBITMQ_DEFAULT_USER: spryker
+      environment_secrets:
+        RABBITMQ_DEFAULT_PASS: spryker
 
   pipeline:
     base:

--- a/src/spryker/helm/app/templates/application/jenkins-runner/deployment.yaml
+++ b/src/spryker/helm/app/templates/application/jenkins-runner/deployment.yaml
@@ -1,8 +1,5 @@
 {{- if .Values.service.jenkins_runner -}}
-{{- $service := merge
-  (dict "environment" .Values.environment)
-  (index .Values.docker.services "console")
-  (index .Values.docker.services "php-base") -}}
+{{- $service := merge (dict "environment" .Values.environment) (index .Values.docker.services "console") (index .Values.docker.services "php-base") -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/src/spryker/helm/app/templates/application/jenkins-runner/deployment.yaml
+++ b/src/spryker/helm/app/templates/application/jenkins-runner/deployment.yaml
@@ -1,4 +1,8 @@
-{{ if .Values.service.jenkins_runner }}
+{{- if .Values.service.jenkins_runner -}}
+{{- $service := merge
+  (dict "environment" .Values.environment)
+  (index .Values.docker.services "console")
+  (index .Values.docker.services "php-base") -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -20,7 +24,7 @@ spec:
     spec:
       containers:
       - env:
-        {{- range $key, $value := index .Values.docker.services "php-base" "environment" }}
+        {{- range $key, $value := $service.environment }}
         {{- $tp := typeOf $value }}
         - name: {{ $key | quote }}
         {{- if eq $tp "string" }}
@@ -29,18 +33,10 @@ spec:
           value: {{ $value | quote }}
         {{- end }}
         {{- end }}
-        {{- range $key, $value := index .Values.docker.services "jenkins-runner" "environment" }}
-        {{- $tp := typeOf $value }}
-        - name: {{ $key | quote }}
-        {{- if eq $tp "string" }}
-          value: {{ tpl $value $ | quote }}
-        {{- else }}
-          value: {{ $value | quote }}
-        {{- end }}
-        {{- end }}
-        {{- range $key, $value := .Values.environment }}
-        - name: {{ $key | quote }}
-          value: {{ $value | quote }}
+        {{- if $service.environment_secrets }}
+        envFrom:
+          - secretRef:
+              name: {{ .Values.resourcePrefix }}jenkins-runner
         {{- end }}
         image: {{ .Values.docker.image.jenkins_runner }}
         imagePullPolicy: Always
@@ -76,4 +72,4 @@ spec:
       {{- else }} []
       {{- end }}
 status: {}
-{{ end }}
+{{- end }}

--- a/src/spryker/helm/app/templates/application/jenkins-runner/deployment.yaml
+++ b/src/spryker/helm/app/templates/application/jenkins-runner/deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.service.jenkins_runner -}}
-{{- $service := merge (dict "environment" .Values.environment) (index .Values.docker.services "jenkins-runner") (index .Values.docker.services "php-base") -}}
+{{- $service := mergeOverwrite (dict) (index .Values.docker.services "php-base") (index .Values.docker.services "jenkins-runner") (dict "environment" .Values.environment) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/src/spryker/helm/app/templates/application/jenkins-runner/deployment.yaml
+++ b/src/spryker/helm/app/templates/application/jenkins-runner/deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.service.jenkins_runner -}}
-{{- $service := merge (dict "environment" .Values.environment) (index .Values.docker.services "console") (index .Values.docker.services "php-base") -}}
+{{- $service := merge (dict "environment" .Values.environment) (index .Values.docker.services "jenkins-runner") (index .Values.docker.services "php-base") -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/src/spryker/helm/app/templates/application/jenkins-runner/secret.yaml
+++ b/src/spryker/helm/app/templates/application/jenkins-runner/secret.yaml
@@ -1,2 +1,2 @@
 {{- $service := merge (index .Values.docker.services "jenkins-runner") (index .Values.docker.services "php-base") -}}
-{{ template "service.environment.secret" (dict "service_name" "jenkins-runner" "service" $service) }}
+{{ template "service.environment.secret" (dict "service_name" "jenkins-runner" "service" $service "Values" .Values) }}

--- a/src/spryker/helm/app/templates/application/jenkins-runner/secret.yaml
+++ b/src/spryker/helm/app/templates/application/jenkins-runner/secret.yaml
@@ -1,2 +1,2 @@
-{{- $service := merge (index .Values.docker.services "jenkins-runner") (index .Values.docker.services "php-base") -}}
+{{- $service := mergeOverwrite (dict) (index .Values.docker.services "php-base") (index .Values.docker.services "jenkins-runner") -}}
 {{ template "service.environment.secret" (dict "service_name" "jenkins-runner" "service" $service "Values" .Values) }}

--- a/src/spryker/helm/app/templates/application/jenkins-runner/secret.yaml
+++ b/src/spryker/helm/app/templates/application/jenkins-runner/secret.yaml
@@ -1,0 +1,7 @@
+{{ template "service.environment.secret" (dict
+    "service_name" "jenkins-runner"
+    "service" (merge
+      (index .Values.docker.services "jenkins-runner")
+      (index .Values.docker.services "php-fpm")
+    )
+  ) }}

--- a/src/spryker/helm/app/templates/application/jenkins-runner/secret.yaml
+++ b/src/spryker/helm/app/templates/application/jenkins-runner/secret.yaml
@@ -1,7 +1,2 @@
-{{ template "service.environment.secret" (dict
-    "service_name" "jenkins-runner"
-    "service" (merge
-      (index .Values.docker.services "jenkins-runner")
-      (index .Values.docker.services "php-fpm")
-    )
-  ) }}
+{{- $service := merge (index .Values.docker.services "jenkins-runner") (index .Values.docker.services "php-base") -}}
+{{ template "service.environment.secret" (dict "service_name" "jenkins-runner" "service" $service) }}

--- a/src/spryker/helm/app/values.yaml.twig
+++ b/src/spryker/helm/app/values.yaml.twig
@@ -6,8 +6,7 @@ console:
 environment:
 {% include blocks ~ 'environment.yml.twig' %}
 
-feature:
-{{ to_nice_yaml(@('helm.feature'), 2, 2) | raw }}
+feature: {{ to_nice_yaml(@('helm.feature'), 2, 2) | raw }}
 
 ingress:
   target_service: {{ ("varnish" in @('app.services') ? 'varnish' : 'webapp') }}
@@ -25,12 +24,10 @@ docker:
     jenkins_runner: {{ @('docker.repository') ~ ':' ~ @('app.version') ~ '-jenkins-runner' }}
     rabbitmq: {{ @('rabbitmq.image') ~ ':' ~ @('rabbitmq.tag') }}
     php_fpm_exporter: {{ @('docker.repository') ~ ':' ~ @('app.version') ~ '-php-fpm-exporter' }}
-  services:
-{{ deep_merge_to_yaml(
-  [
-    filter_local_services(@('services')),
-    @('pipeline.base.services')
-  ], 2, 4) | raw }}
+  services: {{ to_nice_yaml(deep_merge([
+      filter_local_services(@('services')),
+      @('pipeline.base.services')
+    ]), 2, 4) | raw }}
 
 service:
   elasticsearch: {{ ("elasticsearch" in @('app.services')) ? 'true' : 'false' }}
@@ -46,16 +43,13 @@ service:
   php_fpm_exporter: {{ ("php-fpm-exporter" in @('app.services')) ? 'true' : 'false' }}
   varnish: {{ ("varnish" in @('app.services')) ? 'true' : 'false' }}
 
-replicas:
-{{ to_nice_yaml(@('replicas'), 2, 2) | raw }}
+replicas: {{ to_nice_yaml(@('replicas'), 2, 2) | raw }}
 
 resources:
 {% include blocks ~ 'resources.yml.twig' %}
 
-persistence:
-{{ to_nice_yaml(@('persistence'), 2, 2) | raw }}
+persistence: {{ to_nice_yaml(@('persistence'), 2, 2) | raw }}
 
-prometheus:
-{{ to_nice_yaml(@('pipeline.base.prometheus'), 2, 2) | raw }}
+prometheus: {{ to_nice_yaml(@('pipeline.base.prometheus'), 2, 2) | raw }}
 
 resourcePrefix: {{ @('workspace.name') ~ '-' }}

--- a/src/spryker/helm/app/values.yaml.twig
+++ b/src/spryker/helm/app/values.yaml.twig
@@ -26,7 +26,11 @@ docker:
     rabbitmq: {{ @('rabbitmq.image') ~ ':' ~ @('rabbitmq.tag') }}
     php_fpm_exporter: {{ @('docker.repository') ~ ':' ~ @('app.version') ~ '-php-fpm-exporter' }}
   services:
-{{ deep_merge_to_yaml([@('services'), @('pipeline.base.services')], 2, 4) | raw }}
+{{ deep_merge_to_yaml(
+  [
+    filter_local_services(@('services')),
+    @('pipeline.base.services')
+  ], 2, 4) | raw }}
 
 service:
   elasticsearch: {{ ("elasticsearch" in @('app.services')) ? 'true' : 'false' }}

--- a/src/spryker/helm/preview/values.yaml.twig
+++ b/src/spryker/helm/preview/values.yaml.twig
@@ -10,8 +10,7 @@
 {% endfor %}
   resourcePrefix: {{ @('pipeline.preview.resourcePrefix') | json_encode | raw }}
 {% if @('pipeline.preview.persistence') %}
-  persistence:
-{{ to_nice_yaml(@('pipeline.preview.persistence'), 2, 4) | raw }}
+  persistence: {{ to_nice_yaml(@('pipeline.preview.persistence'), 2, 4) | raw }}
 {% endif %}
 {% set additional_services = {
   'php-base': {
@@ -23,7 +22,6 @@
 } %}
 {{ @('workspace.name') }}:
   docker:
-    services:
-{{ deep_merge_to_yaml([@('pipeline.preview.services'), additional_services], 2, 6) | raw }}
+    services: {{ to_nice_yaml(deep_merge([@('pipeline.preview.services'), additional_services]), 2, 6) | raw }}
 
   prefix: ""

--- a/src/spryker/helm/qa/values.yaml.twig
+++ b/src/spryker/helm/qa/values.yaml.twig
@@ -6,8 +6,7 @@
 {% set hosts_env = hosts_env|merge({('GLUE_HOST_' ~ store): glue_external_host}) %}
 {% endfor %}
 {% if @('pipeline.qa.persistence') %}
-  persistence:
-{{ to_nice_yaml(@('pipeline.qa.persistence'), 2, 4) | raw }}
+  persistence: {{ to_nice_yaml(@('pipeline.qa.persistence'), 2, 4) | raw }}
 {% endif %}
 {% set additional_services = {
   'php-base': {
@@ -19,7 +18,6 @@
 } %}
 {{ @('workspace.name') }}:
   docker:
-    services:
-{{ deep_merge_to_yaml([@('pipeline.qa.services'), additional_services], 2, 6) | raw }}
+    services: {{ to_nice_yaml(deep_merge([@('pipeline.qa.services'), additional_services]), 2, 6) | raw }}
 
   resourcePrefix: ""

--- a/src/wordpress/harness/attributes/docker.yml
+++ b/src/wordpress/harness/attributes/docker.yml
@@ -4,6 +4,7 @@ attributes:
       environment:
         WORDPRESS_INSTALL_DIRECTORY: = @('wordpress.install_directory')
         WORDPRESS_URL: = @('wordpress.url')
+      environment_secrets:
         WORDPRESS_AUTH_KEY: = @('wordpress.security.auth.key')
         WORDPRESS_SECURE_AUTH_KEY: = @('wordpress.security.secure_auth.key')
         WORDPRESS_LOGGED_IN_KEY: = @('wordpress.security.logged_in.key')


### PR DESCRIPTION
Add ability to define env vars from k8s secrets …

* with sealed-secrets used by default for encryption
* environment variables in templates simplified by merging dicts before iterating
* support for custom CRD schemas necessary to pass tests
* local secrets (plaintext still) excluded from pipeline to avoid confusion over encryption