### PR TITLE
MISC Fix testing notes in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ cd `<framework>-test`
 ```
 5. Update the override file in `<framework>-test`:
 ```bash
-echo 'attribute(\'mutagen\'): no' >> workspace.override.yml
+echo "attribute('mutagen'): no" >> workspace.override.yml
 ```
 6. Run in `pipeline` mode to activate `static` mode
 ```bash


### PR DESCRIPTION
```
$ echo 'attribute(\'mutagen\'): no' >> workspace.override.yml
bash: syntax error near unexpected token `)')
```

vs
```
$ echo "attribute('mutagen'): no" >> workspace.override.yml
$
```