### PR TITLE
Automatically choose buster based images if php 7.4

### DIFF
--- a/src/_base/harness/attributes/common.yml
+++ b/src/_base/harness/attributes/common.yml
@@ -95,8 +95,8 @@ attributes.default:
     # in the values.yml in there now instead of project application repositories
     image_pull_config: = @('docker.config')
     image:
-      console: = 'my127/php:' ~ @('php.version') ~ '-fpm-stretch-console'
-      php-fpm: = 'my127/php:' ~ @('php.version') ~ '-fpm-stretch'
+      console: "= 'my127/php:' ~ @('php.version') ~ '-fpm-' ~ (@('php.version') >= 7.4 ? 'buster' : 'stretch') ~ '-console'"
+      php-fpm: "= 'my127/php:' ~ @('php.version') ~ '-fpm-' ~ (@('php.version') >= 7.4 ? 'buster' : 'stretch')"
 
   composer:
     auth:

--- a/src/drupal8/harness.yml
+++ b/src/drupal8/harness.yml
@@ -66,8 +66,8 @@ attributes:
         - run drupal cache:rebuild
   docker:
     image:
-      console: = 'my127/drupal8:' ~ @('php.version') ~ '-fpm-stretch-console'
-      php-fpm: = 'my127/drupal8:' ~ @('php.version') ~ '-fpm-stretch'
+      console: "= 'my127/drupal8:' ~ @('php.version') ~ '-fpm-' ~ (@('php.version') >= 7.4 ? 'buster' : 'stretch') ~ '-console'"
+      php-fpm: "= 'my127/drupal8:' ~ @('php.version') ~ '-fpm-' ~ (@('php.version') >= 7.4 ? 'buster' : 'stretch')"
   persistence:
     enabled: false
     drupal:

--- a/src/magento1/harness.yml
+++ b/src/magento1/harness.yml
@@ -96,8 +96,8 @@ attributes:
         - run n98-magerun.phar cache:clean
   docker:
     image:
-      console: = 'my127/magento1:' ~ @('php.version') ~ '-fpm-stretch-console'
-      php-fpm: = 'my127/magento1:' ~ @('php.version') ~ '-fpm-stretch'
+      console: "= 'my127/magento1:' ~ @('php.version') ~ '-fpm-' ~ (@('php.version') >= 7.4 ? 'buster' : 'stretch') ~ '-console'"
+      php-fpm: "= 'my127/magento1:' ~ @('php.version') ~ '-fpm-' ~ (@('php.version') >= 7.4 ? 'buster' : 'stretch')"
   persistence:
     enabled: false
     magento:

--- a/src/magento2/harness.yml
+++ b/src/magento2/harness.yml
@@ -148,8 +148,8 @@ attributes:
         - "= (@('app.mode') == 'production' ? '* * * * * /cron-run-with-env.sh /app/bin/magento cron:run' : '')"
   docker:
     image:
-      console: = 'my127/magento2:' ~ @('php.version') ~ '-fpm-stretch-console'
-      php-fpm: = 'my127/magento2:' ~ @('php.version') ~ '-fpm-stretch'
+      console: "= 'my127/magento2:' ~ @('php.version') ~ '-fpm-' ~ (@('php.version') >= 7.4 ? 'buster' : 'stretch') ~ '-console'"
+      php-fpm: "= 'my127/magento2:' ~ @('php.version') ~ '-fpm-' ~ (@('php.version') >= 7.4 ? 'buster' : 'stretch')"
   framework:
     readme_blocks:
       - xml_urn_generation

--- a/src/spryker/harness.yml
+++ b/src/spryker/harness.yml
@@ -76,8 +76,8 @@ attributes:
           fi
   docker:
     image:
-      console: = 'my127/spryker:' ~ @('php.version') ~ '-fpm-stretch-console'
-      php-fpm: = 'my127/spryker:' ~ @('php.version') ~ '-fpm-stretch'
+      console: = 'my127/spryker:' ~ @('php.version') ~ '-fpm-' ~ (@('php.version') >= 7.4 ? 'buster' : 'stretch') ~ '-console'
+      php-fpm: = 'my127/spryker:' ~ @('php.version') ~ '-fpm-' ~ (@('php.version') >= 7.4 ? 'buster' : 'stretch')
   elasticsearch:
     image: elasticsearch
     tag: 5.6

--- a/src/spryker/harness.yml
+++ b/src/spryker/harness.yml
@@ -76,8 +76,8 @@ attributes:
           fi
   docker:
     image:
-      console: = 'my127/spryker:' ~ @('php.version') ~ '-fpm-' ~ (@('php.version') >= 7.4 ? 'buster' : 'stretch') ~ '-console'
-      php-fpm: = 'my127/spryker:' ~ @('php.version') ~ '-fpm-' ~ (@('php.version') >= 7.4 ? 'buster' : 'stretch')
+      console: "= 'my127/spryker:' ~ @('php.version') ~ '-fpm-' ~ (@('php.version') >= 7.4 ? 'buster' : 'stretch') ~ '-console'"
+      php-fpm: "= 'my127/spryker:' ~ @('php.version') ~ '-fpm-' ~ (@('php.version') >= 7.4 ? 'buster' : 'stretch')"
   elasticsearch:
     image: elasticsearch
     tag: 5.6

--- a/src/wordpress/harness.yml
+++ b/src/wordpress/harness.yml
@@ -62,8 +62,8 @@ attributes:
         - run bin/wp-cli.phar "--path=${WORDPRESS_INSTALL_DIRECTORY}" user update admin --role=administrator --user_pass=admin123 --skip-email
   docker:
     image:
-      console: = 'my127/wordpress:' ~ @('php.version') ~ '-fpm-stretch-console'
-      php-fpm: = 'my127/wordpress:' ~ @('php.version') ~ '-fpm-stretch'
+      console: = 'my127/wordpress:' ~ @('php.version') ~ '-fpm-' ~ (@('php.version') >= 7.4 ? 'buster' : 'stretch') ~ '-console'
+      php-fpm: = 'my127/wordpress:' ~ @('php.version') ~ '-fpm-' ~ (@('php.version') >= 7.4 ? 'buster' : 'stretch')
 ---
 import:
   - harness/config/*.yml

--- a/src/wordpress/harness.yml
+++ b/src/wordpress/harness.yml
@@ -62,8 +62,8 @@ attributes:
         - run bin/wp-cli.phar "--path=${WORDPRESS_INSTALL_DIRECTORY}" user update admin --role=administrator --user_pass=admin123 --skip-email
   docker:
     image:
-      console: = 'my127/wordpress:' ~ @('php.version') ~ '-fpm-' ~ (@('php.version') >= 7.4 ? 'buster' : 'stretch') ~ '-console'
-      php-fpm: = 'my127/wordpress:' ~ @('php.version') ~ '-fpm-' ~ (@('php.version') >= 7.4 ? 'buster' : 'stretch')
+      console: "= 'my127/wordpress:' ~ @('php.version') ~ '-fpm-' ~ (@('php.version') >= 7.4 ? 'buster' : 'stretch') ~ '-console'"
+      php-fpm: "= 'my127/wordpress:' ~ @('php.version') ~ '-fpm-' ~ (@('php.version') >= 7.4 ? 'buster' : 'stretch')"
 ---
 import:
   - harness/config/*.yml


### PR DESCRIPTION
We only publish buster versions of PHP 7.4 (as upstream https://github.com/docker-library/php/ only publishes buster and alpine versions)

We could centralise this logic but I don't really want to introduce a new attribute.