### PR TITLE
Add Tideways Support

### DIFF
--- a/src/_base/.ci/sample-static/workspace.yml
+++ b/src/_base/.ci/sample-static/workspace.yml
@@ -14,6 +14,9 @@ attribute('app.repository'): null
 attribute('aws.id'): null
 attribute('aws.key'): null
 
+attribute('php.cli.install_extensions'):
+  - sockets
+
 before('harness.install'): |
   #!bash(workspace:/)|@
   if [ ! -d public/ ]; then

--- a/src/_base/_twig/docker-compose.yml/service/tideways.yml.twig
+++ b/src/_base/_twig/docker-compose.yml/service/tideways.yml.twig
@@ -1,0 +1,11 @@
+  tideways:
+    build:
+      context: .my127ws/docker/image/tideways/
+    labels:
+      - traefik.enable=false
+    environment: {{ to_nice_yaml(deep_merge([
+        @('services.tideways.environment'),
+        @('services.tideways.environment_secrets')
+      ]), 2, 6) | raw }}
+    networks:
+      - private

--- a/src/_base/docker/image/console/Dockerfile.twig
+++ b/src/_base/docker/image/console/Dockerfile.twig
@@ -8,6 +8,12 @@ RUN chown -R build:build /home/build \
  && chmod +x /sbin/tini \
  && curl --fail --silent --location --output /usr/local/bin/mhsendmail https://github.com/mailhog/mhsendmail/releases/download/v0.2.0/mhsendmail_linux_amd64 \
  && chmod +x /usr/local/bin/mhsendmail
+{%- set install_extensions=@('php.install_extensions')|merge(@('php.cli.install_extensions'))|filter(v => v is not empty) %}
+{%- if install_extensions %} \
+ && cd /root/installer \
+ && ./enable.sh \
+    {{ install_extensions|join(" \\\n    ") }}
+{% endif %}
 
 ENV APP_MODE={{ @('app.mode') }} \
   APP_BUILD={{ @('app.build') }} \

--- a/src/_base/docker/image/console/root/usr/local/etc/php/conf.d/docker-php-ext-tideways.ini.twig
+++ b/src/_base/docker/image/console/root/usr/local/etc/php/conf.d/docker-php-ext-tideways.ini.twig
@@ -1,0 +1,8 @@
+{% set tideways = @('php.ext-tideways') %}
+
+{% if tideways.cli.enable == 'yes' %}
+  extension=tideways.so
+  {% for key, value in tideways.config -%}
+    tideways.{{ key }}={{ value }}
+  {% endfor %}
+{% endif %}

--- a/src/_base/docker/image/php-fpm/Dockerfile.twig
+++ b/src/_base/docker/image/php-fpm/Dockerfile.twig
@@ -12,6 +12,12 @@ RUN curl --fail --silent --location --output /sbin/tini https://github.com/krall
  && chmod +x /sbin/tini \
  && curl --fail --silent --location --output /usr/local/bin/mhsendmail https://github.com/mailhog/mhsendmail/releases/download/v0.2.0/mhsendmail_linux_amd64 \
  && chmod +x /usr/local/bin/mhsendmail
+{%- set install_extensions=@('php.install_extensions')|merge(@('php.fpm.install_extensions'))|filter(v => v is not empty) %}
+{%- if install_extensions %} \
+ && cd /root/installer \
+ && ./enable.sh \
+    {{ install_extensions|join(" \\\n    ") }}
+{% endif %}
 
 {% if @('app.build') == 'static' %}
 COPY --from=console --chown=root:root /app /app

--- a/src/_base/docker/image/php-fpm/root/usr/local/etc/php/conf.d/docker-php-ext-tideways.ini.twig
+++ b/src/_base/docker/image/php-fpm/root/usr/local/etc/php/conf.d/docker-php-ext-tideways.ini.twig
@@ -1,0 +1,8 @@
+{% set tideways = @('php.ext-tideways') %}
+
+{% if tideways.enable == 'yes' %}
+  extension=tideways.so
+  {% for key, value in tideways.config -%}
+    tideways.{{ key }}={{ value }}
+  {% endfor %}
+{% endif %}

--- a/src/_base/docker/image/tideways/Dockerfile
+++ b/src/_base/docker/image/tideways/Dockerfile
@@ -1,0 +1,16 @@
+FROM debian:stable-slim
+
+ARG TIDEWAYS_ENVIRONMENT_DEFAULT=production
+ENV TIDEWAYS_ENVIRONMENT=$TIDEWAYS_ENVIRONMENT_DEFAULT
+ENV TIDEWAYS_HOSTNAME=tideways-daemon
+
+RUN apt-get update && apt-get install -yq --no-install-recommends gnupg2 curl sudo ca-certificates
+
+RUN echo 'deb https://packages.tideways.com/apt-packages debian main' > /etc/apt/sources.list.d/tideways.list && \
+    curl -L -sS 'https://packages.tideways.com/key.gpg' | apt-key add -
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -yq tideways-daemon && \
+    apt-get autoremove --assume-yes && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+ENTRYPOINT ["/bin/sh", "-c", "exec tideways-daemon --address=0.0.0.0:9135 --hostname=$TIDEWAYS_HOSTNAME"]

--- a/src/_base/harness/attributes/common.yml
+++ b/src/_base/harness/attributes/common.yml
@@ -195,6 +195,15 @@ attributes.default:
       realpath_cache_ttl: 600
       sendmail_path: = '\'/usr/local/bin/mhsendmail --smtp-addr="' ~ @('smtp.host') ~ ':' ~ @('smtp.port') ~ '"\''
       short_open_tag: Off
+    ext-tideways:
+      enable: no
+      cli:
+        enable: no
+      config:
+        connection: "tcp://tideways:9135"
+        collect: tracing
+        sample_rate: 25
+        service: web
     ext-xdebug:
       enable: no
       cli:

--- a/src/_base/harness/attributes/common.yml
+++ b/src/_base/harness/attributes/common.yml
@@ -176,6 +176,7 @@ attributes.default:
       ini:
         max_execution_time: 0
         memory_limit: -1
+      install_extensions: []
     fpm:
       ini:
         disable_functions: pcntl_alarm,pcntl_fork,pcntl_waitpid,pcntl_wait,pcntl_wifexited,pcntl_wifstopped,pcntl_wifsignaled,pcntl_wifcontinued,pcntl_wexitstatus,pcntl_wtermsig,pcntl_wstopsig,pcntl_signal,pcntl_signal_get_handler,pcntl_signal_dispatch,pcntl_get_last_error,pcntl_strerror,pcntl_sigprocmask,pcntl_sigwaitinfo,pcntl_sigtimedwait,pcntl_exec,pcntl_getpriority,pcntl_setpriority,pcntl_async_signals
@@ -189,12 +190,15 @@ attributes.default:
         register_argc_argv: Off
         request_order: GP
         variables_order: GPCS
+      install_extensions: []
     ini:
       enable_dl: Off
       opcache.enable_cli: On
       realpath_cache_ttl: 600
       sendmail_path: = '\'/usr/local/bin/mhsendmail --smtp-addr="' ~ @('smtp.host') ~ ':' ~ @('smtp.port') ~ '"\''
       short_open_tag: Off
+    install_extensions:
+      - "= ('tideways' in @('app.services') ? 'tideways' : '')"
     ext-tideways:
       enable: no
       cli:

--- a/src/_base/harness/attributes/docker-base.yml
+++ b/src/_base/harness/attributes/docker-base.yml
@@ -28,6 +28,7 @@ attributes:
       environment_secrets:
         DB_PASS: = @('database.pass')
         RABBITMQ_PASSWORD: = @('rabbitmq.password')
+        TIDEWAYS_APIKEY: ""
     nginx:
       image: = @('docker.repository') ~ ':' ~ @('app.version') ~ '-nginx'
       publish: true
@@ -94,6 +95,11 @@ attributes:
     redis_session:
       enabled: "= 'redis_session' in @('app.services')"
       image: redis:4-alpine
+    tideways:
+      enabled: "= 'tideways' in @('app.services')"
+      environment:
+        TIDEWAYS_HOSTNAME: = @('hostname')
+        TIDEWAYS_ENV: production
     varnish:
       enabled: "= 'varnish' in @('app.services')"
       image: varnish:6

--- a/src/_base/harness/config/commands.yml
+++ b/src/_base/harness/config/commands.yml
@@ -190,6 +190,41 @@ command('set <attribute> <value>'):
     echo "Setting '${ATTR_KEY}' setting to '${ATTR_VAL}' in workspace.override.yml"
     echo "attribute('${ATTR_KEY}'): ${ATTR_VAL}" >> workspace.override.yml
 
+command('feature tideways (on|off)'):
+  env:
+    ATTR_KEY: 'php.ext-tideways.enable'
+    ATTR_VAL: = input.command(3) == 'on' ? 'yes':'no'
+  exec: |
+    #!bash(workspace:/)|=
+    ws set $ATTR_KEY $ATTR_VAL
+    echo 'Updating templates in .my127ws/'
+    run ws install --step=prepare
+    echo 'Bringing up php-fpm with the new setting'
+    run ws service php-fpm restart
+    echo 'Done'
+
+command('feature tideways cli (on|off)'):
+  env:
+    ATTR_KEY: 'php.ext-tideways.cli.enable'
+    ATTR_VAL: = input.command(4) == 'on' ? 'yes':'no'
+  exec: |
+    #!bash(workspace:/)|=
+    ws set $ATTR_KEY $ATTR_VAL
+    echo 'Updating templates in .my127ws/'
+    run ws install --step=prepare
+    echo 'Bringing up console with the new setting'
+    run ws service php-fpm restart
+    echo 'Done'
+
+command('feature tideways cli configure <server_key>'):
+  env:
+    TIDEWAYS_SERVERKEY: = input.argument('server_key')
+  exec: |
+    #!bash(workspace:/)|=
+    echo "Importing Provided Tideways CLI Key (from https://app.tideways.io/user/cli-import-settings)"
+    docker-compose exec -T -u build console tideways import "$TIDEWAYS_SERVERKEY"
+    echo "Imported Tideways CLI key"
+
 command('feature xdebug (on|off)'):
   env:
     ATTR_KEY: 'php.ext-xdebug.enable'

--- a/src/_base/harness/config/confd.yml
+++ b/src/_base/harness/config/confd.yml
@@ -13,6 +13,7 @@ confd('harness:/'):
   - { src: docker/image/console/root/lib/task/rabbitmq/vhosts.sh }
   - { src: docker/image/console/root/lib/task/welcome.sh }
   - { src: docker/image/console/root/usr/local/etc/php/php.ini }
+  - { src: docker/image/console/root/usr/local/etc/php/conf.d/docker-php-ext-tideways.ini }
   - { src: docker/image/console/root/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini }
   - { src: docker/image/nginx/Dockerfile }
   - { src: docker/image/nginx/root/docker-entrypoint.d/config_render.sh }
@@ -24,6 +25,7 @@ confd('harness:/'):
   - { src: docker/image/php-fpm/root/entrypoint.sh }
   - { src: docker/image/php-fpm/root/fix_app_permissions.sh }
   - { src: docker/image/php-fpm/root/usr/local/etc/php/php.ini }
+  - { src: docker/image/php-fpm/root/usr/local/etc/php/conf.d/docker-php-ext-tideways.ini }
   - { src: docker/image/php-fpm/root/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini }
   - { src: docker/image/php-fpm/root/usr/local/etc/php-fpm.d/pool.conf.template }
   - { src: docker/image/tls-offload/root/etc/nginx/conf.d/0-nginx.conf }

--- a/src/akeneo/docker/image/console/Dockerfile.twig
+++ b/src/akeneo/docker/image/console/Dockerfile.twig
@@ -8,6 +8,12 @@ RUN chown -R build:build /home/build \
  && chmod +x /sbin/tini \
  && curl --fail --silent --location --output /usr/local/bin/mhsendmail https://github.com/mailhog/mhsendmail/releases/download/v0.2.0/mhsendmail_linux_amd64 \
  && chmod +x /usr/local/bin/mhsendmail
+{%- set install_extensions=@('php.install_extensions')|merge(@('php.cli.install_extensions'))|filter(v => v is not empty) %}
+{%- if install_extensions %} \
+ && cd /root/installer \
+ && ./enable.sh \
+    {{ install_extensions|join(" \\\n    ") }}
+{% endif %}
 
 # gpg: key 5072E1F5: public key "MySQL Release Engineering <mysql-build@oss.oracle.com>" imported
 RUN apt-get update \

--- a/src/akeneo/harness/config/confd.yml
+++ b/src/akeneo/harness/config/confd.yml
@@ -13,6 +13,7 @@ confd('harness:/'):
   - { src: docker/image/console/root/lib/task/rabbitmq/vhosts.sh }
   - { src: docker/image/console/root/lib/task/welcome.sh }
   - { src: docker/image/console/root/usr/local/etc/php/php.ini }
+  - { src: docker/image/console/root/usr/local/etc/php/conf.d/docker-php-ext-tideways.ini }
   - { src: docker/image/console/root/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini }
   - { src: docker/image/nginx/Dockerfile }
   - { src: docker/image/nginx/root/docker-entrypoint.d/config_render.sh }
@@ -24,6 +25,7 @@ confd('harness:/'):
   - { src: docker/image/php-fpm/root/entrypoint.sh }
   - { src: docker/image/php-fpm/root/fix_app_permissions.sh }
   - { src: docker/image/php-fpm/root/usr/local/etc/php/php.ini }
+  - { src: docker/image/php-fpm/root/usr/local/etc/php/conf.d/docker-php-ext-tideways.ini }
   - { src: docker/image/php-fpm/root/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini }
   - { src: docker/image/php-fpm/root/usr/local/etc/php-fpm.d/pool.conf.template }
   - { src: docker/image/tls-offload/root/etc/nginx/conf.d/0-nginx.conf }

--- a/src/drupal8/harness/config/confd.yml
+++ b/src/drupal8/harness/config/confd.yml
@@ -13,6 +13,7 @@ confd('harness:/'):
   - { src: docker/image/console/root/lib/task/rabbitmq/vhosts.sh }
   - { src: docker/image/console/root/lib/task/welcome.sh }
   - { src: docker/image/console/root/usr/local/etc/php/php.ini }
+  - { src: docker/image/console/root/usr/local/etc/php/conf.d/docker-php-ext-tideways.ini }
   - { src: docker/image/console/root/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini }
   - { src: docker/image/nginx/Dockerfile }
   - { src: docker/image/nginx/root/docker-entrypoint.d/config_render.sh }
@@ -24,6 +25,7 @@ confd('harness:/'):
   - { src: docker/image/php-fpm/root/entrypoint.sh }
   - { src: docker/image/php-fpm/root/fix_app_permissions.sh }
   - { src: docker/image/php-fpm/root/usr/local/etc/php/php.ini }
+  - { src: docker/image/php-fpm/root/usr/local/etc/php/conf.d/docker-php-ext-tideways.ini }
   - { src: docker/image/php-fpm/root/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini }
   - { src: docker/image/php-fpm/root/usr/local/etc/php-fpm.d/pool.conf.template }
   - { src: docker/image/tls-offload/root/etc/nginx/conf.d/0-nginx.conf }

--- a/src/magento1/harness/config/confd.yml
+++ b/src/magento1/harness/config/confd.yml
@@ -13,6 +13,7 @@ confd('harness:/'):
   - { src: docker/image/console/root/lib/task/rabbitmq/vhosts.sh }
   - { src: docker/image/console/root/lib/task/welcome.sh }
   - { src: docker/image/console/root/usr/local/etc/php/php.ini }
+  - { src: docker/image/console/root/usr/local/etc/php/conf.d/docker-php-ext-tideways.ini }
   - { src: docker/image/console/root/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini }
   - { src: docker/image/nginx/Dockerfile }
   - { src: docker/image/nginx/root/docker-entrypoint.d/config_render.sh }
@@ -24,6 +25,7 @@ confd('harness:/'):
   - { src: docker/image/php-fpm/root/entrypoint.sh }
   - { src: docker/image/php-fpm/root/fix_app_permissions.sh }
   - { src: docker/image/php-fpm/root/usr/local/etc/php/php.ini }
+  - { src: docker/image/php-fpm/root/usr/local/etc/php/conf.d/docker-php-ext-tideways.ini }
   - { src: docker/image/php-fpm/root/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini }
   - { src: docker/image/php-fpm/root/usr/local/etc/php-fpm.d/pool.conf.template }
   - { src: docker/image/tls-offload/root/etc/nginx/conf.d/0-nginx.conf }

--- a/src/magento2/docker/image/console/Dockerfile.twig
+++ b/src/magento2/docker/image/console/Dockerfile.twig
@@ -8,6 +8,12 @@ RUN chown -R build:build /home/build \
  && chmod +x /sbin/tini \
  && curl --fail --silent --location --output /usr/local/bin/mhsendmail https://github.com/mailhog/mhsendmail/releases/download/v0.2.0/mhsendmail_linux_amd64 \
  && chmod +x /usr/local/bin/mhsendmail
+{%- set install_extensions=@('php.install_extensions')|merge(@('php.cli.install_extensions'))|filter(v => v is not empty) %}
+{%- if install_extensions %} \
+ && cd /root/installer \
+ && ./enable.sh \
+    {{ install_extensions|join(" \\\n    ") }}
+{% endif %}
 
 ENV APP_MODE={{ @('app.mode') }} \
   APP_BUILD={{ @('app.build') }} \

--- a/src/magento2/harness/config/confd.yml
+++ b/src/magento2/harness/config/confd.yml
@@ -13,6 +13,7 @@ confd('harness:/'):
   - { src: docker/image/console/root/lib/task/rabbitmq/vhosts.sh }
   - { src: docker/image/console/root/lib/task/welcome.sh }
   - { src: docker/image/console/root/usr/local/etc/php/php.ini }
+  - { src: docker/image/console/root/usr/local/etc/php/conf.d/docker-php-ext-tideways.ini }
   - { src: docker/image/console/root/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini }
   - { src: docker/image/nginx/Dockerfile }
   - { src: docker/image/nginx/root/docker-entrypoint.d/config_render.sh }
@@ -24,6 +25,7 @@ confd('harness:/'):
   - { src: docker/image/php-fpm/root/entrypoint.sh }
   - { src: docker/image/php-fpm/root/fix_app_permissions.sh }
   - { src: docker/image/php-fpm/root/usr/local/etc/php/php.ini }
+  - { src: docker/image/php-fpm/root/usr/local/etc/php/conf.d/docker-php-ext-tideways.ini }
   - { src: docker/image/php-fpm/root/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini }
   - { src: docker/image/php-fpm/root/usr/local/etc/php-fpm.d/pool.conf.template }
   - { src: docker/image/tls-offload/root/etc/nginx/conf.d/0-nginx.conf }

--- a/src/spryker/harness/config/confd.yml
+++ b/src/spryker/harness/config/confd.yml
@@ -13,6 +13,7 @@ confd('harness:/'):
   - { src: docker/image/console/root/lib/task/rabbitmq/vhosts.sh }
   - { src: docker/image/console/root/lib/task/welcome.sh }
   - { src: docker/image/console/root/usr/local/etc/php/php.ini }
+  - { src: docker/image/console/root/usr/local/etc/php/conf.d/docker-php-ext-tideways.ini }
   - { src: docker/image/console/root/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini }
   - { src: docker/image/nginx/Dockerfile }
   - { src: docker/image/nginx/root/docker-entrypoint.d/config_render.sh }
@@ -24,6 +25,7 @@ confd('harness:/'):
   - { src: docker/image/php-fpm/root/entrypoint.sh }
   - { src: docker/image/php-fpm/root/fix_app_permissions.sh }
   - { src: docker/image/php-fpm/root/usr/local/etc/php/php.ini }
+  - { src: docker/image/php-fpm/root/usr/local/etc/php/conf.d/docker-php-ext-tideways.ini }
   - { src: docker/image/php-fpm/root/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini }
   - { src: docker/image/php-fpm/root/usr/local/etc/php-fpm.d/pool.conf.template }
   - { src: docker/image/tls-offload/root/etc/nginx/conf.d/0-nginx.conf }

--- a/src/symfony/docker/image/console/Dockerfile.twig
+++ b/src/symfony/docker/image/console/Dockerfile.twig
@@ -8,6 +8,12 @@ RUN chown -R build:build /home/build \
  && chmod +x /sbin/tini \
  && curl --fail --silent --location --output /usr/local/bin/mhsendmail https://github.com/mailhog/mhsendmail/releases/download/v0.2.0/mhsendmail_linux_amd64 \
  && chmod +x /usr/local/bin/mhsendmail
+{%- set install_extensions=@('php.install_extensions')|merge(@('php.cli.install_extensions'))|filter(v => v is not empty) %}
+{%- if install_extensions %} \
+ && cd /root/installer \
+ && ./enable.sh \
+    {{ install_extensions|join(" \\\n    ") }}
+{% endif %}
 
 ENV APP_MODE={{ @('app.mode') }} \
   APP_BUILD={{ @('app.build') }} \

--- a/src/symfony/harness/config/confd.yml
+++ b/src/symfony/harness/config/confd.yml
@@ -13,6 +13,7 @@ confd('harness:/'):
   - { src: docker/image/console/root/lib/task/rabbitmq/vhosts.sh }
   - { src: docker/image/console/root/lib/task/welcome.sh }
   - { src: docker/image/console/root/usr/local/etc/php/php.ini }
+  - { src: docker/image/console/root/usr/local/etc/php/conf.d/docker-php-ext-tideways.ini }
   - { src: docker/image/console/root/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini }
   - { src: docker/image/nginx/Dockerfile }
   - { src: docker/image/nginx/root/docker-entrypoint.d/config_render.sh }
@@ -24,6 +25,7 @@ confd('harness:/'):
   - { src: docker/image/php-fpm/root/entrypoint.sh }
   - { src: docker/image/php-fpm/root/fix_app_permissions.sh }
   - { src: docker/image/php-fpm/root/usr/local/etc/php/php.ini }
+  - { src: docker/image/php-fpm/root/usr/local/etc/php/conf.d/docker-php-ext-tideways.ini }
   - { src: docker/image/php-fpm/root/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini }
   - { src: docker/image/php-fpm/root/usr/local/etc/php-fpm.d/pool.conf.template }
   - { src: docker/image/tls-offload/root/etc/nginx/conf.d/0-nginx.conf }

--- a/src/wordpress/harness/config/confd.yml
+++ b/src/wordpress/harness/config/confd.yml
@@ -13,6 +13,7 @@ confd('harness:/'):
   - { src: docker/image/console/root/lib/task/rabbitmq/vhosts.sh }
   - { src: docker/image/console/root/lib/task/welcome.sh }
   - { src: docker/image/console/root/usr/local/etc/php/php.ini }
+  - { src: docker/image/console/root/usr/local/etc/php/conf.d/docker-php-ext-tideways.ini }
   - { src: docker/image/console/root/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini }
   - { src: docker/image/nginx/Dockerfile }
   - { src: docker/image/nginx/root/docker-entrypoint.d/config_render.sh }
@@ -24,6 +25,7 @@ confd('harness:/'):
   - { src: docker/image/php-fpm/root/entrypoint.sh }
   - { src: docker/image/php-fpm/root/fix_app_permissions.sh }
   - { src: docker/image/php-fpm/root/usr/local/etc/php/php.ini }
+  - { src: docker/image/php-fpm/root/usr/local/etc/php/conf.d/docker-php-ext-tideways.ini }
   - { src: docker/image/php-fpm/root/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini }
   - { src: docker/image/php-fpm/root/usr/local/etc/php-fpm.d/pool.conf.template }
   - { src: docker/image/tls-offload/root/etc/nginx/conf.d/0-nginx.conf }


### PR DESCRIPTION
Pairs with https://github.com/my127/docker-php/pull/38

* Add support for https://tideways.com/ being enabled or disabled ala Xdebug.
* Install extensions for console and php-fpm via attributes instead of having to override the template in the project.