### PR TITLE
Deduce the docker registry_url from repository

### DIFF
--- a/src/_base/harness/attributes/common.yml
+++ b/src/_base/harness/attributes/common.yml
@@ -78,6 +78,7 @@ attributes.default:
         external_host: = 'rabbitmq-' ~ @('pipeline.qa.hostname')
 
   docker:
+    registry_url: = get_docker_registry(@('docker.repository'))
     repository: = @("workspace.name")
     compose:
       file_version: '3.7'

--- a/src/_base/harness/config/functions.yml
+++ b/src/_base/harness/config/functions.yml
@@ -58,6 +58,14 @@ function('get_docker_external_networks'): |
   }
   = join(" ", $externalNetworks);
 
+function('get_docker_registry', [dockerRepository]): |
+  #!php
+  $dockerRepoParts = explode('/', $dockerRepository);
+  if (strpos($dockerRepoParts[0], '.') !== false) {
+      $registry = $dockerRepoParts[0];
+  }
+  = $registry ?? 'https://index.docker.io/v1/';
+
 function('branch'): |
   #!bash(workspace:/)
   =$(git branch | grep \* | cut -d ' ' -f2)

--- a/src/_base/harness/config/pipeline.yml
+++ b/src/_base/harness/config/pipeline.yml
@@ -40,14 +40,14 @@ command('app publish'):
     HAS_CRON: "= ('cron' in @('app.services') ? 'true' : 'false')"
   exec: |
     #!bash(workspace:/)|@
-    echo "@('docker.password')" | run docker login --username="@('docker.username')" --password-stdin @('docker.repository')
+    echo "@('docker.password')" | run docker login --username="@('docker.username')" --password-stdin @('docker.registry_url')
     run docker push @('docker.repository'):@('app.version')-console
     run docker push @('docker.repository'):@('app.version')-php-fpm
     run docker push @('docker.repository'):@('app.version')-nginx
     if [[ "${HAS_CRON}" == "true" ]]; then
       run docker push @('docker.repository'):@('app.version')-cron
     fi
-    run docker logout @('docker.repository')
+    run docker logout @('docker.registry_url')
 
 command('app publish chart <release> <message>'):
   env:

--- a/src/akeneo/harness/config/q-akeneo-pipeline.yml
+++ b/src/akeneo/harness/config/q-akeneo-pipeline.yml
@@ -13,11 +13,11 @@ command('app build job-queue-consumer'): |
 
 command('app publish'): |
   #!bash(workspace:/)|@
-  echo "@('docker.password')" | run docker login --username="@('docker.username')" --password-stdin @('docker.repository')
+  echo "@('docker.password')" | run docker login --username="@('docker.username')" --password-stdin @('docker.registry_url')
   run docker push @('docker.repository'):@('app.version')-console
   run docker push @('docker.repository'):@('app.version')-php-fpm
   run docker push @('docker.repository'):@('app.version')-job-queue-consumer
   run docker push @('docker.repository'):@('app.version')-cron
   run docker push @('docker.repository'):@('app.version')-nginx
-  run docker logout @('docker.repository')
+  run docker logout @('docker.registry_url')
 

--- a/src/spryker/harness/config/spryker-pipeline.yml
+++ b/src/spryker/harness/config/spryker-pipeline.yml
@@ -8,12 +8,12 @@ command('app build'): |
 
 command('app publish'): |
   #!bash(workspace:/)|@
-  echo "@('docker.password')" | run docker login --username="@('docker.username')" --password-stdin @('docker.repository')
+  echo "@('docker.password')" | run docker login --username="@('docker.username')" --password-stdin @('docker.registry_url')
   run docker push @('docker.repository'):@('app.version')-console
   run docker push @('docker.repository'):@('app.version')-php-fpm
   run docker push @('docker.repository'):@('app.version')-nginx
   run docker push @('docker.repository'):@('app.version')-jenkins-runner
-  run docker logout @('docker.repository')
+  run docker logout @('docker.registry_url')
 
 command('app build jenkins-runner'): |
   #!bash(workspace:/)|@


### PR DESCRIPTION
Docker login doesn't work when the repository is using the default daemon registry (common when pushing to docker hub)

Also makes it clear there is no per-repository login credential store, only per-registry, so not good for parallel builds of different projects