### PR TITLE
Support Docker Desktop Edge 2.3.5.0 which ships with grpcFUSE filesystem drivers

### DIFF
--- a/src/_base/docker/image/console/root/entrypoint.dynamic.sh
+++ b/src/_base/docker/image/console/root/entrypoint.dynamic.sh
@@ -29,6 +29,8 @@ resolve_volume_mount_strategy()
     elif [ "${HOST_OS_FAMILY}" = "darwin" ]; then
         if (mount | grep "/app type fuse.osxfs") > /dev/null 2>&1; then
             STRATEGY="host-osx-normal"
+        elif (mount | grep "/app type fuse.grpcfuse") > /dev/null 2>&1; then
+            STRATEGY="host-osx-normal"
         elif (mount | grep "/app type ext4") > /dev/null 2>&1; then
             STRATEGY="host-osx-dockersync"
         elif (mount | grep "/app type btrfs") > /dev/null 2>&1; then

--- a/src/_base/docker/image/php-fpm/root/entrypoint.dynamic.sh
+++ b/src/_base/docker/image/php-fpm/root/entrypoint.dynamic.sh
@@ -44,6 +44,8 @@ resolve_volume_mount_strategy()
     elif [ "${HOST_OS_FAMILY}" = "darwin" ]; then
         if (mount | grep "/app type fuse.osxfs") > /dev/null 2>&1; then
             STRATEGY="host-osx-normal"
+        elif (mount | grep "/app type fuse.grpcfuse") > /dev/null 2>&1; then
+            STRATEGY="host-osx-normal"
         elif (mount | grep "/app type ext4") > /dev/null 2>&1; then
             STRATEGY="host-osx-dockersync"
         elif (mount | grep "/app type btrfs") > /dev/null 2>&1; then


### PR DESCRIPTION
Avoids exiting with exit code 1 in the entrypoint.