### PR TITLE
MISC Downgrade elastic search to the latest Adobe Commerce Cloud-supported version

### DIFF
--- a/src/magento2/harness/attributes/docker.yml
+++ b/src/magento2/harness/attributes/docker.yml
@@ -12,7 +12,7 @@ attributes:
     redis_session:
       image: "redis:5"
     elasticsearch:
-      image: "elasticsearch:7.8.1"
+      image: "elasticsearch:7.7.1"
   pipeline:
     preview:
       persistence:


### PR DESCRIPTION
related to https://github.com/inviqa/harness-base-php/pull/425