### PR TITLE
Switch back to the default docker stop signal in cli images

### DIFF
--- a/src/_base/docker/image/console/Dockerfile.twig
+++ b/src/_base/docker/image/console/Dockerfile.twig
@@ -1,4 +1,6 @@
 FROM {{ @('docker.image.console') }}
+# fix upstream signal
+STOPSIGNAL SIGTERM
 
 COPY .my127ws/docker/image/console/root /
 RUN chown -R build:build /home/build \

--- a/src/_base/docker/image/cron/Dockerfile.twig
+++ b/src/_base/docker/image/cron/Dockerfile.twig
@@ -3,6 +3,8 @@ FROM {{ @('docker.repository') ~ ':' ~ @('app.version') }}-php-fpm
 {% else %}
 FROM {{ @('workspace.name') ~ '-php-fpm:dev' }}
 {% endif %}
+# fix upstream signal
+STOPSIGNAL SIGTERM
 
 # Install cron
 RUN apt-get update -qq \

--- a/src/akeneo/docker/image/console/Dockerfile.twig
+++ b/src/akeneo/docker/image/console/Dockerfile.twig
@@ -1,4 +1,6 @@
 FROM {{ @('docker.image.console') }}
+# fix upstream signal
+STOPSIGNAL SIGTERM
 
 COPY .my127ws/docker/image/console/root /
 RUN chown -R build:build /home/build \

--- a/src/magento2/docker/image/console/Dockerfile.twig
+++ b/src/magento2/docker/image/console/Dockerfile.twig
@@ -1,4 +1,6 @@
 FROM {{ @('docker.image.console') }}
+# fix upstream signal
+STOPSIGNAL SIGTERM
 
 COPY .my127ws/docker/image/console/root /
 RUN chown -R build:build /home/build \


### PR DESCRIPTION
Most cli processes don't trap SIGQUIT, so end up being SIGKILLed after 10 seconds of waiting with no graceful handling