### PR TITLE
Remove the lost+found removal and improve handling

### DIFF
--- a/src/_base/_twig/docker-compose.yml/service/mysql.yml.twig
+++ b/src/_base/_twig/docker-compose.yml/service/mysql.yml.twig
@@ -1,14 +1,12 @@
-{% set command = [] %}
-{% for var, value in @('services.mysql.arguments')|filter(v => v is not empty) -%}
-    {% set command = command|merge(['--' ~ var ~ '=' ~ value]) %}
-{% endfor %}
+{% set command = @('services.mysql.options')
+  | filter(v => v is not empty)
+  | map((value, var) => '--' ~ var ~ '=' ~ value)
+  | reduce((carry, v) => carry|merge([v]), []) %}
   mysql:
     image: {{ @('services.mysql.image') }}
     labels:
       - traefik.enable=false
-{% if command|length %}
-    command: {{ command|join(' ') }}
-{% endif %}
+    command: {{ to_nice_yaml(command, 2, 6) }}
     environment: {{ to_nice_yaml(deep_merge([
         @('services.mysql.environment'),
         @('services.mysql.environment_secrets')

--- a/src/_base/harness/attributes/docker-base.yml
+++ b/src/_base/harness/attributes/docker-base.yml
@@ -79,7 +79,7 @@ attributes:
     mysql:
       enabled: "= 'mysql' in @('app.services')"
       image: = @('mysql.image') ~ ':' ~ @('mysql.tag')
-      arguments: = @('database.var')
+      options: = @('database.var')
       environment:
         MYSQL_DATABASE: = @('database.name')
         MYSQL_USER: = @('database.user')
@@ -138,7 +138,7 @@ attributes:
             PHP_IDE_CONFIG: = ''
             VARNISH_HOSTNAME_TEMPLATE: "{{ .Values.resourcePrefix }}varnish-%d.{{ .Values.resourcePrefix }}varnish-headless"
         mysql:
-          arguments: = @('services.mysql.arguments')
+          options: = @('services.mysql.options')
         nginx:
           environment:
             FPM_HOST: localhost

--- a/src/_base/helm/app/templates/service/mysql/deployment.yaml
+++ b/src/_base/helm/app/templates/service/mysql/deployment.yaml
@@ -21,15 +21,6 @@ spec:
       labels:
         app.service: {{ .Values.resourcePrefix }}mysql
     spec:
-{{- if and (.Values.persistence.mysql.enabled) (not (index .Values.docker.services.mysql.arguments "ignore-db-dir")) }}
-      initContainers:
-      - name: "remove-lost-found"
-        image: "busybox:latest"
-        command:  ["rm", "-rf", "/var/lib/mysql/lost+found"]
-        volumeMounts:
-        - name: {{ .Values.resourcePrefix }}mysql-persistent-storage
-          mountPath: /var/lib/mysql
-{{- end }}
       containers:
       - env:
         {{- range $key, $value := .Values.docker.services.mysql.environment }}
@@ -44,12 +35,11 @@ spec:
         image: {{ .Values.docker.image.mysql | default .Values.docker.services.mysql.image | quote }}
         imagePullPolicy: Always
         name: mysql
-        {{- if .Values.docker.services.mysql.arguments }}
+        {{- if .Values.docker.services.mysql.options }}
         args:
-        {{- range $var, $value := .Values.docker.services.mysql.arguments }}
+        {{- range $var, $value := .Values.docker.services.mysql.options }}
         {{- if $value }}
-        - --{{ $var }}
-        - {{ $value | quote }}
+        - {{ print "--" $var "=" $value | quote }}
         {{- end }}
         {{- end }}
         {{- end }}


### PR DESCRIPTION
MySQL 8 removed ignore-db-dir because it uses a data dictionary to track databases rather than look at unknown directories in a data directory, so it wont pick up lost+found, which even if deleted may reappear if an fsck run

arguments also renamed to options as they are cli options rather than cli arguments