### PR TITLE
Fix not having output for failed commands

### DIFF
--- a/src/_base/docker/image/console/root/lib/sidekick.sh
+++ b/src/_base/docker/image/console/root/lib/sidekick.sh
@@ -52,7 +52,7 @@ run()
         prompt
         if [ "${DEPRECATED_MODE}" = "yes" ]; then
             echo "  > ${COMMAND_DEPRECATED[*]}" >&2
-            COMMAND=(bash -c "${COMMAND_DEPRECATED[@]}")
+            COMMAND=(bash -e -c "${COMMAND_DEPRECATED[@]}")
         else
           echo "  >$(printf ' %q' "${COMMAND[@]}")" >&2
         fi

--- a/src/_base/docker/image/console/root/lib/sidekick.sh
+++ b/src/_base/docker/image/console/root/lib/sidekick.sh
@@ -54,7 +54,7 @@ run()
             echo "  > ${COMMAND_DEPRECATED[*]}" >&2
             COMMAND=(bash -e -c "${COMMAND_DEPRECATED[@]}")
         else
-          echo "  >$(printf ' %q' "${COMMAND[@]}")" >&2
+            echo "  >$(printf ' %q' "${COMMAND[@]}")" >&2
         fi
 
         setCommandIndicator "${INDICATOR_RUNNING}"

--- a/src/_base/docker/image/console/root/lib/sidekick.sh
+++ b/src/_base/docker/image/console/root/lib/sidekick.sh
@@ -51,13 +51,17 @@ run()
 
         prompt
         if [ "${DEPRECATED_MODE}" = "yes" ]; then
+            echo "  >$(printf ' %q' "${COMMAND_DEPRECATED[@]}")" >&2
             COMMAND=(bash -c "${COMMAND_DEPRECATED[@]}")
+        else
+          echo "  >$(printf ' %q' "${COMMAND[@]}")" >&2
         fi
 
-        echo "  >$(printf ' %q' "${COMMAND[@]}")" >&2
         setCommandIndicator "${INDICATOR_RUNNING}"
 
-        if ! "${COMMAND[@]}" > /tmp/my127ws-stdout.txt 2> /tmp/my127ws-stderr.txt; then
+        if "${COMMAND[@]}" > /tmp/my127ws-stdout.txt 2> /tmp/my127ws-stderr.txt; then
+            setCommandIndicator "${INDICATOR_SUCCESS}"
+        else
             setCommandIndicator "${INDICATOR_ERROR}"
             if [ "${APP_BUILD}" = "static" ]; then
               echo "Command failed. stdout:"
@@ -76,8 +80,6 @@ run()
             fi
 
             return 1
-        else
-            setCommandIndicator "${INDICATOR_SUCCESS}"
         fi
     elif [ "${DEPRECATED_MODE}" = "yes" ]; then
         passthru "${COMMAND_DEPRECATED[@]}"

--- a/src/_base/docker/image/console/root/lib/sidekick.sh
+++ b/src/_base/docker/image/console/root/lib/sidekick.sh
@@ -51,7 +51,7 @@ run()
 
         prompt
         if [ "${DEPRECATED_MODE}" = "yes" ]; then
-            echo "  >$(printf ' %q' "${COMMAND_DEPRECATED[@]}")" >&2
+            echo "  > ${COMMAND_DEPRECATED[*]}" >&2
             COMMAND=(bash -c "${COMMAND_DEPRECATED[@]}")
         else
           echo "  >$(printf ' %q' "${COMMAND[@]}")" >&2

--- a/src/_base/docker/image/console/root/lib/sidekick.sh
+++ b/src/_base/docker/image/console/root/lib/sidekick.sh
@@ -107,14 +107,10 @@ passthru()
 
     if [ "${DEPRECATED_MODE}" = "yes" ]; then
         echo -e "\\033[${INDICATOR_PASSTHRU}■\\033[0m > $*" >&2
-        if ! bash -e -c "${COMMAND_DEPRECATED[@]}"; then
-            return 1
-        fi
+        bash -e -c "${COMMAND_DEPRECATED[@]}"
     else
         echo -e "\\033[${INDICATOR_PASSTHRU}■\\033[0m >$(printf ' %q' "${COMMAND[@]}")" >&2
-        if ! "${COMMAND[@]}"; then
-            return 1
-        fi
+        "${COMMAND[@]}"
     fi
 }
 


### PR DESCRIPTION
The `bin/app` `set -e` was not allowing the separated `bash` call to fail and still continue onwards to show the /tmp/my* files.