### PR TITLE
Make the Spryker jenkins runner single executor, multi containers

### DIFF
--- a/src/spryker/docker/image/jenkins-runner/root/entrypoint.jenkins_runner.dynamic.sh
+++ b/src/spryker/docker/image/jenkins-runner/root/entrypoint.jenkins_runner.dynamic.sh
@@ -7,7 +7,7 @@ main()
 
 bootstrap()
 {
-    app jenkins setup
+    app jenkins:setup
 }
 
 bootstrap

--- a/src/spryker/docker/image/jenkins-runner/root/entrypoint.jenkins_runner.sh
+++ b/src/spryker/docker/image/jenkins-runner/root/entrypoint.jenkins_runner.sh
@@ -7,7 +7,7 @@ main()
 
 bootstrap()
 {
-    app jenkins setup
+    app jenkins:setup
 }
 
 bootstrap

--- a/src/spryker/docker/image/jenkins-runner/root/lib/task/jenkins.sh
+++ b/src/spryker/docker/image/jenkins-runner/root/lib/task/jenkins.sh
@@ -2,5 +2,6 @@
 
 function task_jenkins()
 {
+    echo "Deprecated: call app jenkins:$1 directly" >&2
     task "jenkins:$1"
 }

--- a/src/spryker/docker/image/jenkins-runner/root/lib/task/jenkins/register.sh
+++ b/src/spryker/docker/image/jenkins-runner/root/lib/task/jenkins/register.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+function task_jenkins_register()
+{
+    JENKINS_RUNNER_NAME="$(hostname)"
+
+    NODE_OUTPUT="$(java -jar /usr/local/bin/jenkins-cli.jar -s "$JENKINS_URL" get-node "$JENKINS_RUNNER_NAME" 2>&1 || true )"
+
+    if ! echo -n "$NODE_OUTPUT" | grep ERROR: >/dev/null; then
+        # In case of runner recreation, jenkins does not allow re-attaching new runner with same node name,
+        # may be due to IP change, so here we need to remove it first if already exists, and then re-register
+        echo -e "Removing old jenkins runner $JENKINS_RUNNER_NAME:"
+        java -jar /usr/local/bin/jenkins-cli.jar -s "$JENKINS_URL" delete-node "$JENKINS_RUNNER_NAME"
+    fi
+
+    echo -e "Registering jenkins runner $JENKINS_RUNNER_NAME at master"
+        # shellcheck disable=SC2154
+        cat <<EOF | java -jar /usr/local/bin/jenkins-cli.jar -s "$JENKINS_URL" create-node "$JENKINS_RUNNER_NAME"
+            <slave>
+              <name>$JENKINS_RUNNER_NAME</name>
+              <description></description>
+              <remoteFS>/data/shop</remoteFS>
+              <numExecutors>$RUNNER_NUM_EXECUTORS</numExecutors>
+              <mode>NORMAL</mode>
+              <retentionStrategy class="hudson.slaves.RetentionStrategy$Always"/>
+              <launcher class="hudson.slaves.JNLPLauncher"/>
+              <label>backend</label>
+              <nodeProperties/>
+            </slave>
+EOF
+}

--- a/src/spryker/docker/image/jenkins-runner/root/lib/task/jenkins/register.sh
+++ b/src/spryker/docker/image/jenkins-runner/root/lib/task/jenkins/register.sh
@@ -4,28 +4,28 @@ function task_jenkins_register()
 {
     local -r JENKINS_RUNNER_NAME="$(hostname)"
 
-    local -r NODE_OUTPUT="$(java -jar /usr/local/bin/jenkins-cli.jar -s "$JENKINS_URL" get-node "$JENKINS_RUNNER_NAME" 2>&1 || true )"
+    local -r NODE_OUTPUT="$(java -jar /usr/local/bin/jenkins-cli.jar -s "${JENKINS_URL}" get-node "${JENKINS_RUNNER_NAME}" 2>&1 || true )"
 
-    if ! echo -n "$NODE_OUTPUT" | grep ERROR: >/dev/null; then
+    if ! echo -n "${NODE_OUTPUT}" | grep ERROR: >/dev/null; then
         # In case of runner recreation, jenkins does not allow re-attaching new runner with same node name,
         # may be due to IP change, so here we need to remove it first if already exists, and then re-register
-        echo -e "Removing old jenkins runner $JENKINS_RUNNER_NAME:"
-        java -jar /usr/local/bin/jenkins-cli.jar -s "$JENKINS_URL" delete-node "$JENKINS_RUNNER_NAME"
+        echo -e "Removing old jenkins runner ${JENKINS_RUNNER_NAME}:"
+        java -jar /usr/local/bin/jenkins-cli.jar -s "${JENKINS_URL}" delete-node "${JENKINS_RUNNER_NAME}"
     fi
 
-    echo -e "Registering jenkins runner $JENKINS_RUNNER_NAME at master"
-        # shellcheck disable=SC2154
-        cat <<EOF | java -jar /usr/local/bin/jenkins-cli.jar -s "$JENKINS_URL" create-node "$JENKINS_RUNNER_NAME"
-            <slave>
-              <name>$JENKINS_RUNNER_NAME</name>
-              <description></description>
-              <remoteFS>/data/shop</remoteFS>
-              <numExecutors>$RUNNER_NUM_EXECUTORS</numExecutors>
-              <mode>NORMAL</mode>
-              <retentionStrategy class="hudson.slaves.RetentionStrategy$Always"/>
-              <launcher class="hudson.slaves.JNLPLauncher"/>
-              <label>backend</label>
-              <nodeProperties/>
-            </slave>
+    echo -e "Registering jenkins runner ${JENKINS_RUNNER_NAME} at master"
+
+    cat <<EOF | java -jar /usr/local/bin/jenkins-cli.jar -s "${JENKINS_URL}" create-node "${JENKINS_RUNNER_NAME}"
+        <slave>
+            <name>${JENKINS_RUNNER_NAME}</name>
+            <description></description>
+            <remoteFS>/data/shop</remoteFS>
+            <numExecutors>${RUNNER_NUM_EXECUTORS}</numExecutors>
+            <mode>NORMAL</mode>
+            <retentionStrategy class="hudson.slaves.RetentionStrategy\$Always"/>
+            <launcher class="hudson.slaves.JNLPLauncher"/>
+            <label>backend</label>
+            <nodeProperties/>
+        </slave>
 EOF
 }

--- a/src/spryker/docker/image/jenkins-runner/root/lib/task/jenkins/register.sh
+++ b/src/spryker/docker/image/jenkins-runner/root/lib/task/jenkins/register.sh
@@ -2,9 +2,9 @@
 
 function task_jenkins_register()
 {
-    JENKINS_RUNNER_NAME="$(hostname)"
+    local -r JENKINS_RUNNER_NAME="$(hostname)"
 
-    NODE_OUTPUT="$(java -jar /usr/local/bin/jenkins-cli.jar -s "$JENKINS_URL" get-node "$JENKINS_RUNNER_NAME" 2>&1 || true )"
+    local -r NODE_OUTPUT="$(java -jar /usr/local/bin/jenkins-cli.jar -s "$JENKINS_URL" get-node "$JENKINS_RUNNER_NAME" 2>&1 || true )"
 
     if ! echo -n "$NODE_OUTPUT" | grep ERROR: >/dev/null; then
         # In case of runner recreation, jenkins does not allow re-attaching new runner with same node name,

--- a/src/spryker/docker/image/jenkins-runner/root/lib/task/jenkins/setup.sh
+++ b/src/spryker/docker/image/jenkins-runner/root/lib/task/jenkins/setup.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# setup jenkins runner to master
 function task_jenkins_setup()
 {
     echo -e "Bootstrapping jenkins runner"
@@ -8,33 +7,6 @@ function task_jenkins_setup()
 
     curl -s "$JENKINS_URL/jnlpJars/jenkins-cli.jar" -o /usr/local/bin/jenkins-cli.jar
     curl -s "$JENKINS_URL/jnlpJars/slave.jar" -o /usr/local/bin/jenkins-slave.jar
-
-    JENKINS_RUNNER_NAME="$(hostname)"
-
-    (java -jar /usr/local/bin/jenkins-cli.jar -s "$JENKINS_URL" get-node "$JENKINS_RUNNER_NAME" 2>&1 || true ) > /tmp/jenkins.node
-
-    if ! grep ERROR: /tmp/jenkins.node >/dev/null; then
-        # In case of runner recreation, jenkins does not allow re-attaching new runner with same node name,
-        # may be due to IP change, so here we need to remove it first if already exists, and then re-register
-        echo -e "Removing old jenkins runner $JENKINS_RUNNER_NAME:"
-        java -jar /usr/local/bin/jenkins-cli.jar -s "$JENKINS_URL" delete-node "$JENKINS_RUNNER_NAME"
-    fi
-
-    echo -e "Registering jenkins runner $JENKINS_RUNNER_NAME at master"
-        # shellcheck disable=SC2154
-        cat <<EOF | java -jar /usr/local/bin/jenkins-cli.jar -s "$JENKINS_URL" create-node "$JENKINS_RUNNER_NAME"
-            <slave>
-              <name>$JENKINS_RUNNER_NAME</name>
-              <description></description>
-              <remoteFS>/data/shop</remoteFS>
-              <numExecutors>$RUNNER_NUM_EXECUTORS</numExecutors>
-              <mode>NORMAL</mode>
-              <retentionStrategy class="hudson.slaves.RetentionStrategy$Always"/>
-              <launcher class="hudson.slaves.JNLPLauncher"/>
-              <label>backend</label>
-              <nodeProperties/>
-            </slave>
-EOF
 
     # link php where it is expected by cron.conf
     ln -s /usr/local/bin/php /usr/bin/php

--- a/src/spryker/docker/image/jenkins-runner/root/lib/task/jenkins/setup.sh
+++ b/src/spryker/docker/image/jenkins-runner/root/lib/task/jenkins/setup.sh
@@ -9,6 +9,8 @@ function task_jenkins_setup()
     curl -s "$JENKINS_URL/jnlpJars/jenkins-cli.jar" -o /usr/local/bin/jenkins-cli.jar
     curl -s "$JENKINS_URL/jnlpJars/slave.jar" -o /usr/local/bin/jenkins-slave.jar
 
+    JENKINS_RUNNER_NAME="$(hostname)"
+
     (java -jar /usr/local/bin/jenkins-cli.jar -s "$JENKINS_URL" get-node "$JENKINS_RUNNER_NAME" 2>&1 || true ) > /tmp/jenkins.node
 
     if ! grep ERROR: /tmp/jenkins.node >/dev/null; then
@@ -25,7 +27,7 @@ function task_jenkins_setup()
               <name>$JENKINS_RUNNER_NAME</name>
               <description></description>
               <remoteFS>/data/shop</remoteFS>
-              <numExecutors>3</numExecutors>
+              <numExecutors>$RUNNER_NUM_EXECUTORS</numExecutors>
               <mode>NORMAL</mode>
               <retentionStrategy class="hudson.slaves.RetentionStrategy$Always"/>
               <launcher class="hudson.slaves.JNLPLauncher"/>

--- a/src/spryker/docker/image/jenkins-runner/root/lib/task/jenkins/start.sh
+++ b/src/spryker/docker/image/jenkins-runner/root/lib/task/jenkins/start.sh
@@ -1,8 +1,23 @@
-#!/bin/bash
-
 # start jenkins runner
+
+function _trap_jenkins_exit()
+{
+    echo 'Terminating jenkins agent' >&2
+    kill -TERM $(jobs -p)
+    wait
+    app jenkins unregister
+}
+
 function task_jenkins_start()
 {
+    JENKINS_RUNNER_NAME=$(hostname)
+
+    trap _trap_jenkins_exit EXIT
+
+    app jenkins register
+
     java -jar /usr/local/bin/jenkins-cli.jar -s "$JENKINS_URL" offline-node ""
-    java -jar /usr/local/bin/jenkins-slave.jar -jnlpUrl "$JENKINS_URL/computer/$JENKINS_RUNNER_NAME/slave-agent.jnlp"
+    java -jar /usr/local/bin/jenkins-slave.jar -jnlpUrl "$JENKINS_URL/computer/$JENKINS_RUNNER_NAME/slave-agent.jnlp" &
+
+    wait
 }

--- a/src/spryker/docker/image/jenkins-runner/root/lib/task/jenkins/start.sh
+++ b/src/spryker/docker/image/jenkins-runner/root/lib/task/jenkins/start.sh
@@ -14,7 +14,7 @@ function task_jenkins_start()
 
     trap _trap_jenkins_exit EXIT
 
-    app jenkins register
+    app jenkins:register
 
     java -jar /usr/local/bin/jenkins-cli.jar -s "$JENKINS_URL" offline-node ""
     java -jar /usr/local/bin/jenkins-slave.jar -jnlpUrl "$JENKINS_URL/computer/$JENKINS_RUNNER_NAME/slave-agent.jnlp" &

--- a/src/spryker/docker/image/jenkins-runner/root/lib/task/jenkins/start.sh
+++ b/src/spryker/docker/image/jenkins-runner/root/lib/task/jenkins/start.sh
@@ -1,16 +1,18 @@
-# start jenkins runner
+#!/bin/bash
 
 function _trap_jenkins_exit()
 {
     echo 'Terminating jenkins agent' >&2
-    kill -TERM $(jobs -p)
+    local CHILD_PIDS
+    mapfile -t CHILD_PIDS < <(jobs -p)
+    kill -TERM "${CHILD_PIDS[@]}"
     wait
     app jenkins unregister
 }
 
 function task_jenkins_start()
 {
-    JENKINS_RUNNER_NAME=$(hostname)
+    local -r JENKINS_RUNNER_NAME=$(hostname)
 
     trap _trap_jenkins_exit EXIT
 

--- a/src/spryker/docker/image/jenkins-runner/root/lib/task/jenkins/unregister.sh
+++ b/src/spryker/docker/image/jenkins-runner/root/lib/task/jenkins/unregister.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+function task_jenkins_unregister()
+{
+    JENKINS_RUNNER_NAME="$(hostname)"
+
+    NODE_OUTPUT="$(java -jar /usr/local/bin/jenkins-cli.jar -s "$JENKINS_URL" get-node "$JENKINS_RUNNER_NAME" 2>&1 || true )"
+
+    if ! echo -n "$NODE_OUTPUT" | grep ERROR: >/dev/null; then
+        echo -e "Unregistering jenkins runner $JENKINS_RUNNER_NAME:"
+        java -jar /usr/local/bin/jenkins-cli.jar -s "$JENKINS_URL" delete-node "$JENKINS_RUNNER_NAME"
+    fi
+}

--- a/src/spryker/docker/image/jenkins-runner/root/lib/task/jenkins/unregister.sh
+++ b/src/spryker/docker/image/jenkins-runner/root/lib/task/jenkins/unregister.sh
@@ -2,9 +2,9 @@
 
 function task_jenkins_unregister()
 {
-    JENKINS_RUNNER_NAME="$(hostname)"
+    local -r JENKINS_RUNNER_NAME="$(hostname)"
 
-    NODE_OUTPUT="$(java -jar /usr/local/bin/jenkins-cli.jar -s "$JENKINS_URL" get-node "$JENKINS_RUNNER_NAME" 2>&1 || true )"
+    local -r NODE_OUTPUT="$(java -jar /usr/local/bin/jenkins-cli.jar -s "$JENKINS_URL" get-node "$JENKINS_RUNNER_NAME" 2>&1 || true )"
 
     if ! echo -n "$NODE_OUTPUT" | grep ERROR: >/dev/null; then
         echo -e "Unregistering jenkins runner $JENKINS_RUNNER_NAME:"

--- a/src/spryker/harness/attributes/docker.yml
+++ b/src/spryker/harness/attributes/docker.yml
@@ -16,7 +16,7 @@ attributes:
     jenkins-runner:
       publish: "= 'jenkins-runner' in @('app.services')"
       environment:
-        JENKINS_RUNNER_NAME: backend
+        RUNNER_NUM_EXECUTORS: 1
     nginx:
       environment:
         ZED_HOST: = @('zed.external_host')


### PR DESCRIPTION
It's much easier to ensure memory limits per container than per executor

Current settings and default memory limits cause OOM errors