### PR TITLE
Allow custom console and cron startup commands

### DIFF
--- a/src/_base/docker/image/console/Dockerfile.twig
+++ b/src/_base/docker/image/console/Dockerfile.twig
@@ -35,5 +35,6 @@ VOLUME /app
 VOLUME /home/build/application
 {% endif %}
 
+RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["sleep", "infinity"]

--- a/src/_base/docker/image/console/root/entrypoint.sh.twig
+++ b/src/_base/docker/image/console/root/entrypoint.sh.twig
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+setup_app_networking()
+{
+    # make linux consistent with docker-for-mac
+    if [ "${HOST_OS_FAMILY}" = "linux" ]; then
+        DOCKER_INTERNAL_HOST="host.docker.internal"
+        if ! grep $DOCKER_INTERNAL_HOST /etc/hosts > /dev/null ; then
+            DOCKER_INTERNAL_IP=$(/sbin/ip route|awk '/default/ { print $3 }')
+            echo -e "$DOCKER_INTERNAL_IP    $DOCKER_INTERNAL_HOST" | tee -a /etc/hosts > /dev/null
+        fi
+    fi
+}
+
+run_steps()
+{
+    # run any command required to be executed at docker startup
+    {% for step in @('console.entrypoint.steps') -%}
+    {{ step|raw }}
+    {% else -%}
+    :
+    {% endfor %}
+}
+
+bootstrap()
+{
+    setup_app_networking
+    run_steps
+}
+
+bootstrap
+
+if [ "${1:-}" == "sleep" ]; then
+    exec /sbin/tini -- bash -c "$(printf "%q " "$@")"
+else
+    exec /sbin/tini -- "$@"
+fi

--- a/src/_base/docker/image/cron/root/entrypoint.sh
+++ b/src/_base/docker/image/cron/root/entrypoint.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-# this is used to load env vars in crontab commands
-env > /app/env.sh
-
-# run
-crontab /crontab
-exec /sbin/tini -- cron -f -L 15

--- a/src/_base/docker/image/cron/root/entrypoint.sh.twig
+++ b/src/_base/docker/image/cron/root/entrypoint.sh.twig
@@ -12,15 +12,31 @@ setup_app_networking()
     fi
 }
 
+run_steps()
+{
+    # run any command required to be executed at docker startup
+    {% for step in @('cron.entrypoint.steps') -%}
+    {{ step|raw }}
+    {% else -%}
+    :
+    {% endfor %}
+}
+
+dump_environment_variables()
+{
+    # this is used to load env vars in crontab commands
+    env > /app/env.sh
+}
+
 bootstrap()
 {
     setup_app_networking
+    run_steps
+    dump_environment_variables
 }
 
 bootstrap
 
-if [ "${1:-}" == "sleep" ]; then
-    exec /sbin/tini -- bash -c "$(printf "%q " "$@")"
-else
-    exec /sbin/tini -- "$@"
-fi
+# run
+crontab /crontab
+exec /sbin/tini -- cron -f -L 15

--- a/src/_base/harness/attributes/common.yml
+++ b/src/_base/harness/attributes/common.yml
@@ -210,6 +210,14 @@ attributes.default:
     remote: ="s3://"~@("aws.bucket")~"/development"
     local: tools/assets/development
 
+  cron:
+    entrypoint:
+      steps: []
+
+  console:
+    entrypoint:
+      steps: []
+
   database:
     # possible platforms are mysql, postgres or ~ for none
     platform: mysql

--- a/src/_base/harness/config/confd.yml
+++ b/src/_base/harness/config/confd.yml
@@ -2,6 +2,7 @@
 confd('harness:/'):
   # base templates
   - { src: docker/image/console/Dockerfile }
+  - { src: docker/image/console/root/entrypoint.sh }
   - { src: docker/image/console/root/home/build/.my.cnf }
   - { src: docker/image/console/root/lib/task/database/import.sh }
   - { src: docker/image/console/root/lib/task/build/frontend.sh }
@@ -33,6 +34,7 @@ confd('harness:/'):
   - { src: docker/image/varnish/root/etc/varnish/default.vcl }
   - { src: docker/image/cron/Dockerfile }
   - { src: docker/image/cron/root/crontab }
+  - { src: docker/image/cron/root/entrypoint.sh }
   - { src: application/overlay/Jenkinsfile }
   - { src: application/overlay/auth.json }
   - { src: application/overlay/.dockerignore, dst: workspace:/.dockerignore }

--- a/src/akeneo/docker/image/console/Dockerfile.twig
+++ b/src/akeneo/docker/image/console/Dockerfile.twig
@@ -57,5 +57,6 @@ VOLUME /home/build/application
 
 ENV PATH "$PATH:/app/bin:/app/vendor/bin"
 
+RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["sleep", "infinity"]

--- a/src/akeneo/harness/config/confd.yml
+++ b/src/akeneo/harness/config/confd.yml
@@ -2,6 +2,7 @@
 confd('harness:/'):
   # base templates
   - { src: docker/image/console/Dockerfile }
+  - { src: docker/image/console/root/entrypoint.sh }
   - { src: docker/image/console/root/home/build/.my.cnf }
   - { src: docker/image/console/root/lib/task/database/import.sh }
   - { src: docker/image/console/root/lib/task/build/frontend.sh }
@@ -33,6 +34,7 @@ confd('harness:/'):
   - { src: docker/image/varnish/root/etc/varnish/default.vcl }
   - { src: docker/image/cron/Dockerfile }
   - { src: docker/image/cron/root/crontab }
+  - { src: docker/image/cron/root/entrypoint.sh }
   - { src: application/overlay/Jenkinsfile }
   - { src: application/overlay/auth.json }
   - { src: application/overlay/.dockerignore, dst: workspace:/.dockerignore }

--- a/src/drupal8/harness/config/confd.yml
+++ b/src/drupal8/harness/config/confd.yml
@@ -2,6 +2,7 @@
 confd('harness:/'):
   # base templates
   - { src: docker/image/console/Dockerfile }
+  - { src: docker/image/console/root/entrypoint.sh }
   - { src: docker/image/console/root/home/build/.my.cnf }
   - { src: docker/image/console/root/lib/task/database/import.sh }
   - { src: docker/image/console/root/lib/task/build/frontend.sh }
@@ -33,6 +34,7 @@ confd('harness:/'):
   - { src: docker/image/varnish/root/etc/varnish/default.vcl }
   - { src: docker/image/cron/Dockerfile }
   - { src: docker/image/cron/root/crontab }
+  - { src: docker/image/cron/root/entrypoint.sh }
   - { src: application/overlay/Jenkinsfile }
   - { src: application/overlay/auth.json }
   - { src: application/overlay/.dockerignore, dst: workspace:/.dockerignore }

--- a/src/magento1/harness/config/confd.yml
+++ b/src/magento1/harness/config/confd.yml
@@ -2,6 +2,7 @@
 confd('harness:/'):
   # base templates
   - { src: docker/image/console/Dockerfile }
+  - { src: docker/image/console/root/entrypoint.sh }
   - { src: docker/image/console/root/home/build/.my.cnf }
   - { src: docker/image/console/root/lib/task/database/import.sh }
   - { src: docker/image/console/root/lib/task/build/frontend.sh }
@@ -33,6 +34,7 @@ confd('harness:/'):
   - { src: docker/image/varnish/root/etc/varnish/default.vcl }
   - { src: docker/image/cron/Dockerfile }
   - { src: docker/image/cron/root/crontab }
+  - { src: docker/image/cron/root/entrypoint.sh }
   - { src: application/overlay/Jenkinsfile }
   - { src: application/overlay/auth.json }
   - { src: application/overlay/.dockerignore, dst: workspace:/.dockerignore }

--- a/src/magento2/docker/image/console/Dockerfile.twig
+++ b/src/magento2/docker/image/console/Dockerfile.twig
@@ -36,5 +36,6 @@ VOLUME /app
 VOLUME /home/build/application
 {% endif %}
 
+RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["sleep", "infinity"]

--- a/src/magento2/harness/config/confd.yml
+++ b/src/magento2/harness/config/confd.yml
@@ -2,6 +2,7 @@
 confd('harness:/'):
   # base templates
   - { src: docker/image/console/Dockerfile }
+  - { src: docker/image/console/root/entrypoint.sh }
   - { src: docker/image/console/root/home/build/.my.cnf }
   - { src: docker/image/console/root/lib/task/database/import.sh }
   - { src: docker/image/console/root/lib/task/build/frontend.sh }
@@ -33,6 +34,7 @@ confd('harness:/'):
   - { src: docker/image/varnish/root/etc/varnish/default.vcl }
   - { src: docker/image/cron/Dockerfile }
   - { src: docker/image/cron/root/crontab }
+  - { src: docker/image/cron/root/entrypoint.sh }
   - { src: application/overlay/Jenkinsfile }
   - { src: application/overlay/auth.json }
   - { src: application/overlay/.dockerignore, dst: workspace:/.dockerignore }

--- a/src/spryker/harness/config/confd.yml
+++ b/src/spryker/harness/config/confd.yml
@@ -2,6 +2,7 @@
 confd('harness:/'):
   # base templates
   - { src: docker/image/console/Dockerfile }
+  - { src: docker/image/console/root/entrypoint.sh }
   - { src: docker/image/console/root/home/build/.my.cnf }
   - { src: docker/image/console/root/lib/task/database/import.sh }
   - { src: docker/image/console/root/lib/task/build/frontend.sh }
@@ -33,6 +34,7 @@ confd('harness:/'):
   - { src: docker/image/varnish/root/etc/varnish/default.vcl }
   - { src: docker/image/cron/Dockerfile }
   - { src: docker/image/cron/root/crontab }
+  - { src: docker/image/cron/root/entrypoint.sh }
   - { src: application/overlay/Jenkinsfile }
   - { src: application/overlay/auth.json }
   - { src: application/overlay/.dockerignore, dst: workspace:/.dockerignore }

--- a/src/symfony/docker/image/console/Dockerfile.twig
+++ b/src/symfony/docker/image/console/Dockerfile.twig
@@ -36,5 +36,6 @@ VOLUME /app
 VOLUME /home/build/application
 {% endif %}
 
+RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["sleep", "infinity"]

--- a/src/symfony/harness/config/confd.yml
+++ b/src/symfony/harness/config/confd.yml
@@ -2,6 +2,7 @@
 confd('harness:/'):
   # base templates
   - { src: docker/image/console/Dockerfile }
+  - { src: docker/image/console/root/entrypoint.sh }
   - { src: docker/image/console/root/home/build/.my.cnf }
   - { src: docker/image/console/root/lib/task/database/import.sh }
   - { src: docker/image/console/root/lib/task/build/frontend.sh }
@@ -33,6 +34,7 @@ confd('harness:/'):
   - { src: docker/image/varnish/root/etc/varnish/default.vcl }
   - { src: docker/image/cron/Dockerfile }
   - { src: docker/image/cron/root/crontab }
+  - { src: docker/image/cron/root/entrypoint.sh }
   - { src: application/overlay/Jenkinsfile }
   - { src: application/overlay/auth.json }
   - { src: application/overlay/.dockerignore, dst: workspace:/.dockerignore }

--- a/src/wordpress/harness/config/confd.yml
+++ b/src/wordpress/harness/config/confd.yml
@@ -2,6 +2,7 @@
 confd('harness:/'):
   # base templates
   - { src: docker/image/console/Dockerfile }
+  - { src: docker/image/console/root/entrypoint.sh }
   - { src: docker/image/console/root/home/build/.my.cnf }
   - { src: docker/image/console/root/lib/task/database/import.sh }
   - { src: docker/image/console/root/lib/task/build/frontend.sh }
@@ -33,6 +34,7 @@ confd('harness:/'):
   - { src: docker/image/varnish/root/etc/varnish/default.vcl }
   - { src: docker/image/cron/Dockerfile }
   - { src: docker/image/cron/root/crontab }
+  - { src: docker/image/cron/root/entrypoint.sh }
   - { src: application/overlay/Jenkinsfile }
   - { src: application/overlay/auth.json }
   - { src: application/overlay/.dockerignore, dst: workspace:/.dockerignore }


### PR DESCRIPTION
Similar to the php-fpm docker image's customisable entrypoint.

This allows us to run commands on startup of containers, e.g. running envsubst or adding extra /etc/hosts entries.