### PR TITLE
Akeneo - fix random build failures

### DIFF
--- a/src/_base/harness/scripts/enable.sh.twig
+++ b/src/_base/harness/scripts/enable.sh.twig
@@ -50,6 +50,9 @@ dynamic()
         passthru docker-compose build jenkins-runner
     {% endif %}
 
+    # Bring up console to fix file permissions
+    passthru docker-compose up -d console
+
     # Bring up all services apart from cron and jenkins-runner
     passthru "docker-compose config --services | grep -v cron | grep -v jenkins-runner | xargs docker-compose up -d"
 

--- a/src/akeneo/harness.yml
+++ b/src/akeneo/harness.yml
@@ -59,6 +59,7 @@ attributes:
         - task composer:install
     install:
       steps:
+        - task http:wait elasticsearch:9200
         - passthru bin/console pim:installer:db --catalog vendor/akeneo/pim-community-dev/src/Akeneo/Platform/Bundle/InstallerBundle/Resources/fixtures/minimal
         - task overlay:apply
         - task assets:dump

--- a/src/akeneo/harness/scripts/enable.sh.twig
+++ b/src/akeneo/harness/scripts/enable.sh.twig
@@ -41,6 +41,10 @@ dynamic()
 
     ws external-images pull
 
+    # Bring up console to fix file permissions
+    passthru docker-compose up -d console
+
+    # Bring up all services apart from cron and job-queue-consumer
     passthru "docker-compose config --services | grep -v cron | grep -v job-queue-consumer | xargs docker-compose build"
     passthru docker-compose build cron job-queue-consumer
 


### PR DESCRIPTION
* Wait for elasticsearch before install
* Bring up console first, so it can do it's entrypoint.dynamic.sh chown of /app to match the build user.
* Then bring up php-fpm and everything else, so www-data will be the same UID as the build user and be able to write to `var/logs/dev.log`.

Previously, UID 1000 owned the /app/var/ folder but www-data was UID 33 still, due to a parallel startup.