### PR TITLE
Spryker - Do not wait 60 seconds if the queue is empty

### DIFF
--- a/src/spryker/application/skeleton/config/install/docker.yml.twig
+++ b/src/spryker/application/skeleton/config/install/docker.yml.twig
@@ -220,7 +220,7 @@ sections:
 
     queue-worker:
         run:
-            command: "vendor/bin/console queue:worker:start -vvv"
+            command: "vendor/bin/console queue:worker:start --stop-when-empty -vvv"
             stores:
                 - DE
                 - AT


### PR DESCRIPTION
Now that we are on the January 2020 release of Spryker demoshop, we can use the `--stop-when-empty` flag to save 3 minutes on the build of Spryker per static/dynamic build, so 9 minutes!

Previously added to #319 but reverted due to older version of the demoshop being used.