### PR TITLE
Add secrets into argo sync wave 1

### DIFF
--- a/src/_base/helm/app/templates/_base_helper.tpl
+++ b/src/_base/helm/app/templates/_base_helper.tpl
@@ -30,8 +30,9 @@ kind: Secret
 {{ end }}
 metadata:
   name: {{ .Values.resourcePrefix }}{{ .service_name }}
-{{ if .Values.feature.sealed_secrets }}
   annotations:
+    argocd.argoproj.io/sync-wave: "1"
+{{ if .Values.feature.sealed_secrets }}
     sealedsecrets.bitnami.com/cluster-wide: "true"
 spec:
   encryptedData:

--- a/src/_base/helm/app/templates/application/image-pull-config.yaml
+++ b/src/_base/helm/app/templates/application/image-pull-config.yaml
@@ -9,7 +9,7 @@ kind: Secret
 metadata:
   name: {{ .Values.resourcePrefix }}image-pull-config
   annotations:
-    argocd.argoproj.io/sync-wave: "4"
+    argocd.argoproj.io/sync-wave: "1"
 {{ if .Values.feature.sealed_secrets }}
     sealedsecrets.bitnami.com/cluster-wide: "true"
 spec:


### PR DESCRIPTION
So before app jobs but with enough room for resources in between that need to be before the jobs, but higher than 0 in case sealed-secrets itself is part of the release