### PR TITLE
Fix drush relative docroot fails

### DIFF
--- a/src/drupal8/harness.yml
+++ b/src/drupal8/harness.yml
@@ -84,7 +84,7 @@ command('drush %'):
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|=
-    passthru ws exec drush --root=={ @('drupal.docroot') } ={ input.argument('%') }
+    passthru ws exec drush --root=/app/={ @('drupal.docroot') } ={ input.argument('%') }
 ---
 command('test-unit'):
   env:


### PR DESCRIPTION
Encountered ./docroot being used internally for `ws drush updb -y`, which fails. Use absolute paths to avoid this.