### PR TITLE
Delete composer cache from console image

### DIFF
--- a/src/_base/docker/image/console/root/lib/task/composer/install.sh.twig
+++ b/src/_base/docker/image/console/root/lib/task/composer/install.sh.twig
@@ -4,9 +4,11 @@ function task_composer_install()
 {
     {% if @('app.mode') == 'development' and @('app.build') == 'static' %}
         passthru composer install --no-interaction --optimize-autoloader
+        run composer clear-cache
     {% elseif @('app.mode') == 'development' %}
         passthru composer install --no-interaction
     {% else %}
         passthru composer install --no-interaction --no-dev --optimize-autoloader
+        run composer clear-cache
     {% endif %}
 }

--- a/src/_base/docker/image/console/root/lib/task/composer/install.sh.twig
+++ b/src/_base/docker/image/console/root/lib/task/composer/install.sh.twig
@@ -4,11 +4,13 @@ function task_composer_install()
 {
     {% if @('app.mode') == 'development' and @('app.build') == 'static' %}
         passthru composer install --no-interaction --optimize-autoloader
-        run composer clear-cache
     {% elseif @('app.mode') == 'development' %}
         passthru composer install --no-interaction
     {% else %}
         passthru composer install --no-interaction --no-dev --optimize-autoloader
-        run composer clear-cache
+    {% endif %}
+
+    {% if @('app.build') == 'static' %}
+        run "composer clear-cache"
     {% endif %}
 }


### PR DESCRIPTION
Merges into #331 

Avoid pushing a large amount of ~/.composer/cache for the build user up to the docker registry.