### PR TITLE
MISC Publish images and chart only when needed

### DIFF
--- a/src/_base/application/overlay/Jenkinsfile.twig
+++ b/src/_base/application/overlay/Jenkinsfile.twig
@@ -4,7 +4,7 @@ pipeline {
         MY127WS_KEY = credentials('{{ @('jenkins.credentials.my127ws_key') }}')
         MY127WS_ENV = "pipeline"
     }
-    triggers { cron(env.BRANCH_NAME == '{{ @('git.main_branch') }}' ? 'H H(0-6) * * *' : '') }
+    triggers { cron(env.BRANCH_NAME == '{{ @('git.default_branch') }}' ? 'H H(0-6) * * *' : '') }
     stages {
         stage('Build') {
             steps {
@@ -36,7 +36,18 @@ pipeline {
 {% endfor %}
             }
 {% endif %}
-            when { not { triggeredBy 'TimerTrigger' } }
+            when {
+                not { triggeredBy 'TimerTrigger' } 
+                anyOf {
+                    branch pattern: '{{ @('pipeline.publish.branch.regexp') }}', comparator: 'REGEXP'
+{% if @('pipeline.qa.enabled') == 'yes' %}
+                    branch '{{ @('pipeline.qa.branch') }}'
+{% endif %}
+{% if @('pipeline.preview.enabled') == 'yes' %}
+                    changeRequest target: '{{ @('git.default_branch') }}'
+{% endif %}
+                }
+            }
             steps {
                 milestone(50)
                 sh 'ws app publish'

--- a/src/_base/application/overlay/Jenkinsfile.twig
+++ b/src/_base/application/overlay/Jenkinsfile.twig
@@ -39,12 +39,16 @@ pipeline {
             when {
                 not { triggeredBy 'TimerTrigger' } 
                 anyOf {
-                    branch pattern: '{{ @('pipeline.publish.branch.regexp') }}', comparator: 'REGEXP'
+{% for branch in @('pipeline.publish.branches') %}
+                    branch '{{ branch }}'
+{% endfor %}
 {% if @('pipeline.qa.enabled') == 'yes' %}
                     branch '{{ @('pipeline.qa.branch') }}'
 {% endif %}
 {% if @('pipeline.preview.enabled') == 'yes' %}
-                    changeRequest target: '{{ @('git.default_branch') }}'
+{% for branch in @('pipeline.preview.target_branches') %}
+                    changeRequest target: '{{ branch }}'
+{% endfor %}
 {% endif %}
                 }
             }

--- a/src/_base/harness/attributes/common.yml
+++ b/src/_base/harness/attributes/common.yml
@@ -39,9 +39,9 @@ attributes.default:
       enabled: no
       services: = publishable_services(@('services'))
       # branches that should publish (other than change requests and qa)
-      # .* is deprecated and will be limited to one branch by default in a future release
-      branch:
-        regexp: .*
+      # * is deprecated and will be limited to one branch by default in a future release
+      branches:
+        - '*'
       # For defining environment variables in Jenkins, e.g. loading up docker username/password from a Jenkins
       # credential
       environment: {}
@@ -62,6 +62,8 @@ attributes.default:
           email: name@example.com
     preview:
       enabled: no
+      target_branches:
+        - = @('git.default_branch')
       environment: {}
       cluster:
         name: null

--- a/src/_base/harness/attributes/common.yml
+++ b/src/_base/harness/attributes/common.yml
@@ -38,6 +38,10 @@ attributes.default:
     publish:
       enabled: no
       services: = publishable_services(@('services'))
+      # branches that should publish (other than change requests and qa)
+      # .* is deprecated and will be limited to one branch by default in a future release
+      branch:
+        regexp: .*
       # For defining environment variables in Jenkins, e.g. loading up docker username/password from a Jenkins
       # credential
       environment: {}
@@ -144,6 +148,8 @@ attributes.default:
           fi
 
   git:
+    default_branch: = @('main_branch')
+    # potentially deprecated, unless it is repurposed
     main_branch: develop
 
   nginx:

--- a/src/drupal8/application/overlay/Jenkinsfile.twig
+++ b/src/drupal8/application/overlay/Jenkinsfile.twig
@@ -4,7 +4,7 @@ pipeline {
         MY127WS_KEY = credentials('{{ @('jenkins.credentials.my127ws_key') }}')
         MY127WS_ENV = "pipeline"
     }
-    triggers { cron(env.BRANCH_NAME == '{{ @('git.main_branch') }}' ? 'H H(0-6) * * *' : '') }
+    triggers { cron(env.BRANCH_NAME == '{{ @('git.default_branch') }}' ? 'H H(0-6) * * *' : '') }
     stages {
         stage('Build') {
             steps {

--- a/src/drupal8/application/overlay/Jenkinsfile.twig
+++ b/src/drupal8/application/overlay/Jenkinsfile.twig
@@ -36,7 +36,22 @@ pipeline {
 {% endfor %}
             }
 {% endif %}
-            when { not { triggeredBy 'TimerTrigger' } }
+            when {
+                not { triggeredBy 'TimerTrigger' } 
+                anyOf {
+{% for branch in @('pipeline.publish.branches') %}
+                    branch '{{ branch }}'
+{% endfor %}
+{% if @('pipeline.qa.enabled') == 'yes' %}
+                    branch '{{ @('pipeline.qa.branch') }}'
+{% endif %}
+{% if @('pipeline.preview.enabled') == 'yes' %}
+{% for branch in @('pipeline.preview.target_branches') %}
+                    changeRequest target: '{{ branch }}'
+{% endfor %}
+{% endif %}
+                }
+            }
             steps {
                 milestone(50)
                 sh 'ws app publish'


### PR DESCRIPTION
* for backwards compatibility, all branches are still published, however that will be changed in a major release
* if preview enabled, then PRs that target the default branch (if pipeline.publish.branches is limited to specific branches)
* rename git.main_branch to git.default_branch as main has meanings that a develop branch process is confusing with (especially if renaming master to main)