### PR TITLE
Use magento root directory for module manifest

### DIFF
--- a/src/magento2/application/skeleton/phpstan.neon
+++ b/src/magento2/application/skeleton/phpstan.neon
@@ -5,6 +5,7 @@ parameters:
     bootstrapFiles:
         - tools/devtools-bootstrap.php
     paths:
+        - app/etc/InviqaNonComposerComponentRegistration.php
         - src
     excludes_analyse:
         - */src/**/registration.php


### PR DESCRIPTION
Previously, the generated module_manifest.php would contain entries such as `/app/src/Example/Module/registration.php`.

This isn't portable outside of a docker image where /app is the mountpoint, e.g. a traditional server deployment.