### PR TITLE
Switch to PSR12 coding standard

### DIFF
--- a/src/magento2/application/overlay/phpcs.xml
+++ b/src/magento2/application/overlay/phpcs.xml
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ruleset name="Inviqa">
-    <description>Inviqa Magento2 PSR2 codesniffer configuration</description>
+    <description>Inviqa Magento2 PSR12 codesniffer configuration</description>
 
-    <rule ref="PSR2"/>
+    <rule ref="PSR12"/>
 
     <file>./src</file>
 
-    <exclude-pattern>*/migrations/*</exclude-pattern>
-    <exclude-pattern>*/Setup/*</exclude-pattern>
     <exclude-pattern>*/Standards/*/Tests/*\.(inc|css|js)</exclude-pattern>
 
     <config name="installed_paths" value="vendor/slevomat/coding-standard" />
@@ -53,12 +51,18 @@
             <property name="forbiddenAnnotations" type="array">
                 <element value="@author" />
                 <element value="@package" />
-                <element value="@api" />
             </property>
         </properties>
     </rule>
 
     <rule ref="SlevomatCodingStandard.Classes.ClassConstantVisibility" />
+
+    <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">
+        <properties>
+            <property name="newlinesCountBetweenOpenTagAndDeclare" value="2"/>
+            <property name="spacesCountAroundEqualsSign" value="0"/>
+        </properties>
+    </rule>
 
     <arg name="extensions" value="php" />
     <arg name="report" value="full" />

--- a/src/magento2/application/skeleton/src/Acme/HelloWorld.php
+++ b/src/magento2/application/skeleton/src/Acme/HelloWorld.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Acme;
 
 class HelloWorld


### PR DESCRIPTION
[PSR2](https://www.php-fig.org/psr/psr-2/) coding standard is deprecated since 2019-08-10, so it is time to switch to the "new" [PSR12](https://www.php-fig.org/psr/psr-12/) coding standard.

*Changelog:*
- Switch from PSR2 to PSR12 coding standard
- Update phpcs configuration to require strict type declaration
- Remove unnecessarily ignored paths (migration folder no longer used - it was used by phinx, which no longer needed, also the Setup namespace now contains separate data patches rather than a huge UpgradeData class, so no need to exclude those from php check style)
- Removed disallowed "@api" annotation, since that's something which recommended to use when developing M2 modules


Also I have updated the phpcs configuration to require strict type declaration from now on.