### PR TITLE
Deploy supporting services in wave 4

### DIFF
--- a/src/_base/helm/app/templates/service/elasticsearch/deployment.yaml
+++ b/src/_base/helm/app/templates/service/elasticsearch/deployment.yaml
@@ -3,6 +3,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.resourcePrefix }}elasticsearch
+  annotations:
+    argocd.argoproj.io/sync-wave: "4"
   labels:
     app.service: {{ .Values.resourcePrefix }}elasticsearch
 spec:

--- a/src/_base/helm/app/templates/service/mysql/deployment.yaml
+++ b/src/_base/helm/app/templates/service/mysql/deployment.yaml
@@ -3,6 +3,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.resourcePrefix }}mysql
+  annotations:
+    argocd.argoproj.io/sync-wave: "4"
   labels:
     app.service: {{ .Values.resourcePrefix }}mysql
 spec:

--- a/src/_base/helm/app/templates/service/postgres/deployment.yaml
+++ b/src/_base/helm/app/templates/service/postgres/deployment.yaml
@@ -3,6 +3,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.resourcePrefix }}postgres
+  annotations:
+    argocd.argoproj.io/sync-wave: "4"
   labels:
     app.service: {{ .Values.resourcePrefix }}postgres
 spec:

--- a/src/_base/helm/app/templates/service/rabbitmq/deployment.yaml
+++ b/src/_base/helm/app/templates/service/rabbitmq/deployment.yaml
@@ -3,6 +3,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.resourcePrefix }}rabbitmq
+  annotations:
+    argocd.argoproj.io/sync-wave: "4"
   labels:
     app.service: {{ .Values.resourcePrefix }}rabbitmq
 spec:

--- a/src/_base/helm/app/templates/service/redis-session/deployment.yaml
+++ b/src/_base/helm/app/templates/service/redis-session/deployment.yaml
@@ -3,6 +3,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.resourcePrefix }}redis-session
+  annotations:
+    argocd.argoproj.io/sync-wave: "4"
   labels:
     app.service: {{ .Values.resourcePrefix }}redis-session
 spec:

--- a/src/_base/helm/app/templates/service/redis/deployment.yaml
+++ b/src/_base/helm/app/templates/service/redis/deployment.yaml
@@ -3,6 +3,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.resourcePrefix }}redis
+  annotations:
+    argocd.argoproj.io/sync-wave: "4"
   labels:
     app.service: {{ .Values.resourcePrefix }}redis
 spec:

--- a/src/_base/helm/app/templates/service/varnish/statefulset.yaml
+++ b/src/_base/helm/app/templates/service/varnish/statefulset.yaml
@@ -3,6 +3,8 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ .Values.resourcePrefix }}varnish
+  annotations:
+    argocd.argoproj.io/sync-wave: "4"
   labels:
     app.service: {{ .Values.resourcePrefix }}varnish
 spec:

--- a/src/spryker/helm/app/templates/service/jenkins/deployment.yaml
+++ b/src/spryker/helm/app/templates/service/jenkins/deployment.yaml
@@ -3,6 +3,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.resourcePrefix }}jenkins
+  annotations:
+    argocd.argoproj.io/sync-wave: "4"
   labels:
     app.service: {{ .Values.resourcePrefix }}jenkins
 spec:


### PR DESCRIPTION
Sealed secrets now in wave 1, so we can't deploy anything relying on secrets in wave 0.

PVC's should be fine in wave 0, same for services and ingresses.