### PR TITLE
Use proper escaping for database credentials in assets apply/dump

### DIFF
--- a/src/_base/docker/image/console/root/lib/task/assets/dump.sh
+++ b/src/_base/docker/image/console/root/lib/task/assets/dump.sh
@@ -3,17 +3,22 @@
 function task_assets_dump()
 {
     local ASSETS_DIR="${ASSETS_DIR:-tools/assets/development}"
+    local DUMP_COMMAND=()
+    local PRE_COMMAND=()
 
     if [ ! -d "/app/${ASSETS_DIR}" ]; then
         run mkdir -p "/app/${ASSETS_DIR}"
     fi
 
     if [ "${DB_PLATFORM}" == "mysql" ]; then
-        run "mysqldump -h '${DB_HOST}' -u '${DB_USER}' '-p${DB_PASS}' '${DB_NAME}' | gzip > '/app/${ASSETS_DIR}/${DB_NAME}.sql.gz'"
+        DUMP_COMMAND=(mysqldump -h "${DB_HOST}" -u "${DB_USER}" "-p${DB_PASS}" "${DB_NAME}")
     elif [ "${DB_PLATFORM}"  == "postgres" ]; then
-        PGPASSWORD="$DB_PASS" run "pg_dump -h '${DB_HOST}' -U '${DB_USER}' '${DB_NAME}' | gzip > '/app/${ASSETS_DIR}/${DB_NAME}.sql.gz'"
+        PRE_COMMAND=("PGPASSWORD=$DB_PASS")
+        DUMP_COMMAND=(pg_dump -h "${DB_HOST}" -U "${DB_USER}" "${DB_NAME}")
     elif [ -n "${DB_PLATFORM}" ]; then
         (>&2 echo "invalid database type")
         exit 1
     fi
+
+    "${PRE_COMMAND[@]}" run "$(printf ' %q' "${DUMP_COMMAND[@]}") | gzip > '/app/${ASSETS_DIR}/${DB_NAME}.sql.gz'"
 }


### PR DESCRIPTION
Not everything properly escaped (e.g. the dump input/output), but only the most likely to need it