### PR TITLE
Fix quoting of commit message

### DIFF
--- a/src/_base/harness/config/pipeline.yml
+++ b/src/_base/harness/config/pipeline.yml
@@ -50,7 +50,7 @@ command('app publish chart <release> <message>'):
 
     export GIT_SSH_COMMAND='ssh -i ../id_rsa -o "IdentitiesOnly yes" -F /dev/null -o StrictHostKeyChecking=no'
     run git -C ./build-artifacts-repository add .
-    run git -C ./build-artifacts-repository commit --allow-empty -m "'${MESSAGE}'"
+    run "git -C ./build-artifacts-repository commit --allow-empty -m '${MESSAGE}'"
     run git -C ./build-artifacts-repository push origin master
 
 command('app deploy <environment>'):

--- a/src/_base/harness/config/pipeline.yml
+++ b/src/_base/harness/config/pipeline.yml
@@ -50,7 +50,7 @@ command('app publish chart <release> <message>'):
 
     export GIT_SSH_COMMAND='ssh -i ../id_rsa -o "IdentitiesOnly yes" -F /dev/null -o StrictHostKeyChecking=no'
     run git -C ./build-artifacts-repository add .
-    run git -C ./build-artifacts-repository commit --allow-empty -m "${MESSAGE}"
+    run git -C ./build-artifacts-repository commit --allow-empty -m "'${MESSAGE}'"
     run git -C ./build-artifacts-repository push origin master
 
 command('app deploy <environment>'):

--- a/src/_base/harness/config/pipeline.yml
+++ b/src/_base/harness/config/pipeline.yml
@@ -5,7 +5,7 @@ command('app build'):
   exec: |
     #!bash(workspace:/)|@
     ws external-images pull
-    
+
     # dependency ordered build
     passthru docker-compose build console
     passthru docker-compose build php-fpm nginx
@@ -42,11 +42,11 @@ command('app publish chart <release> <message>'):
 
     export GIT_SSH_COMMAND='ssh -i ./id_rsa -o "IdentitiesOnly yes" -F /dev/null -o StrictHostKeyChecking=no'
 
-    run git clone $REPOSITORY ./build-artifacts-repository
+    run git clone "$REPOSITORY" ./build-artifacts-repository
     run git -C ./build-artifacts-repository config user.email "${USER_EMAIL}"
 
     run mkdir -p $ARTIFACTS_PATH
-    run rsync --exclude='*.twig' --exclude='_twig' --delete -a .my127ws/helm/app/ ${ARTIFACTS_PATH}/
+    run rsync --exclude='*.twig' --exclude='_twig' --delete -a .my127ws/helm/app/ "${ARTIFACTS_PATH}/"
 
     export GIT_SSH_COMMAND='ssh -i ../id_rsa -o "IdentitiesOnly yes" -F /dev/null -o StrictHostKeyChecking=no'
     run git -C ./build-artifacts-repository add .
@@ -63,12 +63,12 @@ command('app deploy <environment>'):
     #!bash(harness:/helm)|=
     set -o pipefail
     cd "${ENVIRONMENT}"
-    doctl -t $DO_ACCESS_TOKEN kubernetes cluster kubeconfig show $CLUSTER > kubectl.config.yaml
+    doctl -t "$DO_ACCESS_TOKEN" kubernetes cluster kubeconfig show "$CLUSTER" > kubectl.config.yaml
     if helm version --short --client | grep '^Client: v2' >/dev/null 2>&1; then
       passthru helm init --client-only
     fi
     passthru helm dependency build
-    passthru helm --kubeconfig=$PWD/kubectl.config.yaml upgrade --wait --atomic --install --timeout "${TIMEOUT}" --namespace "${NAMESPACE}" "${NAMESPACE}" ./
+    passthru helm --kubeconfig="${PWD}/kubectl.config.yaml" upgrade --wait --atomic --install --timeout "${TIMEOUT}" --namespace "${NAMESPACE}" "${NAMESPACE}" ./
 
 command('helm template <chart-path>'):
   env:


### PR DESCRIPTION
Fixes:
```
+ ws app publish chart PR-50 example-project build artifact e9d5d04718e1325ccb0fbad54ede9c10644c869a

[/home/jenkins/workspace/ect_example-project_PR-50]:

  > rm -rf build-artifacts-repository
■■  > git clone git@github.com:example/repo.git ./build-artifacts-repository
■■  > git -C ./build-artifacts-repository config user.email example-project@example.com
■■  > mkdir -p ./build-artifacts-repository/build-artifacts/example-project/PR-50
■■  > rsync --exclude=*.twig --exclude=_twig --delete -a .my127ws/helm/app/ ./build-artifacts-repository/build-artifacts/example-project/PR-50/
■■  > git -C ./build-artifacts-repository add .
■■  > git -C ./build-artifacts-repository commit --allow-empty -m example-project build artifact e9d5d04718e1325ccb0fbad54ede9c10644c869a
■■error: pathspec 'build' did not match any file(s) known to git.
error: pathspec 'artifact' did not match any file(s) known to git.
error: pathspec 'e9d5d04718e1325ccb0fbad54ede9c10644c869a' did not match any file(s) known to git.
```