### PR TITLE
Fix resource prefixed magento and akeneo

### DIFF
--- a/src/_base/harness/attributes/docker-base.yml
+++ b/src/_base/harness/attributes/docker-base.yml
@@ -125,12 +125,12 @@ attributes:
           environment:
             APP_HOST: = @('pipeline.base.hostname')
             DB_HOST: = '{{ .Values.resourcePrefix }}' ~ @('database.host')
-            ELASTICSEARCH_HOST: '{{ if .Values.service.elasticsearch }}{{ .Values.resourcePrefix  }}elasticsearch{{ end }}'
-            ES_HOST: '{{ if .Values.service.elasticsearch }}{{ .Values.resourcePrefix }}elasticsearch:9200{{ end }}'
-            RABBITMQ_HOST: '{{ if .Values.service.rabbitmq }}{{ .Values.resourcePrefix  }}rabbitmq{{ end }}'
+            ELASTICSEARCH_HOST: '{{ if .Values.service.elasticsearch | default .Values.docker.services.elasticsearch.enabled }}{{ .Values.resourcePrefix  }}elasticsearch{{ end }}'
+            ES_HOST: '{{ if .Values.service.elasticsearch | default .Values.docker.services.elasticsearch.enabled }}{{ .Values.resourcePrefix }}elasticsearch:9200{{ end }}'
+            RABBITMQ_HOST: '{{ if .Values.service.rabbitmq | default .Values.docker.services.rabbitmq.enabled }}{{ .Values.resourcePrefix  }}rabbitmq{{ end }}'
             RABBITMQ_EXTERNAL_HOST: = @('pipeline.preview.rabbitmq.external_host')
-            REDIS_HOST: '{{ if .Values.service.redis }}{{ .Values.resourcePrefix }}redis{{ end }}'
-            REDIS_SESSION_HOST: '{{ if .Values.service.redis_session }}{{ .Values.resourcePrefix }}redis-session{{ end }}'
+            REDIS_HOST: '{{ if .Values.service.redis | default .Values.docker.services.redis.enabled }}{{ .Values.resourcePrefix }}redis{{ end }}'
+            REDIS_SESSION_HOST: '{{ if .Values.service.redis_session | default .Values.docker.services.redis_session.enabled }}{{ .Values.resourcePrefix }}redis-session{{ end }}'
             PHP_IDE_CONFIG: = ''
             VARNISH_HOSTNAME_TEMPLATE: "{{ .Values.resourcePrefix }}varnish-%d.{{ .Values.resourcePrefix }}varnish-headless"
         nginx:

--- a/src/akeneo/harness.yml
+++ b/src/akeneo/harness.yml
@@ -46,7 +46,7 @@ attributes:
         - run "set -e -o pipefail; pv --force \"$1\" | zcat | mysql -h \"$DB_HOST\" -u \"$DB_ADMIN_USER\" -p\"$DB_ADMIN_PASS\" \"$DB_NAME\""
         - passthru bin/console doctrine:migrations:migrate --no-interaction --allow-no-migration
         - passthru echo 'Reindexing Elasticsearch'
-        - task http:wait elasticsearch:9200
+        - task http:wait "${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}"
         - run bin/console akeneo:elasticsearch:reset-indexes -n
         - run bin/console pim:product:index --all
         - run bin/console pim:product-model:index --all
@@ -59,14 +59,14 @@ attributes:
         - task composer:install
     install:
       steps:
-        - task http:wait elasticsearch:9200
+        - task http:wait "${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}"
         - passthru bin/console pim:installer:db --catalog vendor/akeneo/pim-community-dev/src/Akeneo/Platform/Bundle/InstallerBundle/Resources/fixtures/minimal
         - task overlay:apply
         - task assets:dump
     init:
       steps:
         - passthru bin/console doctrine:migrations:migrate --no-interaction --allow-no-migration
-        - task http:wait elasticsearch:9200
+        - task http:wait "${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}"
         - run bin/console akeneo:elasticsearch:reset-indexes --no-interaction
         - run bin/console pim:product:index --all
         - run bin/console pim:product-model:index --all

--- a/src/magento2/harness.yml
+++ b/src/magento2/harness.yml
@@ -85,7 +85,7 @@ attributes:
         # restore it after installation.
         - run rm -f /app/app/etc/env.php
         - run rm -f /app/app/etc/config.php
-        - task http:wait elasticsearch:9200
+        - task http:wait "${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}"
         - |
           passthru "magento setup:install \
             --key='${MAGENTO_CRYPT_KEY}' \
@@ -136,7 +136,7 @@ attributes:
     init:
       steps:
         - task rabbitmq:vhosts
-        - task http:wait elasticsearch:9200
+        - task http:wait "${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}"
         - run magento setup:upgrade --keep-generated
         - run magento config:set 'web/unsecure/base_url'       "https://${APP_HOST}/"
         - run magento config:set 'web/secure/base_url'         "https://${APP_HOST}/"
@@ -148,7 +148,7 @@ attributes:
           fi
     migrate:
       steps:
-        - task http:wait elasticsearch:9200
+        - task http:wait "${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}"
         - run magento setup:upgrade --keep-generated
         - run magento cache:clean
     cron:


### PR DESCRIPTION
Would be something like `magento-elasticsearch:9200` on kubernetes