### PR TITLE
Handle service enabled/image as services attributes

### DIFF
--- a/src/_base/_twig/docker-compose.yml/application.yml.twig
+++ b/src/_base/_twig/docker-compose.yml/application.yml.twig
@@ -21,7 +21,7 @@
       - ./.my127ws/docker/image/console/root/lib/task:/lib/task
       - ./.my127ws:/.my127ws
 {% else %}
-    image: {{ @('docker.repository') ~ ':' ~ @('app.version') ~ '-console' }}
+    image: {{ @('services.console.image') }}
 {% endif %}
     labels:
       - traefik.enable=false
@@ -41,7 +41,7 @@
     volumes:
       - {{ (syncvolume) ? @('workspace.name') ~ '-sync:/app:nocopy' : ('./:/app' ~ @('docker.compose.host_volume_options'))  }}
 {% else %}
-    image: {{ @('docker.repository') ~ ':' ~ @('app.version') ~ '-nginx' }}
+    image: {{ @('services.nginx.image') }}
 {% endif %}
     labels:
 {% if 'varnish' not in @('app.services') %}
@@ -80,7 +80,7 @@
       - {{ (syncvolume) ? @('workspace.name') ~ '-sync:/app:nocopy' : ('./:/app' ~ @('docker.compose.host_volume_options')) }}
       - ./.my127ws:/.my127ws
 {% else %}
-    image: {{ @('docker.repository') ~ ':' ~ @('app.version') ~ '-php-fpm' }}
+    image: {{ @('services.php-fpm.image') }}
 {% endif %}
     labels:
       - traefik.enable=false

--- a/src/_base/_twig/docker-compose.yml/service/cron.yml.twig
+++ b/src/_base/_twig/docker-compose.yml/service/cron.yml.twig
@@ -7,7 +7,7 @@
       - {{ (syncvolume) ? @('workspace.name') ~ '-sync:/app:nocopy' : ('./:/app' ~ @('docker.compose.host_volume_options')) }}
       - ./.my127ws/application:/home/build/application
 {% else %}
-    image: {{ @('docker.repository') ~ ':' ~ @('app.version') ~ '-cron' }}
+    image: {{ @('services.cron.image') }}
 {% endif %}
     environment: {{ to_nice_yaml(deep_merge([
         @('services.php-base.environment'),

--- a/src/_base/_twig/docker-compose.yml/service/elasticsearch.yml.twig
+++ b/src/_base/_twig/docker-compose.yml/service/elasticsearch.yml.twig
@@ -1,5 +1,5 @@
   elasticsearch:
-    image: {{ @('elasticsearch.image') }}:{{ @('elasticsearch.tag') }}
+    image: {{ @('services.elasticsearch.image') }}
     labels:
       - traefik.enable=false
     environment:

--- a/src/_base/_twig/docker-compose.yml/service/memcached.yml.twig
+++ b/src/_base/_twig/docker-compose.yml/service/memcached.yml.twig
@@ -1,5 +1,5 @@
   memcached:
-    image: memcached:1-alpine
+    image: {{ @('services.memcached.image') }}
     labels:
       - traefik.enable=false
     networks:

--- a/src/_base/_twig/docker-compose.yml/service/mysql.yml.twig
+++ b/src/_base/_twig/docker-compose.yml/service/mysql.yml.twig
@@ -3,7 +3,7 @@
     {% set command = command|merge(['--' ~ var ~ '=' ~ value]) %}
 {% endfor %}
   mysql:
-    image: {{ @('mysql.image') }}:{{ @('mysql.tag') }}
+    image: {{ @('services.mysql.image') }}
     labels:
       - traefik.enable=false
 {% if command|length %}

--- a/src/_base/_twig/docker-compose.yml/service/php-fpm-exporter.yml.twig
+++ b/src/_base/_twig/docker-compose.yml/service/php-fpm-exporter.yml.twig
@@ -1,5 +1,5 @@
   php-fpm-exporter:
-    image: hipages/php-fpm_exporter
+    image: {{ @('services.php-fpm-exporter.image') }}
     environment: {{ to_nice_yaml(deep_merge([
         @('services.php-fpm-exporter.environment'),
         @('services.php-fpm-exporter.environment_secrets')

--- a/src/_base/_twig/docker-compose.yml/service/postgres.yml.twig
+++ b/src/_base/_twig/docker-compose.yml/service/postgres.yml.twig
@@ -1,5 +1,5 @@
   postgres:
-    image: postgres:9.6
+    image: {{ @('services.postgres.image') }}
     labels:
       - traefik.enable=false
     environment: {{ to_nice_yaml(deep_merge([

--- a/src/_base/_twig/docker-compose.yml/service/rabbitmq.yml.twig
+++ b/src/_base/_twig/docker-compose.yml/service/rabbitmq.yml.twig
@@ -1,5 +1,5 @@
   rabbitmq:
-    image: {{ @('rabbitmq.image') }}:{{ @('rabbitmq.tag') }}
+    image: {{ @('services.rabbitmq.image') }}
     environment: {{ to_nice_yaml(deep_merge([
         @('services.rabbitmq.environment'),
         @('services.rabbitmq.environment_secrets')

--- a/src/_base/_twig/docker-compose.yml/service/redis-session.yml.twig
+++ b/src/_base/_twig/docker-compose.yml/service/redis-session.yml.twig
@@ -1,5 +1,5 @@
   redis-session:
-    image: redis:4-alpine
+    image: {{ @('services.redis_session.image') }}
     # 1GB; evict key that would expire soonest
     command: redis-server --maxmemory 1073742000 --maxmemory-policy volatile-ttl --save 3600 1 --save 300 100 --save 60 10000
     labels:

--- a/src/_base/_twig/docker-compose.yml/service/redis.yml.twig
+++ b/src/_base/_twig/docker-compose.yml/service/redis.yml.twig
@@ -1,5 +1,5 @@
   redis:
-    image: redis:4-alpine
+    image: {{ @('services.redis.image')  }}
     # 1GB; evict any least recently used key even if they don't have a TTL
     command: redis-server --maxmemory 1073742000 --maxmemory-policy allkeys-lru --save 3600 1 --save 300 100 --save 60 10000
     labels:

--- a/src/_base/_twig/docker-compose.yml/service/varnish.yml.twig
+++ b/src/_base/_twig/docker-compose.yml/service/varnish.yml.twig
@@ -2,7 +2,7 @@
 {% set hostnames = [@('hostname')] %}
 {% set hostnames = hostnames|merge(@('hostname_aliases')|map(alias => "#{alias}." ~ @('domain'))) %}
   varnish:
-    image: varnish:6
+    image: {{ @('services.varnish.image') }}
     labels:
       - traefik.backend={{ @('workspace.name') }}
       - traefik.frontend.rule=Host:{{ hostnames|join(',') }}

--- a/src/_base/harness/attributes/docker-base.yml
+++ b/src/_base/harness/attributes/docker-base.yml
@@ -27,11 +27,13 @@ attributes:
         DB_PASS: = @('database.pass')
         RABBITMQ_PASSWORD: = @('rabbitmq.password')
     nginx:
+      image: = @('docker.repository') ~ ':' ~ @('app.version') ~ '-nginx'
       publish: true
       environment:
         FPM_HOST: php-fpm
     console:
       enabled: true
+      image: = @('docker.repository') ~ ':' ~ @('app.version') ~ '-console'
       publish: true
       environment:
         DB_ADMIN_USER: root
@@ -40,20 +42,26 @@ attributes:
         DB_ADMIN_PASS: = @('database.root_pass')
     cron:
       enabled: "= 'cron' in @('app.services')"
+      image: = @('docker.repository') ~ ':' ~ @('app.version') ~ '-cron'
       publish: "= 'cron' in @('app.services')"
     php-fpm:
+      image: = @('docker.repository') ~ ':' ~ @('app.version') ~ '-php-fpm'
       publish: true
       environment:
         AUTOSTART_PHP_FPM: "true"
     php-fpm-exporter:
+      image: hipages/php-fpm_exporter
       environment:
         PHP_FPM_SCRAPE_URI: = php_fpm_exporter_scrape_url('php-fpm', @('php-fpm.pools'))
     elasticsearch:
       enabled: "= 'elasticsearch' in @('app.services')"
+      image: = @('elasticsearch.image') ~ ':' ~ @('elasticsearch.tag')
     memcached:
       enabled: "= 'memcached' in @('app.services')"
+      image: memcached:1-alpine
     mysql:
       enabled: "= 'mysql' in @('app.services')"
+      image: = @('mysql.image') ~ ':' ~ @('mysql.tag')
       environment:
         MYSQL_DATABASE: = @('database.name')
         MYSQL_USER: = @('database.user')
@@ -62,6 +70,7 @@ attributes:
         MYSQL_ROOT_PASSWORD: = @('database.root_pass')
     postgres:
       enabled: "= 'postgres' in @('app.services')"
+      image: postgres:9.6
       environment:
         POSTGRES_DB: = @('database.name')
         POSTGRES_USER: = @('database.user')
@@ -70,19 +79,22 @@ attributes:
         POSTGRES_PASSWORD: = @('database.pass')
     rabbitmq:
       enabled: "= 'rabbitmq' in @('app.services')"
+      image: = @('rabbitmq.image') ~ ':' ~ @('rabbitmq.tag')
       environment:
         RABBITMQ_DEFAULT_USER: = @('rabbitmq.user')
         RABBITMQ_DEFAULT_VHOST: = @('rabbitmq.vhosts.default')
       environment_secrets:
         RABBITMQ_DEFAULT_PASS: = @('rabbitmq.password')
         RABBITMQ_ERLANG_COOKIE: = @('rabbitmq.erlang_cookie')
-      environment: []
     redis:
       enabled: "= 'redis' in @('app.services')"
+      image: redis:4-alpine
     redis_session:
       enabled: "= 'redis_session' in @('app.services')"
+      image: redis:4-alpine
     varnish:
       enabled: "= 'varnish' in @('app.services')"
+      image: varnish:6
       environment:
         VARNISH_SIZE: "1024M"
   pipeline:

--- a/src/_base/harness/attributes/docker-base.yml
+++ b/src/_base/harness/attributes/docker-base.yml
@@ -38,6 +38,9 @@ attributes:
         HAS_VARNISH: "= ('varnish' in @('app.services') ? 'true' : 'false')"
       environment_secrets:
         DB_ADMIN_PASS: = @('database.root_pass')
+    cron:
+      enabled: "= 'cron' in @('app.services')"
+      publish: "= 'cron' in @('app.services')"
     php-fpm:
       publish: true
       environment:
@@ -45,31 +48,41 @@ attributes:
     php-fpm-exporter:
       environment:
         PHP_FPM_SCRAPE_URI: = php_fpm_exporter_scrape_url('php-fpm', @('php-fpm.pools'))
+    elasticsearch:
+      enabled: "= 'elasticsearch' in @('app.services')"
+    memcached:
+      enabled: "= 'memcached' in @('app.services')"
     mysql:
+      enabled: "= 'mysql' in @('app.services')"
       environment:
         MYSQL_DATABASE: = @('database.name')
         MYSQL_USER: = @('database.user')
       environment_secrets:
         MYSQL_PASSWORD: = @('database.pass')
         MYSQL_ROOT_PASSWORD: = @('database.root_pass')
-    rabbitmq:
-      environment:
-        RABBITMQ_DEFAULT_USER: = @('rabbitmq.user')
-        RABBITMQ_DEFAULT_VHOST: = @('rabbitmq.vhosts.default')
-      environment_secrets:
-        RABBITMQ_DEFAULT_PASS: = @('rabbitmq.password')
-        RABBITMQ_ERLANG_COOKIE: = @('rabbitmq.erlang_cookie')
     postgres:
+      enabled: "= 'postgres' in @('app.services')"
       environment:
         POSTGRES_DB: = @('database.name')
         POSTGRES_USER: = @('database.user')
         PGDATA: /var/lib/postgresql/data/pgdata
       environment_secrets:
         POSTGRES_PASSWORD: = @('database.pass')
-    cron:
-      publish: "= 'cron' in @('app.services')"
+    rabbitmq:
+      enabled: "= 'rabbitmq' in @('app.services')"
+      environment:
+        RABBITMQ_DEFAULT_USER: = @('rabbitmq.user')
+        RABBITMQ_DEFAULT_VHOST: = @('rabbitmq.vhosts.default')
+      environment_secrets:
+        RABBITMQ_DEFAULT_PASS: = @('rabbitmq.password')
+        RABBITMQ_ERLANG_COOKIE: = @('rabbitmq.erlang_cookie')
       environment: []
+    redis:
+      enabled: "= 'redis' in @('app.services')"
+    redis_session:
+      enabled: "= 'redis_session' in @('app.services')"
     varnish:
+      enabled: "= 'varnish' in @('app.services')"
       environment:
         VARNISH_SIZE: "1024M"
   pipeline:
@@ -107,7 +120,22 @@ attributes:
         gateways:
           - "istio-system/{{ .Release.Namespace }}-gateway"
         additionalGateways: []
-    production: {}
+    production:
+      # assumption is that in a production style environment these would be
+      # managed services outside of the applications control
+      services:
+        elasticsearch:
+          enabled: false
+        memcached:
+          enabled: false
+        mysql:
+          enabled: false
+        postgres:
+          enabled: false
+        redis:
+          enabled: false
+        redis_session:
+          enabled: false
     qa:
       services:
         php-base:

--- a/src/_base/harness/config/functions.yml
+++ b/src/_base/harness/config/functions.yml
@@ -85,8 +85,9 @@ function('filter_local_services', [services]): |
     $filteredService = [];
     foreach ($service as $key => $value) {
       switch ($key) {
-        case 'environment':
         case 'enabled':
+        case 'environment':
+        case 'image':
           $filteredService[$key] = $value;
       }
     }

--- a/src/_base/helm/app/_twig/templates/service/varnish/configmap.yaml.twig
+++ b/src/_base/helm/app/_twig/templates/service/varnish/configmap.yaml.twig
@@ -1,6 +1,6 @@
 {% set blocks  = 'docker/image/varnish/root/etc/varnish/' %}
 {% verbatim %}
-{{ if .Values.service.varnish }}
+{{ if .Values.service.varnish | default .Values.docker.services.varnish.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/src/_base/helm/app/templates/_base_helper.tpl
+++ b/src/_base/helm/app/templates/_base_helper.tpl
@@ -20,7 +20,7 @@
 {{- end }}
 
 {{- define "service.environment.secret" }}
-{{ if .service.environment_secrets }}
+{{ if and .service.environment_secrets (.service.enabled | default true) }}
 {{ if .Values.feature.sealed_secrets }}
 apiVersion: bitnami.com/v1alpha1
 kind: SealedSecret

--- a/src/_base/helm/app/templates/application/app-init.yaml
+++ b/src/_base/helm/app/templates/application/app-init.yaml
@@ -30,7 +30,7 @@ spec:
           - secretRef:
               name: {{ .Values.resourcePrefix }}console
         {{- end }}
-        image: {{ .Values.docker.image.console }}
+        image: {{ .Values.docker.image.console | default $service.image | quote }}
         imagePullPolicy: Always
         name: app-init
 {{ if eq .Values.ingress.type "istio" }}

--- a/src/_base/helm/app/templates/application/app-migrate.yaml
+++ b/src/_base/helm/app/templates/application/app-migrate.yaml
@@ -28,7 +28,7 @@ spec:
           - secretRef:
               name: {{ .Values.resourcePrefix }}console
         {{- end }}
-        image: {{ .Values.docker.image.console }}
+        image: {{ .Values.docker.image.console | default $service.image }}
         imagePullPolicy: Always
         name: app-migrate
 {{ if eq .Values.ingress.type "istio" }}

--- a/src/_base/helm/app/templates/application/console/deployment.yaml
+++ b/src/_base/helm/app/templates/application/console/deployment.yaml
@@ -35,7 +35,7 @@ spec:
           - secretRef:
               name: {{ .Values.resourcePrefix }}console
         {{- end }}
-        image: {{ .Values.docker.image.console }}
+        image: {{ .Values.docker.image.console | default $service.image }}
         imagePullPolicy: Always
         name: console
         resources:

--- a/src/_base/helm/app/templates/application/cron/deployment.yaml
+++ b/src/_base/helm/app/templates/application/cron/deployment.yaml
@@ -1,5 +1,5 @@
-{{- if .Values.service.cron -}}
 {{- $service := mergeOverwrite (dict) (index .Values.docker.services "php-base") (index .Values.docker.services "cron") (dict "environment" .Values.environment) -}}
+{{- if .Values.service.cron | default $service.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/src/_base/helm/app/templates/application/cron/deployment.yaml
+++ b/src/_base/helm/app/templates/application/cron/deployment.yaml
@@ -52,7 +52,7 @@ spec:
           - secretRef:
               name: {{ .Values.resourcePrefix }}cron
         {{- end }}
-        image: {{ .Values.docker.image.cron }}
+        image: {{ .Values.docker.image.cron | default $service.image }}
         imagePullPolicy: Always
         resources:
           limits:

--- a/src/_base/helm/app/templates/application/webapp/deployment.yaml
+++ b/src/_base/helm/app/templates/application/webapp/deployment.yaml
@@ -51,7 +51,7 @@ spec:
           - secretRef:
               name: {{ .Values.resourcePrefix }}nginx
         {{- end }}
-        image: {{ .Values.docker.image.nginx }}
+        image: {{ .Values.docker.image.nginx | default .Values.docker.services.nginx.image }}
         imagePullPolicy: Always
         ports:
         - name: http
@@ -88,7 +88,7 @@ spec:
           - secretRef:
               name: {{ .Values.resourcePrefix }}php-fpm
         {{- end }}
-        image: {{ .Values.docker.image.fpm }}
+        image: {{ .Values.docker.image.fpm | default $service_php_fpm.image | quote }}
         imagePullPolicy: Always
         ports:
         - containerPort: 9000
@@ -121,7 +121,7 @@ spec:
           value: {{ $value | quote }}
         {{- end }}
         {{- end }}
-        image: hipages/php-fpm_exporter
+        image: {{ index .Values.docker.services "php-fpm-exporter" "image" | quote }}
         imagePullPolicy: Always
         ports:
         - name: php-fpm-metrics

--- a/src/_base/helm/app/templates/application/webapp/deployment.yaml
+++ b/src/_base/helm/app/templates/application/webapp/deployment.yaml
@@ -109,7 +109,7 @@ spec:
         {{- else }} []
         {{- end }}
 
-      {{ if .Values.service.php_fpm_exporter }}
+      {{ if .Values.service.php_fpm_exporter | default (index .Values.docker.services "php-fpm-exporter" "enabled") }}
       - name: php-fpm-exporter
         env:
         {{- range $key, $value := index .Values.docker.services "php-fpm-exporter" "environment" }}

--- a/src/_base/helm/app/templates/application/webapp/podmonitor.yaml
+++ b/src/_base/helm/app/templates/application/webapp/podmonitor.yaml
@@ -13,7 +13,7 @@ spec:
 {{- if .Values.docker.services.nginx.metricsEnabled -}}
 {{ .Values.docker.services.nginx.metricsEndpoints | toYaml | nindent 6 -}}
 {{- end -}}
-{{- if and .Values.service.php_fpm_exporter (index .Values.docker.services "php-fpm-exporter" "metricsEnabled") -}}
+{{- if and (.Values.service.php_fpm_exporter | default (index .Values.docker.services "php-fpm-exporter" "enabled")) (index .Values.docker.services "php-fpm-exporter" "metricsEnabled") -}}
 {{ index .Values.docker.services "php-fpm-exporter" "metricsEndpoints" | toYaml | nindent 6 -}}
 {{- end -}}
 {{- end -}}

--- a/src/_base/helm/app/templates/service/elasticsearch/deployment.yaml
+++ b/src/_base/helm/app/templates/service/elasticsearch/deployment.yaml
@@ -25,7 +25,7 @@ spec:
           value: -Xmx512m -Xms512m
         - name: discovery.type
           value: single-node
-        image: {{ .Values.docker.image.elasticsearch }}
+        image: {{ .Values.docker.image.elasticsearch | default .Values.docker.services.elasticsearch.image | quote }}
         imagePullPolicy: Always
         name: elasticsearch
         ports:

--- a/src/_base/helm/app/templates/service/elasticsearch/deployment.yaml
+++ b/src/_base/helm/app/templates/service/elasticsearch/deployment.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.service.elasticsearch }}
+{{ if .Values.service.elasticsearch | default .Values.docker.services.elasticsearch.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/src/_base/helm/app/templates/service/elasticsearch/pvc.yaml
+++ b/src/_base/helm/app/templates/service/elasticsearch/pvc.yaml
@@ -1,4 +1,4 @@
-{{ if and .Values.service.elasticsearch .Values.persistence.elasticsearch.enabled -}}
+{{ if and .Values.persistence.elasticsearch.enabled (.Values.service.elasticsearch | default .Values.docker.services.elasticsearch.enabled) -}}
 
 {{- with .Values.persistence.elasticsearch -}}
 

--- a/src/_base/helm/app/templates/service/elasticsearch/service.yaml
+++ b/src/_base/helm/app/templates/service/elasticsearch/service.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.service.elasticsearch }}
+{{ if .Values.service.elasticsearch | default .Values.docker.services.elasticsearch.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/src/_base/helm/app/templates/service/mysql/deployment.yaml
+++ b/src/_base/helm/app/templates/service/mysql/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           - secretRef:
               name: {{ .Values.resourcePrefix }}mysql
         {{- end }}
-        image: {{ .Values.docker.image.mysql }}
+        image: {{ .Values.docker.image.mysql | default .Values.docker.services.mysql.image | quote }}
         imagePullPolicy: Always
         name: mysql
         args:

--- a/src/_base/helm/app/templates/service/mysql/deployment.yaml
+++ b/src/_base/helm/app/templates/service/mysql/deployment.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.service.mysql }}
+{{ if .Values.service.mysql | default .Values.docker.services.mysql.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/src/_base/helm/app/templates/service/mysql/pvc.yaml
+++ b/src/_base/helm/app/templates/service/mysql/pvc.yaml
@@ -1,4 +1,4 @@
-{{ if and .Values.service.mysql .Values.persistence.mysql.enabled -}}
+{{ if and .Values.persistence.mysql.enabled (.Values.service.mysql | default .Values.docker.services.mysql.enabled) -}}
 
 {{- with .Values.persistence.mysql -}}
 

--- a/src/_base/helm/app/templates/service/mysql/service.yaml
+++ b/src/_base/helm/app/templates/service/mysql/service.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.service.mysql }}
+{{ if .Values.service.mysql | default .Values.docker.services.mysql.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/src/_base/helm/app/templates/service/postgres/deployment.yaml
+++ b/src/_base/helm/app/templates/service/postgres/deployment.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.service.postgres }}
+{{ if .Values.service.postgres | default .Values.docker.services.postgres.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/src/_base/helm/app/templates/service/postgres/deployment.yaml
+++ b/src/_base/helm/app/templates/service/postgres/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           - secretRef:
               name: {{ .Values.resourcePrefix }}postgres
         {{- end }}
-        image: postgres:9.6
+        image: {{ .Values.docker.services.postgres.image | quote }}
         imagePullPolicy: Always
         name: postgres
         ports:

--- a/src/_base/helm/app/templates/service/postgres/pvc.yaml
+++ b/src/_base/helm/app/templates/service/postgres/pvc.yaml
@@ -1,4 +1,4 @@
-{{ if and .Values.service.postgres .Values.persistence.postgres.enabled -}}
+{{ if and .Values.persistence.postgres.enabled (.Values.service.postgres | default .Values.docker.services.postgres.enabled) -}}
 
 {{- with .Values.persistence.postgres -}}
 

--- a/src/_base/helm/app/templates/service/postgres/service.yaml
+++ b/src/_base/helm/app/templates/service/postgres/service.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.service.postgres }}
+{{ if .Values.service.postgres | default .Values.docker.services.postgres.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/src/_base/helm/app/templates/service/rabbitmq/deployment.yaml
+++ b/src/_base/helm/app/templates/service/rabbitmq/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           - secretRef:
               name: {{ .Values.resourcePrefix }}rabbitmq
         {{- end }}
-        image: {{ .Values.docker.image.rabbitmq }}
+        image: {{ .Values.docker.image.rabbitmq | default .Values.docker.services.rabbitmq.image | quote }}
         imagePullPolicy: Always
         name: rabbitmq
         ports:

--- a/src/_base/helm/app/templates/service/rabbitmq/deployment.yaml
+++ b/src/_base/helm/app/templates/service/rabbitmq/deployment.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.service.rabbitmq }}
+{{ if .Values.service.rabbitmq | default .Values.docker.services.rabbitmq.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/src/_base/helm/app/templates/service/rabbitmq/pvc.yaml
+++ b/src/_base/helm/app/templates/service/rabbitmq/pvc.yaml
@@ -1,4 +1,4 @@
-{{ if and .Values.service.rabbitmq .Values.persistence.rabbitmq.enabled -}}
+{{ if and .Values.persistence.rabbitmq.enabled (.Values.service.rabbitmq | default .Values.docker.services.rabbitmq.enabled) -}}
 
 {{- with .Values.persistence.rabbitmq -}}
 

--- a/src/_base/helm/app/templates/service/rabbitmq/service.yaml
+++ b/src/_base/helm/app/templates/service/rabbitmq/service.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.service.rabbitmq }}
+{{ if .Values.service.rabbitmq | default .Values.docker.services.rabbitmq.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/src/_base/helm/app/templates/service/redis-session/deployment.yaml
+++ b/src/_base/helm/app/templates/service/redis-session/deployment.yaml
@@ -35,7 +35,7 @@ spec:
         - --save
         - "60"
         - "10000"
-        image: redis:4-alpine
+        image: {{ .Values.docker.services.redis_session.image | quote }}
         imagePullPolicy: Always
         name: redis-session
         ports:

--- a/src/_base/helm/app/templates/service/redis-session/deployment.yaml
+++ b/src/_base/helm/app/templates/service/redis-session/deployment.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.service.redis_session }}
+{{ if .Values.service.redis_session | default .Values.docker.services.redis_session.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/src/_base/helm/app/templates/service/redis-session/pvc.yaml
+++ b/src/_base/helm/app/templates/service/redis-session/pvc.yaml
@@ -1,4 +1,4 @@
-{{ if and .Values.service.redis_session .Values.persistence.redis_session.enabled -}}
+{{ if and .Values.persistence.redis_session.enabled (.Values.service.redis_session | default .Values.docker.services.redis_session.enabled) -}}
 
 {{- with .Values.persistence.redis_session -}}
 

--- a/src/_base/helm/app/templates/service/redis-session/service.yaml
+++ b/src/_base/helm/app/templates/service/redis-session/service.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.service.redis_session }}
+{{ if .Values.service.redis_session | default .Values.docker.services.redis_session.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/src/_base/helm/app/templates/service/redis/deployment.yaml
+++ b/src/_base/helm/app/templates/service/redis/deployment.yaml
@@ -36,7 +36,7 @@ spec:
         - --save
         - "60"
         - "10000"
-        image: redis:4-alpine
+        image: {{ .Values.docker.services.redis.image | quote }}
         imagePullPolicy: Always
         name: redis
         ports:

--- a/src/_base/helm/app/templates/service/redis/deployment.yaml
+++ b/src/_base/helm/app/templates/service/redis/deployment.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.service.redis }}
+{{ if .Values.service.redis | default .Values.docker.services.redis.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/src/_base/helm/app/templates/service/redis/pvc.yaml
+++ b/src/_base/helm/app/templates/service/redis/pvc.yaml
@@ -1,4 +1,4 @@
-{{ if and .Values.service.redis .Values.persistence.redis.enabled -}}
+{{ if and .Values.persistence.redis.enabled (.Values.service.redis | default .Values.docker.services.redis.enabled) -}}
 
 {{- with .Values.persistence.redis -}}
 

--- a/src/_base/helm/app/templates/service/redis/service.yaml
+++ b/src/_base/helm/app/templates/service/redis/service.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.service.redis }}
+{{ if .Values.service.redis | default .Values.docker.services.redis.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/src/_base/helm/app/templates/service/varnish/headless-service.yaml
+++ b/src/_base/helm/app/templates/service/varnish/headless-service.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.service.varnish }}
+{{ if .Values.service.varnish | default .Values.docker.services.varnish.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/src/_base/helm/app/templates/service/varnish/service.yaml
+++ b/src/_base/helm/app/templates/service/varnish/service.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.service.varnish }}
+{{ if .Values.service.varnish | default .Values.docker.services.varnish.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/src/_base/helm/app/templates/service/varnish/statefulset.yaml
+++ b/src/_base/helm/app/templates/service/varnish/statefulset.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: varnish
-        image: varnish:6
+        image: {{ .Values.docker.services.varnish.image | quote }}
         imagePullPolicy: Always
         ports:
         - containerPort: 80

--- a/src/_base/helm/app/templates/service/varnish/statefulset.yaml
+++ b/src/_base/helm/app/templates/service/varnish/statefulset.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.service.varnish }}
+{{ if .Values.service.varnish | default .Values.docker.services.varnish.enabled }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/src/_base/helm/app/values-production.yaml.twig
+++ b/src/_base/helm/app/values-production.yaml.twig
@@ -1,14 +1,5 @@
-
-# assumption is that in a production style environment these would be
-# managed services outside of the applications control
-
-service:
-  elasticsearch: false
-  memcached: false
-  mysql: false
-  postgres: false
-  redis: false
-  redis_session: false
+# deprecated, use docker.services.*.enabled instead
+service: {}
 
 {% if @('pipeline.production.services') %}
 docker:

--- a/src/_base/helm/app/values.yaml.twig
+++ b/src/_base/helm/app/values.yaml.twig
@@ -11,15 +11,8 @@ ingress:
 
 docker:
   image_pull_config: {{ @('docker.image_pull_config') | raw }}
-  image:
-    console: {{ @('docker.repository') ~ ':' ~ @('app.version') ~ '-console' }}
-    cron: {{ @('docker.repository') ~ ':' ~ @('app.version') ~ '-cron' }}
-    elasticsearch: {{ @('elasticsearch.image') ~ ':' ~ @('elasticsearch.tag') }}
-    fpm: {{ @('docker.repository') ~ ':' ~ @('app.version') ~ '-php-fpm' }}
-    mysql: {{ @('mysql.image') ~ ':' ~ @('mysql.tag') }}
-    nginx: {{ @('docker.repository') ~ ':' ~ @('app.version') ~ '-nginx' }}
-    rabbitmq: {{ @('rabbitmq.image') ~ ':' ~ @('rabbitmq.tag') }}
-    php_fpm_exporter: {{ @('docker.repository') ~ ':' ~ @('app.version') ~ '-php-fpm-exporter' }}
+  # deprecated, use docker.services.*.image instead
+  image: {}
   services: {{ to_nice_yaml(deep_merge([
       filter_local_services(@('services')),
       @('pipeline.base.services')

--- a/src/_base/helm/app/values.yaml.twig
+++ b/src/_base/helm/app/values.yaml.twig
@@ -25,17 +25,8 @@ docker:
       @('pipeline.base.services')
     ]), 2, 4) | raw }}
 
-service:
-  elasticsearch: {{ ("elasticsearch" in @('app.services')) ? 'true' : 'false' }}
-  memcached: {{ ("memcached" in @('app.services')) ? 'true' : 'false' }}
-  mysql: {{ ("mysql" in @('app.services')) ? 'true' : 'false' }}
-  postgres: {{ ("postgres" in @('app.services')) ? 'true' : 'false' }}
-  rabbitmq: {{ ("rabbitmq" in @('app.services')) ? 'true' : 'false' }}
-  redis: {{ ("redis" in @('app.services')) ? 'true' : 'false' }}
-  redis_session: {{ ("redis-session" in @('app.services')) ? 'true' : 'false' }}
-  cron: {{ ("cron" in @('app.services')) ? 'true' : 'false' }}
-  php_fpm_exporter: {{ ("php-fpm-exporter" in @('app.services')) ? 'true' : 'false' }}
-  varnish: {{ ("varnish" in @('app.services')) ? 'true' : 'false' }}
+# deprecated, use docker.services.*.enabled instead
+service: {}
 
 replicas: {{ to_nice_yaml(@('replicas'), 2, 2) | raw }}
 

--- a/src/akeneo/_twig/docker-compose.yml/service/job-queue-consumer.yml.twig
+++ b/src/akeneo/_twig/docker-compose.yml/service/job-queue-consumer.yml.twig
@@ -7,7 +7,7 @@
       - {{ (syncvolume) ? @('workspace.name') ~ '-sync:/app:nocopy' : ('./:/app' ~ @('docker.compose.host_volume_options')) }}
       - ./.my127ws/application:/home/build/application
 {% else %}
-    image: {{ @('docker.repository') ~ ':' ~ @('app.version') ~ '-job-queue-consumer' }}
+    image: {{ @('services.job-queue-consumer.image') }}
 {% endif %}
     environment: {{ to_nice_yaml(deep_merge([
         @('services.php-base.environment'),

--- a/src/akeneo/harness/attributes/docker.yml
+++ b/src/akeneo/harness/attributes/docker.yml
@@ -24,6 +24,7 @@ attributes:
         APP_DATABASE_PASSWORD: = @('database.pass')
         APP_SECRET: = @('akeneo.secret')
     job-queue-consumer:
+      enabled: "= 'job-queue-consumer' in @('app.services')"
       publish: "= 'job-queue-consumer' in @('app.services')"
       environment:
         AUTOSTART_AKENEO_JOB_QUEUE_CONSUMER: "true"

--- a/src/akeneo/harness/attributes/docker.yml
+++ b/src/akeneo/harness/attributes/docker.yml
@@ -25,6 +25,7 @@ attributes:
         APP_SECRET: = @('akeneo.secret')
     job-queue-consumer:
       enabled: "= 'job-queue-consumer' in @('app.services')"
+      image: = @('docker.repository') ~ ':' ~ @('app.version') ~ '-job-queue-consumer'
       publish: "= 'job-queue-consumer' in @('app.services')"
       environment:
         AUTOSTART_AKENEO_JOB_QUEUE_CONSUMER: "true"

--- a/src/akeneo/helm/app/templates/application/job-queue-consumer/deployment.yaml
+++ b/src/akeneo/helm/app/templates/application/job-queue-consumer/deployment.yaml
@@ -52,7 +52,7 @@ spec:
           - secretRef:
               name: {{ .Values.resourcePrefix }}job-queue-consumer
         {{- end }}
-        image: {{ .Values.docker.image.job_queue_consumer }}
+        image: {{ .Values.docker.image.job_queue_consumer | default $service.image | quote }}
         imagePullPolicy: Always
         ports:
         - containerPort: 9000

--- a/src/akeneo/helm/app/templates/application/job-queue-consumer/deployment.yaml
+++ b/src/akeneo/helm/app/templates/application/job-queue-consumer/deployment.yaml
@@ -1,4 +1,5 @@
 {{- $service := mergeOverwrite (dict) (index .Values.docker.services "php-base") (index .Values.docker.services "job-queue-consumer") (dict "environment" .Values.environment) -}}
+{{- if index .Values.service "job-queue-consumer" | default $service.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -84,3 +85,4 @@ spec:
       {{- else }} []
       {{- end }}
 status: {}
+{{- end }}

--- a/src/akeneo/helm/app/values.yaml.twig
+++ b/src/akeneo/helm/app/values.yaml.twig
@@ -26,18 +26,8 @@ docker:
       @('pipeline.base.services')
     ]), 2, 4) | raw }}
 
-service:
-  elasticsearch: {{ ("elasticsearch" in @('app.services')) ? 'true' : 'false' }}
-  memcached: {{ ("memcached" in @('app.services')) ? 'true' : 'false' }}
-  mysql: {{ ("mysql" in @('app.services')) ? 'true' : 'false' }}
-  postgres: {{ ("postgres" in @('app.services')) ? 'true' : 'false' }}
-  rabbitmq: {{ ("rabbitmq" in @('app.services')) ? 'true' : 'false' }}
-  redis: {{ ("redis" in @('app.services')) ? 'true' : 'false' }}
-  redis_session: {{ ("redis-session" in @('app.services')) ? 'true' : 'false' }}
-  job-queue-consumer: {{ ("job-queue-consumer" in @('app.services')) ? 'true' : 'false' }}
-  cron: {{ ("cron" in @('app.services')) ? 'true' : 'false' }}
-  php_fpm_exporter: {{ ("php-fpm-exporter" in @('app.services')) ? 'true' : 'false' }}
-  varnish: {{ ("varnish" in @('app.services')) ? 'true' : 'false' }}
+# deprecated, use docker.services.*.enabled instead
+service: {}
 
 replicas: {{ to_nice_yaml(@('replicas'), 2, 2) | raw }}
 

--- a/src/akeneo/helm/app/values.yaml.twig
+++ b/src/akeneo/helm/app/values.yaml.twig
@@ -11,16 +11,8 @@ ingress:
 
 docker:
   image_pull_config: {{ @('docker.image_pull_config') | raw }}
-  image:
-    console: {{ @('docker.repository') ~ ':' ~ @('app.version') ~ '-console' }}
-    cron: {{ @('docker.repository') ~ ':' ~ @('app.version') ~ '-cron' }}
-    elasticsearch: {{ @('elasticsearch.image') ~ ':' ~ @('elasticsearch.tag') }}
-    fpm: {{ @('docker.repository') ~ ':' ~ @('app.version') ~ '-php-fpm' }}
-    job_queue_consumer: {{ @('docker.repository') ~ ':' ~ @('app.version') ~ '-job-queue-consumer' }}
-    mysql: {{ @('mysql.image') ~ ':' ~ @('mysql.tag') }}
-    nginx: {{ @('docker.repository') ~ ':' ~ @('app.version') ~ '-nginx' }}
-    rabbitmq: {{ @('rabbitmq.image') ~ ':' ~ @('rabbitmq.tag') }}
-    php_fpm_exporter: {{ @('docker.repository') ~ ':' ~ @('app.version') ~ '-php-fpm-exporter' }}
+  # deprecated, use docker.services.*.image instead
+  image: {}
   services: {{ to_nice_yaml(deep_merge([
       filter_local_services(@('services')),
       @('pipeline.base.services')

--- a/src/spryker/_twig/docker-compose.yml/application.yml.twig
+++ b/src/spryker/_twig/docker-compose.yml/application.yml.twig
@@ -20,7 +20,7 @@
       - ./.my127ws/docker/image/console/root/lib/task:/lib/task
       - ./.my127ws:/.my127ws
 {% else %}
-    image: {{ @('docker.repository') ~ ':' ~ @('app.version') ~ '-console' }}
+    image: {{ @('services.console.image') }}
 {% endif %}
     labels:
       - traefik.enable=false
@@ -40,7 +40,7 @@
     volumes:
       - {{ (syncvolume) ? @('workspace.name') ~ '-sync:/app:nocopy' : ('./:/app' ~ @('docker.compose.host_volume_options')) }}
 {% else %}
-    image: {{ @('docker.repository') ~ ':' ~ @('app.version') ~ '-nginx' }}
+    image: {{ @('services.nginx.image') }}
 {% endif %}
     labels:
       - traefik.backend={{ @('workspace.name') }}
@@ -76,7 +76,7 @@
       - {{ (syncvolume) ? @('workspace.name') ~ '-sync:/app:nocopy' : ('./:/app' ~ @('docker.compose.host_volume_options')) }}
       - ./.my127ws:/.my127ws
 {% else %}
-    image: {{ @('docker.repository') ~ ':' ~ @('app.version') ~ '-php-fpm' }}
+    image: {{ @('services.php-fpm.image') }}
 {% endif %}
     labels:
       - traefik.enable=false

--- a/src/spryker/_twig/docker-compose.yml/service/jenkins-runner.yml.twig
+++ b/src/spryker/_twig/docker-compose.yml/service/jenkins-runner.yml.twig
@@ -9,7 +9,7 @@
       - {{ (syncvolume) ? @('workspace.name') ~ '-sync:/app:nocopy' : ('./:/app' ~ @('docker.compose.host_volume_options')) }}
       - ./.my127ws/application:/home/build/application
 {% else %}
-    image: {{ @('docker.repository') ~ ':' ~ @('app.version') ~ '-jenkins-runner' }}
+    image: {{ @('services.jenkins-runner.image') }}
 {% endif %}
     depends_on:
       - console

--- a/src/spryker/_twig/docker-compose.yml/service/jenkins.yml.twig
+++ b/src/spryker/_twig/docker-compose.yml/service/jenkins.yml.twig
@@ -1,5 +1,5 @@
   jenkins:
-    image: "jenkins:alpine"
+    image: {{ @('services.jenkins.image') }}
     environment:
       JAVA_OPTS: '-Djenkins.install.runSetupWizard=false'
     networks:

--- a/src/spryker/harness/attributes/docker.yml
+++ b/src/spryker/harness/attributes/docker.yml
@@ -13,7 +13,10 @@ attributes:
         ZED_HOST: = @('zed.external_host')
       environment_secrets:
         SPRYKER_SALT: = @('spryker.salt')
+    jenkins:
+      enabled: "= 'jenkins' in @('app.services')"
     jenkins-runner:
+      enabled: "= 'jenkins-runner' in @('app.services')"
       publish: "= 'jenkins-runner' in @('app.services')"
       environment:
         RUNNER_NUM_EXECUTORS: 1

--- a/src/spryker/harness/attributes/docker.yml
+++ b/src/spryker/harness/attributes/docker.yml
@@ -15,8 +15,10 @@ attributes:
         SPRYKER_SALT: = @('spryker.salt')
     jenkins:
       enabled: "= 'jenkins' in @('app.services')"
+      image: jenkins:alpine
     jenkins-runner:
       enabled: "= 'jenkins-runner' in @('app.services')"
+      image: = @('docker.repository') ~ ':' ~ @('app.version') ~ '-jenkins-runner'
       publish: "= 'jenkins-runner' in @('app.services')"
       environment:
         RUNNER_NUM_EXECUTORS: 1

--- a/src/spryker/helm/app/templates/application/jenkins-runner/deployment.yaml
+++ b/src/spryker/helm/app/templates/application/jenkins-runner/deployment.yaml
@@ -35,7 +35,7 @@ spec:
           - secretRef:
               name: {{ .Values.resourcePrefix }}jenkins-runner
         {{- end }}
-        image: {{ .Values.docker.image.jenkins_runner }}
+        image: {{ .Values.docker.image.jenkins_runner | default $service.image | quote }}
         imagePullPolicy: Always
         name: jenkins-runner
         resources:

--- a/src/spryker/helm/app/templates/application/jenkins-runner/deployment.yaml
+++ b/src/spryker/helm/app/templates/application/jenkins-runner/deployment.yaml
@@ -1,5 +1,5 @@
-{{- if .Values.service.jenkins_runner -}}
 {{- $service := mergeOverwrite (dict) (index .Values.docker.services "php-base") (index .Values.docker.services "jenkins-runner") (dict "environment" .Values.environment) -}}
+{{- if .Values.service.jenkins_runner | default $service.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/src/spryker/helm/app/templates/service/jenkins/deployment.yaml
+++ b/src/spryker/helm/app/templates/service/jenkins/deployment.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.service.jenkins }}
+{{ if .Values.service.jenkins | default .Values.docker.services.jenkins.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/src/spryker/helm/app/templates/service/jenkins/deployment.yaml
+++ b/src/spryker/helm/app/templates/service/jenkins/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       - env:
         - name: JAVA_OPTS
           value: -Djenkins.install.runSetupWizard=false
-        image: jenkins:alpine
+        image: {{ .Values.docker.services.jenkins.image | quote }}
         imagePullPolicy: Always
         name: jenkins
         ports:

--- a/src/spryker/helm/app/templates/service/jenkins/service.yaml
+++ b/src/spryker/helm/app/templates/service/jenkins/service.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.service.jenkins }}
+{{ if .Values.service.jenkins | default .Values.docker.services.jenkins.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/src/spryker/helm/app/values.yaml.twig
+++ b/src/spryker/helm/app/values.yaml.twig
@@ -29,19 +29,8 @@ docker:
       @('pipeline.base.services')
     ]), 2, 4) | raw }}
 
-service:
-  elasticsearch: {{ ("elasticsearch" in @('app.services')) ? 'true' : 'false' }}
-  jenkins: {{ ("jenkins" in @('app.services')) ? 'true' : 'false' }}
-  jenkins_runner: {{ ("jenkins-runner" in @('app.services')) ? 'true' : 'false' }}
-  memcached: {{ ("memcached" in @('app.services')) ? 'true' : 'false' }}
-  mysql: {{ ("mysql" in @('app.services')) ? 'true' : 'false' }}
-  postgres: {{ ("postgres" in @('app.services')) ? 'true' : 'false' }}
-  rabbitmq: {{ ("rabbitmq" in @('app.services')) ? 'true' : 'false' }}
-  redis: {{ ("redis" in @('app.services')) ? 'true' : 'false' }}
-  redis_session: {{ ("redis-session" in @('app.services')) ? 'true' : 'false' }}
-  cron: {{ ("cron" in @('app.services')) ? 'true' : 'false' }}
-  php_fpm_exporter: {{ ("php-fpm-exporter" in @('app.services')) ? 'true' : 'false' }}
-  varnish: {{ ("varnish" in @('app.services')) ? 'true' : 'false' }}
+# deprecated, use docker.services.*.enabled instead
+service: {}
 
 replicas: {{ to_nice_yaml(@('replicas'), 2, 2) | raw }}
 

--- a/src/spryker/helm/app/values.yaml.twig
+++ b/src/spryker/helm/app/values.yaml.twig
@@ -14,16 +14,8 @@ ingress:
 
 docker:
   image_pull_config: {{ @('docker.image_pull_config') | raw }}
-  image:
-    console: {{ @('docker.repository') ~ ':' ~ @('app.version') ~ '-console' }}
-    cron: {{ @('docker.repository') ~ ':' ~ @('app.version') ~ '-cron' }}
-    elasticsearch: {{ @('elasticsearch.image') ~ ':' ~ @('elasticsearch.tag') }}
-    fpm: {{ @('docker.repository') ~ ':' ~ @('app.version') ~ '-php-fpm' }}
-    mysql: {{ @('mysql.image') ~ ':' ~ @('mysql.tag') }}
-    nginx: {{ @('docker.repository') ~ ':' ~ @('app.version') ~ '-nginx' }}
-    jenkins_runner: {{ @('docker.repository') ~ ':' ~ @('app.version') ~ '-jenkins-runner' }}
-    rabbitmq: {{ @('rabbitmq.image') ~ ':' ~ @('rabbitmq.tag') }}
-    php_fpm_exporter: {{ @('docker.repository') ~ ':' ~ @('app.version') ~ '-php-fpm-exporter' }}
+  # deprecated, use docker.services.*.image instead
+  image: {}
   services: {{ to_nice_yaml(deep_merge([
       filter_local_services(@('services')),
       @('pipeline.base.services')


### PR DESCRIPTION
.Values.service and .Values.docker.image are now deprecated, but will take precedence over their newer location to maintain backwards compatibility until removed

This is part of a multi-step conversion of helm values so service related values are in a common location. Other candidates require a bit more thought