### PR TITLE
Fix php syntax check not exiting with non-zero exit code on error

### DIFF
--- a/src/akeneo/application/skeleton/composer.json.twig
+++ b/src/akeneo/application/skeleton/composer.json.twig
@@ -67,7 +67,7 @@
       "@test-acceptance"
     ],
     "test-production-quality": [
-      "set -o pipefail && find src/ | xargs -n 1 -P 8 -i php -l {} | grep -v 'No syntax errors detected' && echo 'OK'"
+      "bash -e -o pipefail -c 'find src/ | xargs -n 1 -P 8 -i php -l {} | grep -v \\'No syntax errors detected\\' && echo OK'"
     ],
     "test-quality": [
       "phpcs -p",

--- a/src/akeneo/application/skeleton/composer.json.twig
+++ b/src/akeneo/application/skeleton/composer.json.twig
@@ -67,7 +67,7 @@
       "@test-acceptance"
     ],
     "test-production-quality": [
-      "bash -e -o pipefail -c \"find src/ | xargs -n 1 -P 8 -i php -l {} | grep -v 'No syntax errors detected' && echo OK\""
+      "bash -e -o pipefail -c \"find src/ -type f -name '*.php' -print0 | xargs -0 --no-run-if-empty -n 1 -P 8 -i php -l {} | (grep -v 'No syntax errors detected' || echo OK)\""
     ],
     "test-quality": [
       "phpcs -p",

--- a/src/akeneo/application/skeleton/composer.json.twig
+++ b/src/akeneo/application/skeleton/composer.json.twig
@@ -67,7 +67,7 @@
       "@test-acceptance"
     ],
     "test-production-quality": [
-      "find src/ | xargs -n 1 -P 8 -i php -l {} | grep -v 'No syntax errors detected' || echo 'OK'"
+      "set -o pipefail && find src/ | xargs -n 1 -P 8 -i php -l {} | grep -v 'No syntax errors detected' && echo 'OK'"
     ],
     "test-quality": [
       "phpcs -p",

--- a/src/akeneo/application/skeleton/composer.json.twig
+++ b/src/akeneo/application/skeleton/composer.json.twig
@@ -67,7 +67,7 @@
       "@test-acceptance"
     ],
     "test-production-quality": [
-      "bash -e -o pipefail -c 'find src/ | xargs -n 1 -P 8 -i php -l {} | grep -v \\'No syntax errors detected\\' && echo OK'"
+      "bash -e -o pipefail -c \"find src/ | xargs -n 1 -P 8 -i php -l {} | grep -v 'No syntax errors detected' && echo OK\""
     ],
     "test-quality": [
       "phpcs -p",

--- a/src/drupal8/application/skeleton/composer.json
+++ b/src/drupal8/application/skeleton/composer.json
@@ -62,7 +62,7 @@
       "@test-acceptance"
     ],
     "test-production-quality": [
-      "set -o pipefail && find docroot/ -type f ! -path 'docroot/core/lib/Drupal/Component/Assertion/global_namespace_php5.php' \\( -name '*.inc' -o -name '*.install' -o -name '*.module' -o -name '*.php' -o -name '*.profile' -o -name '*.test' -o -name '*.theme' \\) | xargs -n 1 -P 8 -i php -l {} | grep -v 'No syntax errors detected' && echo 'OK'"
+      "bash -e -o pipefail -c 'find docroot/ -type f ! -path \\'docroot/core/lib/Drupal/Component/Assertion/global_namespace_php5.php\\' \\( -name \\'*.inc\\' -o -name \\'*.install\\' -o -name \\'*.module\\' -o -name \\'*.php\\' -o -name \\'*.profile\\' -o -name \\'*.test\\' -o -name \\'*.theme\\' \\) | xargs -n 1 -P 8 -i php -l {} | grep -v \\'No syntax errors detected\\' && echo OK'"
     ],
     "test-quality": [
       "phpcs -v ./docroot/modules/custom",

--- a/src/drupal8/application/skeleton/composer.json
+++ b/src/drupal8/application/skeleton/composer.json
@@ -62,7 +62,7 @@
       "@test-acceptance"
     ],
     "test-production-quality": [
-      "find docroot/ -type f ! -path 'docroot/core/lib/Drupal/Component/Assertion/global_namespace_php5.php' \\( -name '*.phtml' -o -name '*.php' \\) | xargs -n 1 -P 8 -i php -l {} | grep -v 'No syntax errors detected' || echo 'OK'"
+      "set -o pipefail && find docroot/ -type f ! -path 'docroot/core/lib/Drupal/Component/Assertion/global_namespace_php5.php' \\( -name '*.inc' -o -name '*.install' -o -name '*.module' -o -name '*.php' -o -name '*.profile' -o -name '*.test' -o -name '*.theme' \\) | xargs -n 1 -P 8 -i php -l {} | grep -v 'No syntax errors detected' && echo 'OK'"
     ],
     "test-quality": [
       "phpcs -v ./docroot/modules/custom",

--- a/src/drupal8/application/skeleton/composer.json
+++ b/src/drupal8/application/skeleton/composer.json
@@ -62,7 +62,7 @@
       "@test-acceptance"
     ],
     "test-production-quality": [
-      "bash -e -o pipefail -c 'find docroot/ -type f ! -path \\'docroot/core/lib/Drupal/Component/Assertion/global_namespace_php5.php\\' \\( -name \\'*.inc\\' -o -name \\'*.install\\' -o -name \\'*.module\\' -o -name \\'*.php\\' -o -name \\'*.profile\\' -o -name \\'*.test\\' -o -name \\'*.theme\\' \\) | xargs -n 1 -P 8 -i php -l {} | grep -v \\'No syntax errors detected\\' && echo OK'"
+      "bash -e -o pipefail -c \"find docroot/ -type f ! -path 'docroot/core/lib/Drupal/Component/Assertion/global_namespace_php5.php' \\( -name '*.inc' -o -name '*.install' -o -name '*.module' -o -name '*.php' -o -name '*.profile' -o -name '*.test' -o -name '*.theme' \\) | xargs -n 1 -P 8 -i php -l {} | grep -v 'No syntax errors detected' && echo OK\""
     ],
     "test-quality": [
       "phpcs -v ./docroot/modules/custom",

--- a/src/drupal8/application/skeleton/composer.json
+++ b/src/drupal8/application/skeleton/composer.json
@@ -62,7 +62,7 @@
       "@test-acceptance"
     ],
     "test-production-quality": [
-      "bash -e -o pipefail -c \"find docroot/ -type f ! -path 'docroot/core/lib/Drupal/Component/Assertion/global_namespace_php5.php' \\( -name '*.inc' -o -name '*.install' -o -name '*.module' -o -name '*.php' -o -name '*.profile' -o -name '*.test' -o -name '*.theme' \\) | xargs -n 1 -P 8 -i php -l {} | grep -v 'No syntax errors detected' && echo OK\""
+      "bash -e -o pipefail -c \"find docroot/ -type f ! -path 'docroot/core/lib/Drupal/Component/Assertion/global_namespace_php5.php' \\( -name '*.inc' -o -name '*.install' -o -name '*.module' -o -name '*.php' -o -name '*.profile' -o -name '*.test' -o -name '*.theme' \\)  -print0 | xargs -0 --no-run-if-empty -n 1 -P 8 -i php -l {} | (grep -v 'No syntax errors detected' || echo OK)\""
     ],
     "test-quality": [
       "phpcs -v ./docroot/modules/custom",

--- a/src/magento1/application/skeleton/_twig/composer.json/default.twig
+++ b/src/magento1/application/skeleton/_twig/composer.json/default.twig
@@ -90,7 +90,7 @@
             "@test-acceptance"
         ],
         "test-production-quality": [
-            "find public/app/code/ public/app/design/ -type f ! -path 'public/app/code/core/Mage/Adminhtml/Model/Extension.php' \\( -name '*.phtml' -o -name '*.php' \\) | xargs -n 1 -P 8 -i php -l {} | grep -v 'No syntax errors detected' || echo 'OK'"
+            "set -o pipefail && find public/app/code/ public/app/design/ -type f ! -path 'public/app/code/core/Mage/Adminhtml/Model/Extension.php' \\( -name '*.phtml' -o -name '*.php' \\) | xargs -n 1 -P 8 -i php -l {} | grep -v 'No syntax errors detected' && echo 'OK'"
         ],
         "test-quality": [
             "phpcs -v ./src",

--- a/src/magento1/application/skeleton/_twig/composer.json/default.twig
+++ b/src/magento1/application/skeleton/_twig/composer.json/default.twig
@@ -90,7 +90,7 @@
             "@test-acceptance"
         ],
         "test-production-quality": [
-            "bash -e -o pipefail -c \"find public/app/code/ public/app/design/ -type f ! -path 'public/app/code/core/Mage/Adminhtml/Model/Extension.php' \\( -name '*.phtml' -o -name '*.php' \\) | xargs -n 1 -P 8 -i php -l {} | grep -v 'No syntax errors detected' && echo OK\""
+            "bash -e -o pipefail -c \"find public/app/code/ public/app/design/ -type f ! -path 'public/app/code/core/Mage/Adminhtml/Model/Extension.php' \\( -name '*.phtml' -o -name '*.php' \\) -print0 | xargs -0 --no-run-if-empty -n 1 -P 8 -i php -l {} | (grep -v 'No syntax errors detected' || echo OK)\""
         ],
         "test-quality": [
             "phpcs -v ./src",

--- a/src/magento1/application/skeleton/_twig/composer.json/default.twig
+++ b/src/magento1/application/skeleton/_twig/composer.json/default.twig
@@ -90,7 +90,7 @@
             "@test-acceptance"
         ],
         "test-production-quality": [
-            "set -o pipefail && find public/app/code/ public/app/design/ -type f ! -path 'public/app/code/core/Mage/Adminhtml/Model/Extension.php' \\( -name '*.phtml' -o -name '*.php' \\) | xargs -n 1 -P 8 -i php -l {} | grep -v 'No syntax errors detected' && echo 'OK'"
+            "bash -e -o pipefail -c 'find public/app/code/ public/app/design/ -type f ! -path \\'public/app/code/core/Mage/Adminhtml/Model/Extension.php\\' \\( -name \\'*.phtml\\' -o -name \\'*.php\\' \\) | xargs -n 1 -P 8 -i php -l {} | grep -v \\'No syntax errors detected\\' && echo OK'"
         ],
         "test-quality": [
             "phpcs -v ./src",

--- a/src/magento1/application/skeleton/_twig/composer.json/default.twig
+++ b/src/magento1/application/skeleton/_twig/composer.json/default.twig
@@ -90,7 +90,7 @@
             "@test-acceptance"
         ],
         "test-production-quality": [
-            "bash -e -o pipefail -c 'find public/app/code/ public/app/design/ -type f ! -path \\'public/app/code/core/Mage/Adminhtml/Model/Extension.php\\' \\( -name \\'*.phtml\\' -o -name \\'*.php\\' \\) | xargs -n 1 -P 8 -i php -l {} | grep -v \\'No syntax errors detected\\' && echo OK'"
+            "bash -e -o pipefail -c \"find public/app/code/ public/app/design/ -type f ! -path 'public/app/code/core/Mage/Adminhtml/Model/Extension.php' \\( -name '*.phtml' -o -name '*.php' \\) | xargs -n 1 -P 8 -i php -l {} | grep -v 'No syntax errors detected' && echo OK\""
         ],
         "test-quality": [
             "phpcs -v ./src",

--- a/src/magento1/application/skeleton/_twig/composer.json/php-5.6.twig
+++ b/src/magento1/application/skeleton/_twig/composer.json/php-5.6.twig
@@ -91,7 +91,7 @@
             "@test-acceptance"
         ],
         "test-production-quality": [
-            "bash -e -o pipefail -c \"find public/app/code/ public/app/design/ -type f \\( -name '*.phtml' -o -name '*.php' \\) | xargs -n 1 -P 8 -i php -l {} | grep -v 'No syntax errors detected' && echo OK\""
+            "bash -e -o pipefail -c \"find public/app/code/ public/app/design/ -type f \\( -name '*.phtml' -o -name '*.php' \\) -print0 | xargs -0 --no-run-if-empty -n 1 -P 8 -i php -l {} | (grep -v 'No syntax errors detected' || echo OK)\""
         ],
         "test-quality": [
             "phpcs -v ./src",

--- a/src/magento1/application/skeleton/_twig/composer.json/php-5.6.twig
+++ b/src/magento1/application/skeleton/_twig/composer.json/php-5.6.twig
@@ -91,7 +91,7 @@
             "@test-acceptance"
         ],
         "test-production-quality": [
-            "set -o pipefail && find public/app/code/ public/app/design/ -type f \\( -name '*.phtml' -o -name '*.php' \\) | xargs -n 1 -P 8 -i php -l {} | grep -v 'No syntax errors detected' && echo 'OK'"
+            "bash -e -o pipefail -c 'find public/app/code/ public/app/design/ -type f \\( -name \\'*.phtml\\' -o -name \\'*.php\\' \\) | xargs -n 1 -P 8 -i php -l {} | grep -v \\'No syntax errors detected\\' && echo OK'"
         ],
         "test-quality": [
             "phpcs -v ./src",

--- a/src/magento1/application/skeleton/_twig/composer.json/php-5.6.twig
+++ b/src/magento1/application/skeleton/_twig/composer.json/php-5.6.twig
@@ -91,7 +91,7 @@
             "@test-acceptance"
         ],
         "test-production-quality": [
-            "find public/app/code/ public/app/design/ -type f \\( -name '*.phtml' -o -name '*.php' \\) | xargs -n 1 -P 8 -i php -l {} | grep -v 'No syntax errors detected' || echo 'OK'"
+            "set -o pipefail && find public/app/code/ public/app/design/ -type f \\( -name '*.phtml' -o -name '*.php' \\) | xargs -n 1 -P 8 -i php -l {} | grep -v 'No syntax errors detected' && echo 'OK'"
         ],
         "test-quality": [
             "phpcs -v ./src",

--- a/src/magento1/application/skeleton/_twig/composer.json/php-5.6.twig
+++ b/src/magento1/application/skeleton/_twig/composer.json/php-5.6.twig
@@ -91,7 +91,7 @@
             "@test-acceptance"
         ],
         "test-production-quality": [
-            "bash -e -o pipefail -c 'find public/app/code/ public/app/design/ -type f \\( -name \\'*.phtml\\' -o -name \\'*.php\\' \\) | xargs -n 1 -P 8 -i php -l {} | grep -v \\'No syntax errors detected\\' && echo OK'"
+            "bash -e -o pipefail -c \"find public/app/code/ public/app/design/ -type f \\( -name '*.phtml' -o -name '*.php' \\) | xargs -n 1 -P 8 -i php -l {} | grep -v 'No syntax errors detected' && echo OK\""
         ],
         "test-quality": [
             "phpcs -v ./src",

--- a/src/magento2/application/skeleton/composer.json.twig
+++ b/src/magento2/application/skeleton/composer.json.twig
@@ -75,7 +75,7 @@
             "@test-acceptance"
         ],
         "test-production-quality": [
-            "bash -e -o pipefail -c \"find src/ pub/ -type f \\( -name '*.phtml' -o -name '*.php' \\) | xargs -n 1 -P 8 -i php -l {} | grep -v 'No syntax errors detected' && echo OK\"",
+            "bash -e -o pipefail -c \"find src/ pub/ -type f \\( -name '*.phtml' -o -name '*.php' \\) -print0 | xargs -0 --no-run-if-empty -n 1 -P 8 -i php -l {} | (grep -v 'No syntax errors detected' || echo OK)\"",
             "app phpstan"
         ],
         "test-quality": [

--- a/src/magento2/application/skeleton/composer.json.twig
+++ b/src/magento2/application/skeleton/composer.json.twig
@@ -75,7 +75,7 @@
             "@test-acceptance"
         ],
         "test-production-quality": [
-            "find src/ pub/ -type f \\( -name '*.phtml' -o -name '*.php' \\) | xargs -n 1 -P 8 -i php -l {} | grep -v 'No syntax errors detected' || echo 'OK'",
+            "set -o pipefail && find src/ pub/ -type f \\( -name '*.phtml' -o -name '*.php' \\) | xargs -n 1 -P 8 -i php -l {} | grep -v 'No syntax errors detected' && echo 'OK'",
             "app phpstan"
         ],
         "test-quality": [

--- a/src/magento2/application/skeleton/composer.json.twig
+++ b/src/magento2/application/skeleton/composer.json.twig
@@ -75,7 +75,7 @@
             "@test-acceptance"
         ],
         "test-production-quality": [
-            "set -o pipefail && find src/ pub/ -type f \\( -name '*.phtml' -o -name '*.php' \\) | xargs -n 1 -P 8 -i php -l {} | grep -v 'No syntax errors detected' && echo 'OK'",
+            "bash -e -o pipefail -c 'find src/ pub/ -type f \\( -name \\'*.phtml\\' -o -name \\'*.php\\' \\) | xargs -n 1 -P 8 -i php -l {} | grep -v \\'No syntax errors detected\\' && echo OK'",
             "app phpstan"
         ],
         "test-quality": [

--- a/src/magento2/application/skeleton/composer.json.twig
+++ b/src/magento2/application/skeleton/composer.json.twig
@@ -75,7 +75,7 @@
             "@test-acceptance"
         ],
         "test-production-quality": [
-            "bash -e -o pipefail -c 'find src/ pub/ -type f \\( -name \\'*.phtml\\' -o -name \\'*.php\\' \\) | xargs -n 1 -P 8 -i php -l {} | grep -v \\'No syntax errors detected\\' && echo OK'",
+            "bash -e -o pipefail -c \"find src/ pub/ -type f \\( -name '*.phtml' -o -name '*.php' \\) | xargs -n 1 -P 8 -i php -l {} | grep -v 'No syntax errors detected' && echo OK\"",
             "app phpstan"
         ],
         "test-quality": [

--- a/src/spryker/application/skeleton/composer-harness.json
+++ b/src/spryker/application/skeleton/composer-harness.json
@@ -42,7 +42,7 @@
       "APPLICATION_ENV=development vendor/bin/console dev:ide:generate-auto-completion"
     ],
     "test-production-quality": [
-      "bash -e -o pipefail -c 'find src/ | xargs -n 1 -P 8 -i php -l {} | grep -v \\'No syntax errors detected\\' && echo OK'"
+      "bash -e -o pipefail -c \"find src/ | xargs -n 1 -P 8 -i php -l {} | grep -v 'No syntax errors detected' && echo OK\""
     ],
     "test-quality": [
       "@generate",

--- a/src/spryker/application/skeleton/composer-harness.json
+++ b/src/spryker/application/skeleton/composer-harness.json
@@ -42,7 +42,7 @@
       "APPLICATION_ENV=development vendor/bin/console dev:ide:generate-auto-completion"
     ],
     "test-production-quality": [
-      "set -o pipefail && find src/ | xargs -n 1 -P 8 -i php -l {} | grep -v 'No syntax errors detected' && echo 'OK'"
+      "bash -e -o pipefail -c 'find src/ | xargs -n 1 -P 8 -i php -l {} | grep -v \\'No syntax errors detected\\' && echo OK'"
     ],
     "test-quality": [
       "@generate",

--- a/src/spryker/application/skeleton/composer-harness.json
+++ b/src/spryker/application/skeleton/composer-harness.json
@@ -42,7 +42,7 @@
       "APPLICATION_ENV=development vendor/bin/console dev:ide:generate-auto-completion"
     ],
     "test-production-quality": [
-      "find src/ | xargs -n 1 -P 8 -i php -l {} | grep -v 'No syntax errors detected' || echo 'OK'"
+      "set -o pipefail && find src/ | xargs -n 1 -P 8 -i php -l {} | grep -v 'No syntax errors detected' && echo 'OK'"
     ],
     "test-quality": [
       "@generate",

--- a/src/spryker/application/skeleton/composer-harness.json
+++ b/src/spryker/application/skeleton/composer-harness.json
@@ -42,7 +42,7 @@
       "APPLICATION_ENV=development vendor/bin/console dev:ide:generate-auto-completion"
     ],
     "test-production-quality": [
-      "bash -e -o pipefail -c \"find src/ | xargs -n 1 -P 8 -i php -l {} | grep -v 'No syntax errors detected' && echo OK\""
+      "bash -e -o pipefail -c \"find src/ -type f -name '*.php' -print0 | xargs -0 --no-run-if-empty -n 1 -P 8 -i php -l {} | (grep -v 'No syntax errors detected' || echo OK)\""
     ],
     "test-quality": [
       "@generate",

--- a/src/wordpress/application/skeleton/composer.json.twig
+++ b/src/wordpress/application/skeleton/composer.json.twig
@@ -47,7 +47,7 @@
             "@test-acceptance"
         ],
         "test-production-quality": [
-            "find public/ -type f -name '*.php' | xargs -n 1 -P 8 -i php -l {} | grep -v 'No syntax errors detected' || echo 'OK'"
+            "set -o pipefail && find public/ -type f -name '*.php' | xargs -n 1 -P 8 -i php -l {} | grep -v 'No syntax errors detected' && echo 'OK'"
         ],
         "test-quality": [
             "phpcs"

--- a/src/wordpress/application/skeleton/composer.json.twig
+++ b/src/wordpress/application/skeleton/composer.json.twig
@@ -47,7 +47,7 @@
             "@test-acceptance"
         ],
         "test-production-quality": [
-            "bash -e -o pipefail -c 'find public/ -type f -name \\'*.php\\' | xargs -n 1 -P 8 -i php -l {} | grep -v \\'No syntax errors detected\\' && echo OK'"
+            "bash -e -o pipefail -c \"find public/ -type f -name '*.php' | xargs -n 1 -P 8 -i php -l {} | grep -v 'No syntax errors detected' && echo OK\""
         ],
         "test-quality": [
             "phpcs"

--- a/src/wordpress/application/skeleton/composer.json.twig
+++ b/src/wordpress/application/skeleton/composer.json.twig
@@ -47,7 +47,7 @@
             "@test-acceptance"
         ],
         "test-production-quality": [
-            "set -o pipefail && find public/ -type f -name '*.php' | xargs -n 1 -P 8 -i php -l {} | grep -v 'No syntax errors detected' && echo 'OK'"
+            "bash -e -o pipefail -c 'find public/ -type f -name \\'*.php\\' | xargs -n 1 -P 8 -i php -l {} | grep -v \\'No syntax errors detected\\' && echo OK'"
         ],
         "test-quality": [
             "phpcs"

--- a/src/wordpress/application/skeleton/composer.json.twig
+++ b/src/wordpress/application/skeleton/composer.json.twig
@@ -47,7 +47,7 @@
             "@test-acceptance"
         ],
         "test-production-quality": [
-            "bash -e -o pipefail -c \"find public/ -type f -name '*.php' | xargs -n 1 -P 8 -i php -l {} | grep -v 'No syntax errors detected' && echo OK\""
+            "bash -e -o pipefail -c \"find public/ -type f -name '*.php'  -print0 | xargs -0 --no-run-if-empty -n 1 -P 8 -i php -l {} | (grep -v 'No syntax errors detected' || echo OK)\""
         ],
         "test-quality": [
             "phpcs"


### PR DESCRIPTION
Also expand checks for drupal8 to cover the same PHP extensions as phpcs.  