### PR TITLE
Increase push timeout for docker-compose

### DIFF
--- a/src/_base/harness/config/pipeline.yml
+++ b/src/_base/harness/config/pipeline.yml
@@ -20,11 +20,15 @@ command('app build <service>'):
     #!bash(workspace:/)|@
     passthru docker-compose build "${SERVICE}"
 
-command('app publish'): |
-  #!bash(workspace:/)|@
-  echo '@('docker.registry.password')' | run docker login --username='@('docker.registry.username')' --password-stdin '@('docker.registry.url')'
-  passthru docker-compose push @('pipeline.publish.services')
-  run docker logout '@('docker.registry.url')'
+command('app publish'):
+  env:
+    COMPOSE_HTTP_TIMEOUT: 180
+    DOCKER_CLIENT_TIMEOUT: 180
+  exec: |
+    #!bash(workspace:/)|@
+    echo '@('docker.registry.password')' | run docker login --username='@('docker.registry.username')' --password-stdin '@('docker.registry.url')'
+    passthru docker-compose push @('pipeline.publish.services')
+    run docker logout '@('docker.registry.url')'
 
 command('app publish chart <release> <message>'):
   env:


### PR DESCRIPTION
Fixes:
```
■ > docker-compose push nginx console php-fpm cron
Pushing console (quay.io/example-organisation/example-repository:COMMIT_HASH-console)...
The push refers to repository [quay.io/example-organisation/example-repository]
[16560] Failed to execute script docker-compose
Traceback (most recent call last):
  File "site-packages/urllib3/response.py", line 360, in _error_catcher
  File "site-packages/urllib3/response.py", line 442, in read
  File "http/client.py", line 449, in read
  File "http/client.py", line 483, in readinto
  File "http/client.py", line 578, in _readinto_chunked
  File "http/client.py", line 546, in _get_chunk_left
  File "http/client.py", line 506, in _read_next_chunk_size
  File "socket.py", line 586, in readinto
socket.timeout: timed out

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "bin/docker-compose", line 6, in <module>
  File "compose/cli/main.py", line 71, in main
  File "compose/cli/main.py", line 127, in perform_command
  File "compose/cli/main.py", line 771, in push
  File "compose/project.py", line 596, in push
  File "compose/service.py", line 1230, in push
  File "compose/progress_stream.py", line 112, in get_digest_from_push
  File "compose/progress_stream.py", line 25, in stream_output
  File "compose/utils.py", line 62, in split_buffer
  File "compose/utils.py", line 38, in stream_as_text
  File "site-packages/docker/api/client.py", line 330, in _stream_helper
  File "site-packages/urllib3/response.py", line 459, in read
  File "contextlib.py", line 99, in __exit__
  File "site-packages/urllib3/response.py", line 365, in _error_catcher
urllib3.exceptions.ReadTimeoutError: UnixHTTPConnectionPool(host='localhost', port=None): Read timed out.
script returned exit code 255
```