### PR TITLE
Test using 3 Jenkins workers

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,7 @@ pipeline {
     }
     options {
         buildDiscarder(logRotator(daysToKeepStr: '30'))
+        parallelsAlwaysFailFast()
     }
     triggers { cron(env.BRANCH_NAME ==~ /^\d+\.\d+\.x$/ ? 'H H(0-6) * * *' : '') }
     stages {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     stages {
         stage('Build and Test') {
             parallel {
-                stage('1. PHP, Symfony, Wordpress, Akeneo') {
+                stage('1. PHP, Drupal 8, Akeneo') {
                     agent { label "my127ws" }
                     stages {
                         stage('Prepare') {
@@ -19,11 +19,8 @@ pipeline {
                         stage('PHP Static') {
                             steps { sh './test php static' }
                         }
-                        stage('Symfony Static') {
-                            steps { sh './test symfony static' }
-                        }
-                        stage('Wordpress Static') {
-                            steps { sh './test wordpress static' }
+                        stage('Drupal 8 Static') {
+                            steps { sh './test drupal8 static' }
                         }
                         stage('Akeneo Static') {
                             steps { sh './test akeneo static' }
@@ -31,11 +28,8 @@ pipeline {
                         stage('PHP Dynamic') {
                             steps { sh './test php dynamic' }
                         }
-                        stage('Symfony Dynamic') {
-                            steps { sh './test symfony dynamic' }
-                        }
-                        stage('Wordpress Dynamic') {
-                            steps { sh './test wordpress dynamic' }
+                        stage('Drupal 8 Dynamic') {
+                            steps { sh './test drupal8 dynamic' }
                         }
                         stage('Akeneo Dynamic') {
                             steps { sh './test akeneo dynamic' }
@@ -43,11 +37,8 @@ pipeline {
                         stage('PHP Dynamic Mutagen') {
                             steps { sh './test php dynamic mutagen' }
                         }
-                        stage('Symfony Dynamic Mutagen') {
-                            steps { sh './test symfony dynamic mutagen' }
-                        }
-                        stage('Wordpress Dynamic Mutagen') {
-                            steps { sh './test wordpress dynamic mutagen' }
+                        stage('Drupal 8 Dynamic Mutagen') {
+                            steps { sh './test drupal8 dynamic mutagen' }
                         }
                         stage('Akeneo Dynamic Mutagen') {
                             steps { sh './test akeneo dynamic mutagen' }
@@ -61,38 +52,38 @@ pipeline {
                         }
                     }
                 }
-                stage('2. Drupal 8, Magento 1, Magento 2') {
+                stage('2. Symfony, Magento 2, Magento 1') {
                     agent { label "my127ws" }
                     stages {
                         stage('Prepare') {
                             steps { sh './build' }
                         }
-                        stage('Drupal 8 Static') {
-                            steps { sh './test drupal8 static' }
-                        }
-                        stage('Magento 1 Static') {
-                            steps { sh './test magento1 static' }
+                        stage('Symfony Static') {
+                            steps { sh './test symfony static' }
                         }
                         stage('Magento 2 Static') {
                             steps { sh './test magento2 static' }
                         }
-                        stage('Drupal 8 Dynamic') {
-                            steps { sh './test drupal8 dynamic' }
+                        stage('Magento 1 Static') {
+                            steps { sh './test magento1 static' }
                         }
-                        stage('Magento 1 Dynamic') {
-                            steps { sh './test magento1 dynamic' }
+                        stage('Symfony Dynamic') {
+                            steps { sh './test symfony dynamic' }
                         }
                         stage('Magento 2 Dynamic') {
                             steps { sh './test magento2 dynamic' }
                         }
-                        stage('Drupal 8 Dynamic Mutagen') {
-                            steps { sh './test drupal8 dynamic mutagen' }
+                        stage('Magento 1 Dynamic') {
+                            steps { sh './test magento1 dynamic' }
                         }
-                        stage('Magento 1 Dynamic Mutagen') {
-                            steps { sh './test magento1 dynamic mutagen' }
+                        stage('Symfony Dynamic Mutagen') {
+                            steps { sh './test symfony dynamic mutagen' }
                         }
                         stage('Magento 2 Dynamic Mutagen') {
                             steps { sh './test magento2 dynamic mutagen' }
+                        }
+                        stage('Magento 1 Dynamic Mutagen') {
+                            steps { sh './test magento1 dynamic mutagen' }
                         }
                     }
                     post {
@@ -103,17 +94,26 @@ pipeline {
                         }
                     }
                 }
-                stage('3. Spryker') {
+                stage('3. Wordpress, Spryker') {
                     agent { label "my127ws" }
                     stages {
                         stage('Prepare') {
                             steps { sh './build' }
                         }
+                        stage('Wordpress Static') {
+                            steps { sh './test wordpress static' }
+                        }
                         stage('Spryker Static') {
                             steps { sh './test spryker static' }
                         }
+                        stage('Wordpress Dynamic') {
+                            steps { sh './test wordpress dynamic' }
+                        }
                         stage('Spryker Dynamic') {
                             steps { sh './test spryker dynamic' }
+                        }
+                        stage('Wordpress Dynamic Mutagen') {
+                            steps { sh './test wordpress dynamic mutagen' }
                         }
                         stage('Spryker Dynamic Mutagen') {
                             steps { sh './test spryker dynamic mutagen' }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,29 +52,14 @@ pipeline {
                         }
                     }
                 }
-                stage('3. Spryker Static') {
+                stage('3. Spryker') {
                     agent { label "my127ws" }
-                    steps { sh './build && ./test spryker static' }
-                    post {
-                        always {
-                            sh 'ws destroy || true'
-                            cleanWs()
-                        }
+                    steps {
+                        sh './build'
+                        sh './test spryker static'
+                        sh './test spryker dynamic'
+                        sh './test spryker dynamic mutagen'
                     }
-                }
-                stage('4. Spryker Dynamic') {
-                    agent { label "my127ws" }
-                    steps { sh './build && ./test spryker dynamic' }
-                    post {
-                        always {
-                            sh 'ws destroy || true'
-                            cleanWs()
-                        }
-                    }
-                }
-                stage('5. Spryker Dynamic Mutagen') {
-                    agent { label "my127ws" }
-                    steps { sh './build && ./test spryker dynamic mutagen' }
                     post {
                         always {
                             sh 'ws destroy || true'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,12 +17,15 @@ pipeline {
                         sh './test php static'
                         sh './test symfony static'
                         sh './test wordpress static'
+                        sh './test akeneo static'
                         sh './test php dynamic'
                         sh './test symfony dynamic'
                         sh './test wordpress dynamic'
+                        sh './test akeneo dynamic'
                         sh './test php dynamic mutagen'
                         sh './test symfony dynamic mutagen'
                         sh './test wordpress dynamic mutagen'
+                        sh './test akeneo dynamic mutagen'
                     }
                     post {
                         always {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,23 +12,50 @@ pipeline {
             parallel {
                 stage('1. PHP, Symfony, Wordpress, Akeneo') {
                     agent { label "my127ws" }
-                    steps {
-                        sh './build'
-                        sh './test php static'
-                        sh './test symfony static'
-                        sh './test wordpress static'
-                        sh './test akeneo static'
-                        sh './test php dynamic'
-                        sh './test symfony dynamic'
-                        sh './test wordpress dynamic'
-                        sh './test akeneo dynamic'
-                        sh './test php dynamic mutagen'
-                        sh './test symfony dynamic mutagen'
-                        sh './test wordpress dynamic mutagen'
-                        sh './test akeneo dynamic mutagen'
+                    stages {
+                        stage('Prepare') {
+                            steps { sh './build' }
+                        }
+                        stage('PHP Static') {
+                            steps { sh './test php static' }
+                        }
+                        stage('Symfony Static') {
+                            steps { sh './test symfony static' }
+                        }
+                        stage('Wordpress Static') {
+                            steps { sh './test wordpress static' }
+                        }
+                        stage('Akeneo Static') {
+                            steps { sh './test akeneo static' }
+                        }
+                        stage('PHP Dynamic') {
+                            steps { sh './test php dynamic' }
+                        }
+                        stage('Symfony Dynamic') {
+                            steps { sh './test symfony dynamic' }
+                        }
+                        stage('Wordpress Dynamic') {
+                            steps { sh './test wordpress dynamic' }
+                        }
+                        stage('Akeneo Dynamic') {
+                            steps { sh './test akeneo dynamic' }
+                        }
+                        stage('PHP Dynamic Mutagen') {
+                            steps { sh './test php dynamic mutagen' }
+                        }
+                        stage('Symfony Dynamic Mutagen') {
+                            steps { sh './test symfony dynamic mutagen' }
+                        }
+                        stage('Wordpress Dynamic Mutagen') {
+                            steps { sh './test wordpress dynamic mutagen' }
+                        }
+                        stage('Akeneo Dynamic Mutagen') {
+                            steps { sh './test akeneo dynamic mutagen' }
+                        }
                     }
                     post {
                         always {
+                            sh '(cd tmp-test && ws destroy) || true'
                             sh 'ws destroy || true'
                             cleanWs()
                         }
@@ -36,20 +63,41 @@ pipeline {
                 }
                 stage('2. Drupal 8, Magento 1, Magento 2') {
                     agent { label "my127ws" }
-                    steps {
-                        sh './build'
-                        sh './test drupal8 static'
-                        sh './test magento1 static'
-                        sh './test magento2 static'
-                        sh './test drupal8 dynamic'
-                        sh './test magento1 dynamic'
-                        sh './test magento2 dynamic'
-                        sh './test drupal8 dynamic mutagen'
-                        sh './test magento1 dynamic mutagen'
-                        sh './test magento2 dynamic mutagen'
+                    stages {
+                        stage('Prepare') {
+                            steps { sh './build' }
+                        }
+                        stage('Drupal 8 Static') {
+                            steps { sh './test drupal8 static' }
+                        }
+                        stage('Magento 1 Static') {
+                            steps { sh './test magento1 static' }
+                        }
+                        stage('Magento 2 Static') {
+                            steps { sh './test magento2 static' }
+                        }
+                        stage('Drupal 8 Dynamic') {
+                            steps { sh './test drupal8 dynamic' }
+                        }
+                        stage('Magento 1 Dynamic') {
+                            steps { sh './test magento1 dynamic' }
+                        }
+                        stage('Magento 2 Dynamic') {
+                            steps { sh './test magento2 dynamic' }
+                        }
+                        stage('Drupal 8 Dynamic Mutagen') {
+                            steps { sh './test drupal8 dynamic mutagen' }
+                        }
+                        stage('Magento 1 Dynamic Mutagen') {
+                            steps { sh './test magento1 dynamic mutagen' }
+                        }
+                        stage('Magento 2 Dynamic Mutagen') {
+                            steps { sh './test magento2 dynamic mutagen' }
+                        }
                     }
                     post {
                         always {
+                            sh '(cd tmp-test && ws destroy) || true'
                             sh 'ws destroy || true'
                             cleanWs()
                         }
@@ -57,14 +105,23 @@ pipeline {
                 }
                 stage('3. Spryker') {
                     agent { label "my127ws" }
-                    steps {
-                        sh './build'
-                        sh './test spryker static'
-                        sh './test spryker dynamic'
-                        sh './test spryker dynamic mutagen'
+                    stages {
+                        stage('Prepare') {
+                            steps { sh './build' }
+                        }
+                        stage('Spryker Static') {
+                            steps { sh './test spryker static' }
+                        }
+                        stage('Spryker Dynamic') {
+                            steps { sh './test spryker dynamic' }
+                        }
+                        stage('Spryker Dynamic Mutagen') {
+                            steps { sh './test spryker dynamic mutagen' }
+                        }
                     }
                     post {
                         always {
+                            sh '(cd tmp-test && ws destroy) || true'
                             sh 'ws destroy || true'
                             cleanWs()
                         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,102 +10,121 @@ pipeline {
     triggers { cron(env.BRANCH_NAME ==~ /^\d+\.\d+\.x$/ ? 'H H(0-6) * * *' : '') }
     stages {
         stage('Build and Test') {
-            matrix {
-                axes {
-                    axis {
-                        name 'FRAMEWORKS'
-                        values 'php|drupal8|akeneo', 'symfony|magento2|magento1', 'wordpress|spryker'
+            parallel {
+                stage('1. PHP, Drupal 8, Akeneo') {
+                    agent { label "my127ws" }
+                    stages {
+                        stage('Prepare') {
+                            steps { sh './build' }
+                        }
+                        stage('PHP Static') {
+                            steps { sh './test php static' }
+                        }
+                        stage('Drupal 8 Static') {
+                            steps { sh './test drupal8 static' }
+                        }
+                        stage('Akeneo Static') {
+                            steps { sh './test akeneo static' }
+                        }
+                        stage('PHP Dynamic') {
+                            steps { sh './test php dynamic' }
+                        }
+                        stage('Drupal 8 Dynamic') {
+                            steps { sh './test drupal8 dynamic' }
+                        }
+                        stage('Akeneo Dynamic') {
+                            steps { sh './test akeneo dynamic' }
+                        }
+                        stage('PHP Dynamic Mutagen') {
+                            steps { sh './test php dynamic mutagen' }
+                        }
+                        stage('Drupal 8 Dynamic Mutagen') {
+                            steps { sh './test drupal8 dynamic mutagen' }
+                        }
+                        stage('Akeneo Dynamic Mutagen') {
+                            steps { sh './test akeneo dynamic mutagen' }
+                        }
+                    }
+                    post {
+                        always {
+                            sh '(cd tmp-test && ws destroy) || true'
+                            sh 'ws destroy || true'
+                            cleanWs()
+                        }
                     }
                 }
-                stages {
-                    stage('Static Builds') {
-                        agent { label "my127ws" }
-                        stages {
-                            stage('Prepare') {
-                                steps { sh './build' }
-                            }
-                            stage('1 (mode=static)') {
-                                steps {
-                                    sh './test "$(echo "$FRAMEWORKS" | cut -d"|" -f1)" static'
-                                }
-                            }
-                            stage('2 (mode=static)') {
-                                steps {
-                                    sh './test "$(echo "$FRAMEWORKS" | cut -d"|" -f2)" static'
-                                }
-                            }
-                            stage('3 (mode=static)') {
-                                steps {
-                                    sh './test "$(echo "$FRAMEWORKS" | cut -d"|" -f3)" static'
-                                }
-                            }
+                stage('2. Symfony, Magento 2, Magento 1') {
+                    agent { label "my127ws" }
+                    stages {
+                        stage('Prepare') {
+                            steps { sh './build' }
                         }
-                        post {
-                            always {
-                                sh '(cd tmp-test && ws destroy) || true'
-                                sh 'ws destroy || true'
-                                cleanWs()
-                            }
+                        stage('Symfony Static') {
+                            steps { sh './test symfony static' }
                         }
-                    }
-                    stage('Dynamic Builds') {
-                        agent { label "my127ws" }
-                        stages {
-                            stage('Prepare') {
-                                steps { sh './build' }
-                            }
-                            stage('1 (mode=dynamic)') {
-                                steps {
-                                    sh './test "$(echo "$FRAMEWORKS" | cut -d"|" -f1)" dynamic'
-                                }
-                            }
-                            stage('2 (mode=dynamic)') {
-                                steps {
-                                    sh './test "$(echo "$FRAMEWORKS" | cut -d"|" -f2)" dynamic'
-                                }
-                            }
-                            stage('3 (mode=dynamic)') {
-                                steps {
-                                    sh './test "$(echo "$FRAMEWORKS" | cut -d"|" -f3)" dynamic'
-                                }
-                            }
+                        stage('Magento 2 Static') {
+                            steps { sh './test magento2 static' }
                         }
-                        post {
-                            always {
-                                sh '(cd tmp-test && ws destroy) || true'
-                                sh 'ws destroy || true'
-                                cleanWs()
-                            }
+                        stage('Magento 1 Static') {
+                            steps { sh './test magento1 static' }
+                        }
+                        stage('Symfony Dynamic') {
+                            steps { sh './test symfony dynamic' }
+                        }
+                        stage('Magento 2 Dynamic') {
+                            steps { sh './test magento2 dynamic' }
+                        }
+                        stage('Magento 1 Dynamic') {
+                            steps { sh './test magento1 dynamic' }
+                        }
+                        stage('Symfony Dynamic Mutagen') {
+                            steps { sh './test symfony dynamic mutagen' }
+                        }
+                        stage('Magento 2 Dynamic Mutagen') {
+                            steps { sh './test magento2 dynamic mutagen' }
+                        }
+                        stage('Magento 1 Dynamic Mutagen') {
+                            steps { sh './test magento1 dynamic mutagen' }
                         }
                     }
-                    stage('Dynamic Builds With Mutagen') {
-                        agent { label "my127ws" }
-                        stages {
-                            stage('Prepare') {
-                                steps { sh './build' }
-                            }
-                            stage('1 (mode=dynamic, sync=mutagen)') {
-                                steps {
-                                    sh './test "$(echo "$FRAMEWORKS" | cut -d"|" -f1)" dynamic mutagen'
-                                }
-                            }
-                            stage('2 (mode=dynamic, sync=mutagen)') {
-                                steps {
-                                    sh './test "$(echo "$FRAMEWORKS" | cut -d"|" -f2)" dynamic mutagen'
-                                }
-                            }
-                            stage('3 (mode=dynamic, sync=mutagen)') {
-                                steps {
-                                    sh './test "$(echo "$FRAMEWORKS" | cut -d"|" -f3)" dynamic mutagen'
-                                }
-                            }
+                    post {
+                        always {
+                            sh '(cd tmp-test && ws destroy) || true'
+                            sh 'ws destroy || true'
+                            cleanWs()
                         }
-                        post {
-                            always {
-                                sh '(cd tmp-test && ws destroy) || true'
-                                sh 'ws destroy || true'
-                                cleanWs()
-                            }
+                    }
+                }
+                stage('3. Wordpress, Spryker') {
+                    agent { label "my127ws" }
+                    stages {
+                        stage('Prepare') {
+                            steps { sh './build' }
+                        }
+                        stage('Wordpress Static') {
+                            steps { sh './test wordpress static' }
+                        }
+                        stage('Spryker Static') {
+                            steps { sh './test spryker static' }
+                        }
+                        stage('Wordpress Dynamic') {
+                            steps { sh './test wordpress dynamic' }
+                        }
+                        stage('Spryker Dynamic') {
+                            steps { sh './test spryker dynamic' }
+                        }
+                        stage('Wordpress Dynamic Mutagen') {
+                            steps { sh './test wordpress dynamic mutagen' }
+                        }
+                        stage('Spryker Dynamic Mutagen') {
+                            steps { sh './test spryker dynamic mutagen' }
+                        }
+                    }
+                    post {
+                        always {
+                            sh '(cd tmp-test && ws destroy) || true'
+                            sh 'ws destroy || true'
+                            cleanWs()
                         }
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,201 +8,47 @@ pipeline {
     }
     triggers { cron(env.BRANCH_NAME ==~ /^\d+\.\d+\.x$/ ? 'H H(0-6) * * *' : '') }
     stages {
-        axes {
-            axis {
-                name 'FRAMEWORK'
-                values 'akeneo', 'drupal8', 'magento1', 'magento2', 'php', 'spryker', 'symfony', 'wordpress'
-            }
-        }
         stage('Build and Test') {
             parallel {
                 stage('1. PHP, Symfony, Wordpress, Akeneo') {
-                    stages {
-                        stage('PHP Static') {
-                            agent { label "my127ws" }
-                            steps { sh './build && ./test php static' }
-                            post {
-                                always {
-                                    sh 'ws destroy || true'
-                                    cleanWs()
-                                }
-                            }
-                        }
-                        stage('PHP Dynamic') {
-                            agent { label "my127ws" }
-                            steps { sh './build && ./test php dynamic' }
-                            post {
-                                always {
-                                    sh 'ws destroy || true'
-                                    cleanWs()
-                                }
-                            }
-                        }
-                        stage('PHP Dynamic Mutagen') {
-                            agent { label "my127ws" }
-                            steps { sh './build && ./test php dynamic mutagen' }
-                            post {
-                                always {
-                                    sh 'ws destroy || true'
-                                    cleanWs()
-                                }
-                            }
-                        }
-
-                        stage('Symfony Static') {
-                            agent { label "my127ws" }
-                            steps { sh './build && ./test symfony static' }
-                            post {
-                                always {
-                                    sh 'ws destroy || true'
-                                    cleanWs()
-                                }
-                            }
-                        }
-                        stage('Symfony Dynamic') {
-                            agent { label "my127ws" }
-                            steps { sh './build && ./test symfony dynamic' }
-                            post {
-                                always {
-                                    sh 'ws destroy || true'
-                                    cleanWs()
-                                }
-                            }
-                        }
-                        stage('Symfony Dynamic Mutagen') {
-                            agent { label "my127ws" }
-                            steps { sh './build && ./test symfony dynamic mutagen' }
-                            post {
-                                always {
-                                    sh 'ws destroy || true'
-                                    cleanWs()
-                                }
-                            }
-                        }
-
-                        stage('Wordpress Static') {
-                            agent { label "my127ws" }
-                            steps { sh './build && ./test wordpress static' }
-                            post {
-                                always {
-                                    sh 'ws destroy || true'
-                                    cleanWs()
-                                }
-                            }
-                        }
-                        stage('Wordpress Dynamic') {
-                            agent { label "my127ws" }
-                            steps { sh './build && ./test wordpress dynamic' }
-                            post {
-                                always {
-                                    sh 'ws destroy || true'
-                                    cleanWs()
-                                }
-                            }
-                        }
-                        stage('Wordpress Dynamic Mutagen') {
-                            agent { label "my127ws" }
-                            steps { sh './build && ./test wordpress dynamic mutagen' }
-                            post {
-                                always {
-                                    sh 'ws destroy || true'
-                                    cleanWs()
-                                }
-                            }
+                    agent { label "my127ws" }
+                    steps {
+                        sh './build'
+                        sh './test php static'
+                        sh './test symfony static'
+                        sh './test wordpress static'
+                        sh './test php dynamic'
+                        sh './test symfony dynamic'
+                        sh './test wordpress dynamic'
+                        sh './test php dynamic mutagen'
+                        sh './test symfony dynamic mutagen'
+                        sh './test wordpress dynamic mutagen'
+                    }
+                    post {
+                        always {
+                            sh 'ws destroy || true'
+                            cleanWs()
                         }
                     }
                 }
                 stage('2. Drupal 8, Magento 1, Magento 2') {
-                    stage('Drupal Static') {
-                        agent { label "my127ws" }
-                        steps { sh './build && ./test drupal8 static' }
-                        post {
-                            always {
-                                sh 'ws destroy || true'
-                                cleanWs()
-                            }
-                        }
+                    agent { label "my127ws" }
+                    steps {
+                        sh './build'
+                        sh './test drupal8 static'
+                        sh './test magento1 static'
+                        sh './test magento2 static'
+                        sh './test drupal8 dynamic'
+                        sh './test magento1 dynamic'
+                        sh './test magento2 dynamic'
+                        sh './test drupal8 dynamic mutagen'
+                        sh './test magento1 dynamic mutagen'
+                        sh './test magento2 dynamic mutagen'
                     }
-                    stage('Drupal Dynamic') {
-                        agent { label "my127ws" }
-                        steps { sh './build && ./test drupal8 dynamic' }
-                        post {
-                            always {
-                                sh 'ws destroy || true'
-                                cleanWs()
-                            }
-                        }
-                    }
-                    stage('Drupal Dynamic Mutagen') {
-                        agent { label "my127ws" }
-                        steps { sh './build && ./test drupal8 dynamic mutagen' }
-                        post {
-                            always {
-                                sh 'ws destroy || true'
-                                cleanWs()
-                            }
-                        }
-                    }
-
-                    stage('Magento 1 Static') {
-                        agent { label "my127ws" }
-                        steps { sh './build && ./test magento1 static' }
-                        post {
-                            always {
-                                sh 'ws destroy || true'
-                                cleanWs()
-                            }
-                        }
-                    }
-                    stage('Magento 1 Dynamic') {
-                        agent { label "my127ws" }
-                        steps { sh './build && ./test magento1 dynamic' }
-                        post {
-                            always {
-                                sh 'ws destroy || true'
-                                cleanWs()
-                            }
-                        }
-                    }
-                    stage('Magento 1 Dynamic Mutagen') {
-                        agent { label "my127ws" }
-                        steps { sh './build && ./test magento1 dynamic mutagen' }
-                        post {
-                            always {
-                                sh 'ws destroy || true'
-                                cleanWs()
-                            }
-                        }
-                    }
-
-                    stage('Magento 2 Static') {
-                        agent { label "my127ws" }
-                        steps { sh './build && ./test magento2 static' }
-                        post {
-                            always {
-                                sh 'ws destroy || true'
-                                cleanWs()
-                            }
-                        }
-                    }
-                    stage('Magento 2 Dynamic') {
-                        agent { label "my127ws" }
-                        steps { sh './build && ./test magento2 dynamic' }
-                        post {
-                            always {
-                                sh 'ws destroy || true'
-                                cleanWs()
-                            }
-                        }
-                    }
-                    stage('Magento 2 Dynamic Mutagen') {
-                        agent { label "my127ws" }
-                        steps { sh './build && ./test magento2 dynamic mutagen' }
-                        post {
-                            always {
-                                sh 'ws destroy || true'
-                                cleanWs()
-                            }
+                    post {
+                        always {
+                            sh 'ws destroy || true'
+                            cleanWs()
                         }
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,11 @@ pipeline {
                     agent { label "my127ws" }
                     stages {
                         stage('Prepare') {
-                            steps { sh './build' }
+                            steps {
+                                sh 'docker ps && docker ps -q | xargs --no-run-if-empty docker kill'
+                                sh 'docker ps -a && docker ps -a -q | xargs --no-run-if-empty docker rm -v'
+                                sh './build'
+                            }
                         }
                         stage('PHP Static') {
                             steps { sh './test php static' }
@@ -49,6 +53,8 @@ pipeline {
                         always {
                             sh '(cd tmp-test && ws destroy) || true'
                             sh 'ws destroy || true'
+                            sh 'docker ps && docker ps -q | xargs --no-run-if-empty docker kill'
+                            sh 'docker ps -a && docker ps -a -q | xargs --no-run-if-empty docker rm -v'
                             cleanWs()
                         }
                     }
@@ -57,7 +63,11 @@ pipeline {
                     agent { label "my127ws" }
                     stages {
                         stage('Prepare') {
-                            steps { sh './build' }
+                            steps {
+                                sh 'docker ps && docker ps -q | xargs --no-run-if-empty docker kill'
+                                sh 'docker ps -a && docker ps -a -q | xargs --no-run-if-empty docker rm -v'
+                                sh './build'
+                            }
                         }
                         stage('Symfony Static') {
                             steps { sh './test symfony static' }
@@ -91,6 +101,8 @@ pipeline {
                         always {
                             sh '(cd tmp-test && ws destroy) || true'
                             sh 'ws destroy || true'
+                            sh 'docker ps && docker ps -q | xargs --no-run-if-empty docker kill'
+                            sh 'docker ps -a && docker ps -a -q | xargs --no-run-if-empty docker rm -v'
                             cleanWs()
                         }
                     }
@@ -99,7 +111,11 @@ pipeline {
                     agent { label "my127ws" }
                     stages {
                         stage('Prepare') {
-                            steps { sh './build' }
+                            steps {
+                                sh 'docker ps && docker ps -q | xargs --no-run-if-empty docker kill'
+                                sh 'docker ps -a && docker ps -a -q | xargs --no-run-if-empty docker rm -v'
+                                sh './build'
+                            }
                         }
                         stage('Wordpress Static') {
                             steps { sh './test wordpress static' }
@@ -124,6 +140,8 @@ pipeline {
                         always {
                             sh '(cd tmp-test && ws destroy) || true'
                             sh 'ws destroy || true'
+                            sh 'docker ps && docker ps -q | xargs --no-run-if-empty docker kill'
+                            sh 'docker ps -a && docker ps -a -q | xargs --no-run-if-empty docker rm -v'
                             cleanWs()
                         }
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,18 +8,114 @@ pipeline {
     }
     triggers { cron(env.BRANCH_NAME ==~ /^\d+\.\d+\.x$/ ? 'H H(0-6) * * *' : '') }
     stages {
-        stage('BuildAndTest') {
-            matrix {
-                axes {
-                    axis {
-                        name 'FRAMEWORK'
-                        values 'akeneo', 'drupal8', 'magento1', 'magento2', 'php', 'spryker', 'symfony', 'wordpress'
+        axes {
+            axis {
+                name 'FRAMEWORK'
+                values 'akeneo', 'drupal8', 'magento1', 'magento2', 'php', 'spryker', 'symfony', 'wordpress'
+            }
+        }
+        stage('Build and Test') {
+            parallel {
+                stage('1. PHP, Symfony, Wordpress, Akeneo') {
+                    stages {
+                        stage('PHP Static') {
+                            agent { label "my127ws" }
+                            steps { sh './build && ./test php static' }
+                            post {
+                                always {
+                                    sh 'ws destroy || true'
+                                    cleanWs()
+                                }
+                            }
+                        }
+                        stage('PHP Dynamic') {
+                            agent { label "my127ws" }
+                            steps { sh './build && ./test php dynamic' }
+                            post {
+                                always {
+                                    sh 'ws destroy || true'
+                                    cleanWs()
+                                }
+                            }
+                        }
+                        stage('PHP Dynamic Mutagen') {
+                            agent { label "my127ws" }
+                            steps { sh './build && ./test php dynamic mutagen' }
+                            post {
+                                always {
+                                    sh 'ws destroy || true'
+                                    cleanWs()
+                                }
+                            }
+                        }
+
+                        stage('Symfony Static') {
+                            agent { label "my127ws" }
+                            steps { sh './build && ./test symfony static' }
+                            post {
+                                always {
+                                    sh 'ws destroy || true'
+                                    cleanWs()
+                                }
+                            }
+                        }
+                        stage('Symfony Dynamic') {
+                            agent { label "my127ws" }
+                            steps { sh './build && ./test symfony dynamic' }
+                            post {
+                                always {
+                                    sh 'ws destroy || true'
+                                    cleanWs()
+                                }
+                            }
+                        }
+                        stage('Symfony Dynamic Mutagen') {
+                            agent { label "my127ws" }
+                            steps { sh './build && ./test symfony dynamic mutagen' }
+                            post {
+                                always {
+                                    sh 'ws destroy || true'
+                                    cleanWs()
+                                }
+                            }
+                        }
+
+                        stage('Wordpress Static') {
+                            agent { label "my127ws" }
+                            steps { sh './build && ./test wordpress static' }
+                            post {
+                                always {
+                                    sh 'ws destroy || true'
+                                    cleanWs()
+                                }
+                            }
+                        }
+                        stage('Wordpress Dynamic') {
+                            agent { label "my127ws" }
+                            steps { sh './build && ./test wordpress dynamic' }
+                            post {
+                                always {
+                                    sh 'ws destroy || true'
+                                    cleanWs()
+                                }
+                            }
+                        }
+                        stage('Wordpress Dynamic Mutagen') {
+                            agent { label "my127ws" }
+                            steps { sh './build && ./test wordpress dynamic mutagen' }
+                            post {
+                                always {
+                                    sh 'ws destroy || true'
+                                    cleanWs()
+                                }
+                            }
+                        }
                     }
                 }
-                stages {
-                    stage('Test (mode=static)') {
+                stage('2. Drupal 8, Magento 1, Magento 2') {
+                    stage('Drupal Static') {
                         agent { label "my127ws" }
-                        steps { sh './build && ./test $FRAMEWORK static' }
+                        steps { sh './build && ./test drupal8 static' }
                         post {
                             always {
                                 sh 'ws destroy || true'
@@ -27,9 +123,9 @@ pipeline {
                             }
                         }
                     }
-                    stage('Test (mode=dynamic)') {
+                    stage('Drupal Dynamic') {
                         agent { label "my127ws" }
-                        steps { sh './build && ./test $FRAMEWORK dynamic' }
+                        steps { sh './build && ./test drupal8 dynamic' }
                         post {
                             always {
                                 sh 'ws destroy || true'
@@ -37,14 +133,106 @@ pipeline {
                             }
                         }
                     }
-                    stage('Test (mode=dynamic, sync=mutagen)') {
+                    stage('Drupal Dynamic Mutagen') {
                         agent { label "my127ws" }
-                        steps { sh './build && ./test $FRAMEWORK dynamic mutagen' }
+                        steps { sh './build && ./test drupal8 dynamic mutagen' }
                         post {
                             always {
                                 sh 'ws destroy || true'
                                 cleanWs()
                             }
+                        }
+                    }
+
+                    stage('Magento 1 Static') {
+                        agent { label "my127ws" }
+                        steps { sh './build && ./test magento1 static' }
+                        post {
+                            always {
+                                sh 'ws destroy || true'
+                                cleanWs()
+                            }
+                        }
+                    }
+                    stage('Magento 1 Dynamic') {
+                        agent { label "my127ws" }
+                        steps { sh './build && ./test magento1 dynamic' }
+                        post {
+                            always {
+                                sh 'ws destroy || true'
+                                cleanWs()
+                            }
+                        }
+                    }
+                    stage('Magento 1 Dynamic Mutagen') {
+                        agent { label "my127ws" }
+                        steps { sh './build && ./test magento1 dynamic mutagen' }
+                        post {
+                            always {
+                                sh 'ws destroy || true'
+                                cleanWs()
+                            }
+                        }
+                    }
+
+                    stage('Magento 2 Static') {
+                        agent { label "my127ws" }
+                        steps { sh './build && ./test magento2 static' }
+                        post {
+                            always {
+                                sh 'ws destroy || true'
+                                cleanWs()
+                            }
+                        }
+                    }
+                    stage('Magento 2 Dynamic') {
+                        agent { label "my127ws" }
+                        steps { sh './build && ./test magento2 dynamic' }
+                        post {
+                            always {
+                                sh 'ws destroy || true'
+                                cleanWs()
+                            }
+                        }
+                    }
+                    stage('Magento 2 Dynamic Mutagen') {
+                        agent { label "my127ws" }
+                        steps { sh './build && ./test magento2 dynamic mutagen' }
+                        post {
+                            always {
+                                sh 'ws destroy || true'
+                                cleanWs()
+                            }
+                        }
+                    }
+                }
+                stage('3. Spryker Static') {
+                    agent { label "my127ws" }
+                    steps { sh './build && ./test spryker static' }
+                    post {
+                        always {
+                            sh 'ws destroy || true'
+                            cleanWs()
+                        }
+                    }
+                }
+                stage('4. Spryker Dynamic') {
+                    agent { label "my127ws" }
+                    steps { sh './build && ./test spryker dynamic' }
+                    post {
+                        always {
+                            sh 'ws destroy || true'
+                            cleanWs()
+                        }
+                    }
+                }
+                stage('5. Spryker Dynamic Mutagen') {
+                    agent { label "my127ws" }
+                    steps { sh './build && ./test spryker dynamic mutagen' }
+                    post {
+                        always {
+                            sh 'ws destroy || true'
+                            cleanWs()
                         }
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,121 +10,102 @@ pipeline {
     triggers { cron(env.BRANCH_NAME ==~ /^\d+\.\d+\.x$/ ? 'H H(0-6) * * *' : '') }
     stages {
         stage('Build and Test') {
-            parallel {
-                stage('1. PHP, Drupal 8, Akeneo') {
-                    agent { label "my127ws" }
-                    stages {
-                        stage('Prepare') {
-                            steps { sh './build' }
-                        }
-                        stage('PHP Static') {
-                            steps { sh './test php static' }
-                        }
-                        stage('Drupal 8 Static') {
-                            steps { sh './test drupal8 static' }
-                        }
-                        stage('Akeneo Static') {
-                            steps { sh './test akeneo static' }
-                        }
-                        stage('PHP Dynamic') {
-                            steps { sh './test php dynamic' }
-                        }
-                        stage('Drupal 8 Dynamic') {
-                            steps { sh './test drupal8 dynamic' }
-                        }
-                        stage('Akeneo Dynamic') {
-                            steps { sh './test akeneo dynamic' }
-                        }
-                        stage('PHP Dynamic Mutagen') {
-                            steps { sh './test php dynamic mutagen' }
-                        }
-                        stage('Drupal 8 Dynamic Mutagen') {
-                            steps { sh './test drupal8 dynamic mutagen' }
-                        }
-                        stage('Akeneo Dynamic Mutagen') {
-                            steps { sh './test akeneo dynamic mutagen' }
-                        }
-                    }
-                    post {
-                        always {
-                            sh '(cd tmp-test && ws destroy) || true'
-                            sh 'ws destroy || true'
-                            cleanWs()
-                        }
+            matrix {
+                axes {
+                    axis {
+                        name 'FRAMEWORKS'
+                        values 'php|drupal8|akeneo', 'symfony|magento2|magento1', 'wordpress|spryker'
                     }
                 }
-                stage('2. Symfony, Magento 2, Magento 1') {
-                    agent { label "my127ws" }
-                    stages {
-                        stage('Prepare') {
-                            steps { sh './build' }
+                stages {
+                    stage('Static Builds') {
+                        agent { label "my127ws" }
+                        stages {
+                            stage('Prepare') {
+                                steps { sh './build' }
+                            }
+                            stage('1 (mode=static)') {
+                                steps {
+                                    sh './test "$(echo "$FRAMEWORKS" | cut -d"|" -f1)" static'
+                                }
+                            }
+                            stage('2 (mode=static)') {
+                                steps {
+                                    sh './test "$(echo "$FRAMEWORKS" | cut -d"|" -f2)" static'
+                                }
+                            }
+                            stage('3 (mode=static)') {
+                                steps {
+                                    sh './test "$(echo "$FRAMEWORKS" | cut -d"|" -f3)" static'
+                                }
+                            }
                         }
-                        stage('Symfony Static') {
-                            steps { sh './test symfony static' }
-                        }
-                        stage('Magento 2 Static') {
-                            steps { sh './test magento2 static' }
-                        }
-                        stage('Magento 1 Static') {
-                            steps { sh './test magento1 static' }
-                        }
-                        stage('Symfony Dynamic') {
-                            steps { sh './test symfony dynamic' }
-                        }
-                        stage('Magento 2 Dynamic') {
-                            steps { sh './test magento2 dynamic' }
-                        }
-                        stage('Magento 1 Dynamic') {
-                            steps { sh './test magento1 dynamic' }
-                        }
-                        stage('Symfony Dynamic Mutagen') {
-                            steps { sh './test symfony dynamic mutagen' }
-                        }
-                        stage('Magento 2 Dynamic Mutagen') {
-                            steps { sh './test magento2 dynamic mutagen' }
-                        }
-                        stage('Magento 1 Dynamic Mutagen') {
-                            steps { sh './test magento1 dynamic mutagen' }
+                        post {
+                            always {
+                                sh '(cd tmp-test && ws destroy) || true'
+                                sh 'ws destroy || true'
+                                cleanWs()
+                            }
                         }
                     }
-                    post {
-                        always {
-                            sh '(cd tmp-test && ws destroy) || true'
-                            sh 'ws destroy || true'
-                            cleanWs()
+                    stage('Dynamic Builds') {
+                        agent { label "my127ws" }
+                        stages {
+                            stage('Prepare') {
+                                steps { sh './build' }
+                            }
+                            stage('1 (mode=dynamic)') {
+                                steps {
+                                    sh './test "$(echo "$FRAMEWORKS" | cut -d"|" -f1)" dynamic'
+                                }
+                            }
+                            stage('2 (mode=dynamic)') {
+                                steps {
+                                    sh './test "$(echo "$FRAMEWORKS" | cut -d"|" -f2)" dynamic'
+                                }
+                            }
+                            stage('3 (mode=dynamic)') {
+                                steps {
+                                    sh './test "$(echo "$FRAMEWORKS" | cut -d"|" -f3)" dynamic'
+                                }
+                            }
+                        }
+                        post {
+                            always {
+                                sh '(cd tmp-test && ws destroy) || true'
+                                sh 'ws destroy || true'
+                                cleanWs()
+                            }
                         }
                     }
-                }
-                stage('3. Wordpress, Spryker') {
-                    agent { label "my127ws" }
-                    stages {
-                        stage('Prepare') {
-                            steps { sh './build' }
+                    stage('Dynamic Builds With Mutagen') {
+                        agent { label "my127ws" }
+                        stages {
+                            stage('Prepare') {
+                                steps { sh './build' }
+                            }
+                            stage('1 (mode=dynamic, sync=mutagen)') {
+                                steps {
+                                    sh './test "$(echo "$FRAMEWORKS" | cut -d"|" -f1)" dynamic mutagen'
+                                }
+                            }
+                            stage('2 (mode=dynamic, sync=mutagen)') {
+                                steps {
+                                    sh './test "$(echo "$FRAMEWORKS" | cut -d"|" -f2)" dynamic mutagen'
+                                }
+                            }
+                            stage('3 (mode=dynamic, sync=mutagen)') {
+                                steps {
+                                    sh './test "$(echo "$FRAMEWORKS" | cut -d"|" -f3)" dynamic mutagen'
+                                }
+                            }
                         }
-                        stage('Wordpress Static') {
-                            steps { sh './test wordpress static' }
-                        }
-                        stage('Spryker Static') {
-                            steps { sh './test spryker static' }
-                        }
-                        stage('Wordpress Dynamic') {
-                            steps { sh './test wordpress dynamic' }
-                        }
-                        stage('Spryker Dynamic') {
-                            steps { sh './test spryker dynamic' }
-                        }
-                        stage('Wordpress Dynamic Mutagen') {
-                            steps { sh './test wordpress dynamic mutagen' }
-                        }
-                        stage('Spryker Dynamic Mutagen') {
-                            steps { sh './test spryker dynamic mutagen' }
-                        }
-                    }
-                    post {
-                        always {
-                            sh '(cd tmp-test && ws destroy) || true'
-                            sh 'ws destroy || true'
-                            cleanWs()
+                        post {
+                            always {
+                                sh '(cd tmp-test && ws destroy) || true'
+                                sh 'ws destroy || true'
+                                cleanWs()
+                            }
                         }
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,8 +16,7 @@ pipeline {
                     stages {
                         stage('Prepare') {
                             steps {
-                                sh 'docker ps && docker ps -q | xargs --no-run-if-empty docker kill'
-                                sh 'docker ps -a && docker ps -a -q | xargs --no-run-if-empty docker rm -v'
+                                sh './delete_running_containers.sh'
                                 sh './build'
                             }
                         }
@@ -53,8 +52,7 @@ pipeline {
                         always {
                             sh '(cd tmp-test && ws destroy) || true'
                             sh 'ws destroy || true'
-                            sh 'docker ps && docker ps -q | xargs --no-run-if-empty docker kill'
-                            sh 'docker ps -a && docker ps -a -q | xargs --no-run-if-empty docker rm -v'
+                            sh './delete_running_containers.sh'
                             cleanWs()
                         }
                     }
@@ -101,8 +99,7 @@ pipeline {
                         always {
                             sh '(cd tmp-test && ws destroy) || true'
                             sh 'ws destroy || true'
-                            sh 'docker ps && docker ps -q | xargs --no-run-if-empty docker kill'
-                            sh 'docker ps -a && docker ps -a -q | xargs --no-run-if-empty docker rm -v'
+                            sh './delete_running_containers.sh'
                             cleanWs()
                         }
                     }
@@ -112,8 +109,7 @@ pipeline {
                     stages {
                         stage('Prepare') {
                             steps {
-                                sh 'docker ps && docker ps -q | xargs --no-run-if-empty docker kill'
-                                sh 'docker ps -a && docker ps -a -q | xargs --no-run-if-empty docker rm -v'
+                                sh './delete_running_containers.sh'
                                 sh './build'
                             }
                         }
@@ -140,8 +136,7 @@ pipeline {
                         always {
                             sh '(cd tmp-test && ws destroy) || true'
                             sh 'ws destroy || true'
-                            sh 'docker ps && docker ps -q | xargs --no-run-if-empty docker kill'
-                            sh 'docker ps -a && docker ps -a -q | xargs --no-run-if-empty docker rm -v'
+                            sh './delete_running_containers.sh'
                             cleanWs()
                         }
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,8 +62,7 @@ pipeline {
                     stages {
                         stage('Prepare') {
                             steps {
-                                sh 'docker ps && docker ps -q | xargs --no-run-if-empty docker kill'
-                                sh 'docker ps -a && docker ps -a -q | xargs --no-run-if-empty docker rm -v'
+                                sh './delete_running_containers.sh'
                                 sh './build'
                             }
                         }

--- a/delete_running_containers.sh
+++ b/delete_running_containers.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+if [ -z "$BUILD_ID" ]; then
+  echo "Skipping as not in Jenkins"
+  exit 1
+fi
+
+if docker ps | grep -v my127ws | grep -v CONTAINER | grep '^.*$'; then
+  docker ps | grep -v my127ws | grep -v CONTAINER | cut -d" " -f1 | xargs --no-run-if-empty docker kill
+fi
+if docker ps -a | grep -v my127ws | grep -v CONTAINER | grep '^.*$'; then
+  docker ps -a | grep -v my127ws | grep -v CONTAINER | cut -d" " -f1 | xargs --no-run-if-empty docker rm -f -v
+fi

--- a/delete_running_containers.sh
+++ b/delete_running_containers.sh
@@ -1,13 +1,25 @@
 #!/bin/bash
 
+set -e -o pipefail
+
 if [ -z "$BUILD_ID" ]; then
   echo "Skipping as not in Jenkins"
   exit 1
 fi
 
+echo "Checking running containers:"
 if docker ps | grep -v my127ws | grep -v CONTAINER | grep '^.*$'; then
+  echo "Stopping containers:"
   docker ps | grep -v my127ws | grep -v CONTAINER | cut -d" " -f1 | xargs --no-run-if-empty docker kill
+else
+  echo -n "No extra containers"
 fi
+echo
+echo "Checking stopped containers:"
 if docker ps -a | grep -v my127ws | grep -v CONTAINER | grep '^.*$'; then
+  echo "Deleting containers:"
   docker ps -a | grep -v my127ws | grep -v CONTAINER | cut -d" " -f1 | xargs --no-run-if-empty docker rm -f -v
+else
+  echo -n "No extra containers"
 fi
+echo

--- a/test
+++ b/test
@@ -7,7 +7,11 @@ export path_test="./tmp-test"
 
 function main()
 {
-    test "$1" "$2" "${3:-}"
+    local HARNESS="$1"
+    if [ -z "$HARNESS" ]; then
+      exit 0;
+    fi
+    test "$HARNESS" "$2" "${3:-}"
 }
 
 function test()

--- a/test
+++ b/test
@@ -7,11 +7,7 @@ export path_test="./tmp-test"
 
 function main()
 {
-    local HARNESS="$1"
-    if [ -z "$HARNESS" ]; then
-      exit 0;
-    fi
-    test "$HARNESS" "$2" "${3:-}"
+    test "$1" "$2" "${3:-}"
 }
 
 function test()


### PR DESCRIPTION
Rather than a worker per framework, use 3 Jenkins workers.

Keeps less workers around for the timeout after the build is done (say on the nightly crons), but uses the assigned nodes more.

Builds take around the same time as Spryker is the the longest, but we get feedback for, say, magento 1's build a lot later.

Unsure if this is preferable!