### PR TITLE
Lock the git push for chart publishing

### DIFF
--- a/src/_base/application/overlay/Jenkinsfile.twig
+++ b/src/_base/application/overlay/Jenkinsfile.twig
@@ -56,7 +56,9 @@ pipeline {
                 milestone(50)
                 sh 'ws app publish'
 {% if @('pipeline.publish.chart.enabled') %}
-                sh 'ws app publish chart "${GIT_BRANCH}" "{{ @('workspace.name') }} build artifact ${GIT_COMMIT}"'
+                lock(resource: '{{ @('workspace.name') }}-publish-chart', inversePrecedence: true) {
+                    sh 'ws app publish chart "${GIT_BRANCH}" "{{ @('workspace.name') }} build artifact ${GIT_COMMIT}"'
+                }
 {% endif %}
             }
         }

--- a/src/_base/application/overlay/Jenkinsfile.twig
+++ b/src/_base/application/overlay/Jenkinsfile.twig
@@ -56,7 +56,7 @@ pipeline {
                 milestone(50)
                 sh 'ws app publish'
 {% if @('pipeline.publish.chart.enabled') %}
-                lock(resource: '{{ @('workspace.name') }}-publish-chart', inversePrecedence: true) {
+                lock(resource: '{{ @('pipeline.publish.chart.git.repository') }}', inversePrecedence: true) {
                     sh 'ws app publish chart "${GIT_BRANCH}" "{{ @('workspace.name') }} build artifact ${GIT_COMMIT}"'
                 }
 {% endif %}

--- a/src/drupal8/application/overlay/Jenkinsfile.twig
+++ b/src/drupal8/application/overlay/Jenkinsfile.twig
@@ -60,7 +60,7 @@ pipeline {
                 milestone(50)
                 sh 'ws app publish'
 {% if @('pipeline.publish.chart.enabled') %}
-                lock(resource: '{{ @('workspace.name') }}-publish-chart', inversePrecedence: true) {
+                lock(resource: '{{ @('pipeline.publish.chart.git.repository') }}', inversePrecedence: true) {
                     sh 'ws app publish chart "${GIT_BRANCH}" "{{ @('workspace.name') }} build artifact ${GIT_COMMIT}"'
                 }
 {% endif %}

--- a/src/drupal8/application/overlay/Jenkinsfile.twig
+++ b/src/drupal8/application/overlay/Jenkinsfile.twig
@@ -60,7 +60,9 @@ pipeline {
                 milestone(50)
                 sh 'ws app publish'
 {% if @('pipeline.publish.chart.enabled') %}
-                sh 'ws app publish chart "${GIT_BRANCH}" "{{ @('workspace.name') }} build artifact ${GIT_COMMIT}"'
+                lock(resource: '{{ @('workspace.name') }}-publish-chart', inversePrecedence: true) {
+                    sh 'ws app publish chart "${GIT_BRANCH}" "{{ @('workspace.name') }} build artifact ${GIT_COMMIT}"'
+                }
 {% endif %}
             }
         }


### PR DESCRIPTION
Should fix this that can happen with parallel builds:
```
 ! [remote rejected] master -> master (cannot lock ref 'refs/heads/master': is at 8fd8d71fb9ec39e94fa92161b9d0213932260d29 but expected fe30974a1f4455b5caddc7c089f7602a738a023b)

error: failed to push some refs to 'git@github.com:example/example.git`
```