### PR TITLE
Fix 'ws feature xdebug on/off'

### DIFF
--- a/src/_base/harness/config/commands.yml
+++ b/src/_base/harness/config/commands.yml
@@ -166,8 +166,8 @@ command('service php-fpm restart'):
   exec: |
     #!bash(workspace:/)|@
     passthru ws install --step=prepare
-    passthru docker-compose exec console bash -c 'cp -r /.my127ws/docker/image/console/root/usr/local/etc/php/conf.d/* /usr/local/etc/php/conf.d/'
-    passthru docker-compose exec php-fpm bash -c 'cp -r /.my127ws/docker/image/php-fpm/root/usr/local/etc/php/conf.d/* /usr/local/etc/php/conf.d/'
+    docker-compose exec console bash -c 'cp -r /.my127ws/docker/image/console/root/usr/local/etc/php/conf.d/* /usr/local/etc/php/conf.d/'
+    docker-compose exec php-fpm bash -c 'cp -r /.my127ws/docker/image/php-fpm/root/usr/local/etc/php/conf.d/* /usr/local/etc/php/conf.d/'
     passthru docker-compose exec php-fpm supervisorctl restart php-fpm
 
 command('set <attribute> <value>'):


### PR DESCRIPTION
```
ws feature xdebug off
Removing old 'php.ext-xdebug.enable' setting from workspace.override.yml
Setting 'php.ext-xdebug.enable' setting to 'no' in workspace.override.yml
Updating templates in .my127ws/
■ > ws install --step=prepare
Bringing up php-fpm with the new setting
■ > ws service php-fpm restart
----------------------------------
Full Logs :-
  stdout: /tmp/my127ws-stdout.txt
  stderr: /tmp/my127ws-stderr.txt

/tmp/my127ws-stdout.txt:
■ > ws install --step=prepare
■ > docker-compose exec console bash -c cp -r /.my127ws/docker/image/console/root/usr/local/etc/php/conf.d/* /usr/local/etc/php/conf.d/
cp: missing file operand
Try 'cp --help' for more information
```