### PR TITLE
Fix Magento 2 steps if not using elasticsearch

### DIFF
--- a/src/_base/harness/attributes/docker-base.yml
+++ b/src/_base/harness/attributes/docker-base.yml
@@ -40,6 +40,7 @@ attributes:
       publish: true
       environment:
         DB_ADMIN_USER: root
+        HAS_ELASTICSEARCH: "= ('elasticsearch' in @('app.services') ? 'true' : 'false')"
         HAS_VARNISH: "= ('varnish' in @('app.services') ? 'true' : 'false')"
       environment_secrets:
         DB_ADMIN_PASS: = @('database.root_pass')

--- a/src/magento2/application/overlay/app/etc/env.php.twig
+++ b/src/magento2/application/overlay/app/etc/env.php.twig
@@ -101,9 +101,11 @@ return [
         'default' => [
             'catalog' => [
                 'search' => [
+{% if 'elasticsearch' in @('app.services') -%}
                     'engine' => 'elasticsearch7',
                     'elasticsearch7_server_hostname' => getenv('ELASTICSEARCH_HOST')?:'elasticsearch',
                     'elasticsearch7_server_port' => getenv('ELASTICSEARCH_PORT')?:'9200'
+{% endif -%}
                 ],
             ],
         ],

--- a/src/magento2/harness.yml
+++ b/src/magento2/harness.yml
@@ -85,7 +85,10 @@ attributes:
         # restore it after installation.
         - run rm -f /app/app/etc/env.php
         - run rm -f /app/app/etc/config.php
-        - task http:wait "${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}"
+        - |
+          if [[ "$HAS_ELASTICSEARCH" == "true" ]]; then
+            task http:wait "${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}"
+          fi
         - |
           passthru "magento setup:install \
             --key='${MAGENTO_CRYPT_KEY}' \
@@ -136,7 +139,10 @@ attributes:
     init:
       steps:
         - task rabbitmq:vhosts
-        - task http:wait "${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}"
+        - |
+          if [[ "$HAS_ELASTICSEARCH" == "true" ]]; then
+            task http:wait "${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}"
+          fi
         - run magento setup:upgrade --keep-generated
         - run magento config:set 'web/unsecure/base_url'       "https://${APP_HOST}/"
         - run magento config:set 'web/secure/base_url'         "https://${APP_HOST}/"
@@ -148,7 +154,10 @@ attributes:
           fi
     migrate:
       steps:
-        - task http:wait "${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}"
+        - |
+          if [[ "$HAS_ELASTICSEARCH" == "true" ]]; then
+            task http:wait "${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}"
+          fi
         - run magento setup:upgrade --keep-generated
         - run magento cache:clean
     cron:


### PR DESCRIPTION
With versions older than 2.4, it's not a requirement to use elasticsearch for the search engine.