### PR TITLE
Magento 2 cron needs zombies to exist

### DIFF
--- a/src/_base/docker/image/cron/root/cron-run-with-env.sh
+++ b/src/_base/docker/image/cron/root/cron-run-with-env.sh
@@ -2,4 +2,4 @@
 script_args="$*"
 env_vars=()
 readarray -t env_vars < /app/env.sh
-/usr/bin/env - "${env_vars[@]}" su -s /bin/bash -p -c "$script_args" www-data > /proc/1/fd/1 2> /proc/1/fd/2
+/usr/bin/env - "${env_vars[@]}" su -s /bin/bash -p -c "set -m; $script_args" www-data > /proc/1/fd/1 2> /proc/1/fd/2

--- a/src/_base/docker/image/cron/root/cron-run-with-env.sh
+++ b/src/_base/docker/image/cron/root/cron-run-with-env.sh
@@ -2,4 +2,4 @@
 script_args="$*"
 env_vars=()
 readarray -t env_vars < /app/env.sh
-/usr/bin/env - "${env_vars[@]}" su -s /bin/bash -p -c "set -m; $script_args" www-data > /proc/1/fd/1 2> /proc/1/fd/2
+/usr/bin/env - "${env_vars[@]}" su -s /bin/bash -p -c "$script_args" www-data > /proc/1/fd/1 2> /proc/1/fd/2

--- a/src/magento2/harness.yml
+++ b/src/magento2/harness.yml
@@ -153,7 +153,7 @@ attributes:
         - run magento cache:clean
     cron:
       jobs:
-        - "= (@('app.mode') == 'production' ? '* * * * * /cron-run-with-env.sh /bin/bash -c \"/app/bin/magento cron:run & && wait\"' : '')"
+        - "= (@('app.mode') == 'production' ? '* * * * * /cron-run-with-env.sh \"/app/bin/magento cron:run & wait\"' : '')"
   docker:
     image:
       console: "= 'my127/magento2:' ~ @('php.version') ~ '-fpm-' ~ (@('php.version') >= 7.4 ? 'buster' : 'stretch') ~ '-console'"

--- a/src/magento2/harness.yml
+++ b/src/magento2/harness.yml
@@ -153,7 +153,7 @@ attributes:
         - run magento cache:clean
     cron:
       jobs:
-        - "= (@('app.mode') == 'production' ? '* * * * * /cron-run-with-env.sh /app/bin/magento cron:run' : '')"
+        - "= (@('app.mode') == 'production' ? '* * * * * /cron-run-with-env.sh /bin/bash -c \"/app/bin/magento cron:run & && wait\"' : '')"
   docker:
     image:
       console: "= 'my127/magento2:' ~ @('php.version') ~ '-fpm-' ~ (@('php.version') >= 7.4 ? 'buster' : 'stretch') ~ '-console'"


### PR DESCRIPTION
1. Main cron process spawns new standalone processes as children
2. Main cron process exits after doing it's tasks
3. Zombies created out of the forked processes
4. PID 1 (tini) becomes parent of zombies
5. PID 1 (tini) reaps the zombies
6. Standalone processes never complete