### PR TITLE
Fix behat reliability on drupal8 by moving phpunit to be after it

### DIFF
--- a/src/drupal8/application/overlay/Jenkinsfile.twig
+++ b/src/drupal8/application/overlay/Jenkinsfile.twig
@@ -22,9 +22,13 @@ pipeline {
         stage('Test')  {
             parallel {
                 stage('quality')    { steps { sh 'ws exec composer test-quality'    } }
-                stage('unit')       { steps { sh 'ws test-unit'                     } }
                 stage('acceptance') { steps { sh 'ws exec composer test-acceptance' } }
                 stage('helm kubeval qa')  { steps { sh 'ws helm kubeval qa' } }
+            }
+        }
+        stage('Unit Tests') {
+            steps {
+                sh 'ws test-unit'
             }
         }
 {% if @('pipeline.publish.enabled') == 'yes' %}


### PR DESCRIPTION
`ws phpunit` copies the vendor folder between console and php-fpm.

This seems to be non-atomic so you end up with a broken vendor folder while behat is running