### PR TITLE
Fix frontend watch command

### DIFF
--- a/src/_base/harness/config/commands.yml
+++ b/src/_base/harness/config/commands.yml
@@ -143,7 +143,7 @@ command('frontend watch'):
   exec: |
     #!bash(workspace:/)|@
     # Use `bash -i` to load up /home/build/.bashrc, which sets up node version manager (nvm) paths
-    passthru docker-compose exec -u build --workdir '@('frontend.path')' console bash -i -c '@('frontend.watch')'
+    docker-compose exec -u build --workdir '@('frontend.path')' console bash -i -c '@('frontend.watch')'
 
 command('frontend console'):
   env:


### PR DESCRIPTION
Stops `yarn run watch` just running `yarn` on workspace v0.1.3

Alternatively, we can do a v0.1.4 release.