### PR TITLE
Recreate services that use persistent volumes to avoid multi-node usage attempts

### DIFF
--- a/src/_base/helm/app/templates/service/elasticsearch/deployment.yaml
+++ b/src/_base/helm/app/templates/service/elasticsearch/deployment.yaml
@@ -10,6 +10,10 @@ spec:
   selector:
     matchLabels:
       app.service: {{ .Values.resourcePrefix }}elasticsearch
+{{- if .Values.persistence.elasticsearch.enabled }}
+  strategy:
+    type: Recreate
+{{- end }}
   template:
     metadata:
       labels:

--- a/src/_base/helm/app/templates/service/mysql/deployment.yaml
+++ b/src/_base/helm/app/templates/service/mysql/deployment.yaml
@@ -10,6 +10,10 @@ spec:
   selector:
     matchLabels:
       app.service: {{ .Values.resourcePrefix }}mysql
+{{- if .Values.persistence.mysql.enabled }}
+  strategy:
+    type: Recreate
+{{- end }}
   template:
     metadata:
       labels:

--- a/src/_base/helm/app/templates/service/postgres/deployment.yaml
+++ b/src/_base/helm/app/templates/service/postgres/deployment.yaml
@@ -10,6 +10,10 @@ spec:
   selector:
     matchLabels:
       app.service: {{ .Values.resourcePrefix }}postgres
+{{- if .Values.persistence.postgres.enabled }}
+  strategy:
+    type: Recreate
+{{- end }}
   template:
     metadata:
       labels:

--- a/src/_base/helm/app/templates/service/rabbitmq/deployment.yaml
+++ b/src/_base/helm/app/templates/service/rabbitmq/deployment.yaml
@@ -10,8 +10,10 @@ spec:
   selector:
     matchLabels:
       app.service: {{ .Values.resourcePrefix }}rabbitmq
+{{- if .Values.persistence.rabbitmq.enabled }}
   strategy:
     type: Recreate
+{{- end }}
   template:
     metadata:
       labels:

--- a/src/_base/helm/app/templates/service/redis-session/deployment.yaml
+++ b/src/_base/helm/app/templates/service/redis-session/deployment.yaml
@@ -10,6 +10,10 @@ spec:
   selector:
     matchLabels:
       app.service: {{ .Values.resourcePrefix }}redis-session
+{{- if .Values.persistence.redis_session.enabled }}
+  strategy:
+    type: Recreate
+{{- end }}
   template:
     metadata:
       labels:

--- a/src/_base/helm/app/templates/service/redis/deployment.yaml
+++ b/src/_base/helm/app/templates/service/redis/deployment.yaml
@@ -10,6 +10,10 @@ spec:
   selector:
     matchLabels:
       app.service: {{ .Values.resourcePrefix }}redis
+{{- if .Values.persistence.redis.enabled }}
+  strategy:
+    type: Recreate
+{{- end }}
   template:
     metadata:
       creationTimestamp: null


### PR DESCRIPTION
Read Write Once volumes can't be used on multiple nodes in digitalocean kubernetes or google kubernetes engine.

Any deployment spec changes for services such as mysql fail to launch when using rolling update with a RWO persistent volume attached and manual intervention is needed to scale down the service, then back up.