### PR TITLE
Fix Spryker build by not updating spryker web-profiler dependencies

### DIFF
--- a/src/spryker/application/skeleton/composer-harness.json
+++ b/src/spryker/application/skeleton/composer-harness.json
@@ -3,9 +3,6 @@
   "description": "Startup template for Spryker projects.",
   "type": "project",
   "require": {
-    "spryker/web-profiler": "^1.6",
-    "spryker-shop/web-profiler-widget": "^1.4",
-    "twig/twig": "^3.0"
   },
   "require-dev": {
     "codeception/codeception": "~2.5.6",
@@ -19,8 +16,7 @@
     "friends-of-behat/context-service-extension": "^1.2",
     "friends-of-behat/cross-container-extension": "^1.1",
     "phpcompatibility/php-compatibility": "dev-master",
-    "sensiolabs/behat-page-object-extension": "^2.3",
-    "spryker-sdk/spryk": "^0.2.7"
+    "sensiolabs/behat-page-object-extension": "^2.3"
   },
   "autoload-dev": {
     "psr-4": {

--- a/src/spryker/application/skeleton/composer-harness.json
+++ b/src/spryker/application/skeleton/composer-harness.json
@@ -4,7 +4,8 @@
   "type": "project",
   "require": {
     "spryker/web-profiler": "^1.6",
-    "spryker-shop/web-profiler-widget": "^1.4"
+    "spryker-shop/web-profiler-widget": "^1.4",
+    "twig/twig": "^3.0"
   },
   "require-dev": {
     "codeception/codeception": "~2.5.6",
@@ -18,7 +19,8 @@
     "friends-of-behat/context-service-extension": "^1.2",
     "friends-of-behat/cross-container-extension": "^1.1",
     "phpcompatibility/php-compatibility": "dev-master",
-    "sensiolabs/behat-page-object-extension": "^2.3"
+    "sensiolabs/behat-page-object-extension": "^2.3",
+    "spryker-sdk/spryk": "^0.2.7"
   },
   "autoload-dev": {
     "psr-4": {

--- a/src/spryker/docker/image/console/root/lib/task/skeleton/apply.sh.twig
+++ b/src/spryker/docker/image/console/root/lib/task/skeleton/apply.sh.twig
@@ -37,4 +37,7 @@ function merge_composer_json()
     {% verbatim %}
     [ "${#new_composer_packages[@]}" -gt 0 ] && passthru env COMPOSER_PROCESS_TIMEOUT=600 composer update --with-dependencies --no-interaction --profile "${new_composer_packages[@]}"
     {% endverbatim %}
+
+    # Move web-profiler from packages-dev to packages due to broken dependencies
+    composer require spryker/web-profiler:^1.6 spryker-shop/web-profiler-widget:^1.4
 }


### PR DESCRIPTION
Doing a separate require stops the `composer update --with-dependencies` in https://github.com/inviqa/harness-base-php/blob/0.10.x/src/spryker/docker/image/console/root/lib/task/skeleton/apply.sh.twig#L38 from updating core spryker dependencies.

Fixes #401 