### PR TITLE
Use original base64 -d for support in more linuxes

### DIFF
--- a/src/_base/harness/config/pipeline.yml
+++ b/src/_base/harness/config/pipeline.yml
@@ -41,7 +41,7 @@ command('app publish chart <release> <message>'):
     #!bash(workspace:/)|@
 
     run rm -rf build-artifacts-repository
-    echo "${SSH_PRIVATE_KEY}" | base64 --decode > id_rsa
+    echo "${SSH_PRIVATE_KEY}" | base64 -d > id_rsa
     chmod 0600 id_rsa
 
     export GIT_SSH_COMMAND='ssh -i ./id_rsa -o "IdentitiesOnly yes" -F /dev/null -o StrictHostKeyChecking=no'


### PR DESCRIPTION
Its more important for the base64 decode to work in alpine than macos