### PR TITLE
Wait for elasticsearch before using it in akeneo

### DIFF
--- a/src/akeneo/harness.yml
+++ b/src/akeneo/harness.yml
@@ -46,6 +46,7 @@ attributes:
         - run "set -e -o pipefail; pv --force \"$1\" | zcat | mysql -h \"$DB_HOST\" -u \"$DB_ADMIN_USER\" -p\"$DB_ADMIN_PASS\" \"$DB_NAME\""
         - passthru bin/console doctrine:migrations:migrate --no-interaction --allow-no-migration
         - passthru echo 'Reindexing Elasticsearch'
+        - task http:wait elasticsearch:9200
         - run bin/console akeneo:elasticsearch:reset-indexes -n
         - run bin/console pim:product:index --all
         - run bin/console pim:product-model:index --all
@@ -64,6 +65,7 @@ attributes:
     init:
       steps:
         - passthru bin/console doctrine:migrations:migrate --no-interaction --allow-no-migration
+        - task http:wait elasticsearch:9200
         - run bin/console akeneo:elasticsearch:reset-indexes --no-interaction
         - run bin/console pim:product:index --all
         - run bin/console pim:product-model:index --all


### PR DESCRIPTION
Otherwise, we randomly get this in builds:
```
 ERROR     [console] Error thrown while running command "akeneo:elasticsearch:reset-indexes --no-interaction". Message: "No alive nodes found in your cluster" ["exception" => Elasticsearch\Common\Exceptions\NoNodesAvailableException { …},"command" => "akeneo:elasticsearch:reset-indexes --no-interaction","message" => "No alive nodes found in your cluster"]
```