### PR TITLE
Updating phpcs rules to allow void return type.

### DIFF
--- a/src/drupal8/application/overlay/phpcs.xml.twig
+++ b/src/drupal8/application/overlay/phpcs.xml.twig
@@ -42,6 +42,9 @@
   <rule ref="Drupal.Commenting.FunctionComment.MissingReturnComment">
     <severity>0</severity>
   </rule>
+  <rule ref="Drupal.Commenting.FunctionComment.VoidReturn">
+    <severity>0</severity>
+  </rule>
 
   <!--
   Annotations should be imported, not expanded


### PR DESCRIPTION
Adding a void return typehint is required by phpstan but results in a code sniffer error.