### PR TITLE
Push the helm chart to the default branch of the cluster repository

### DIFF
--- a/src/_base/harness/config/pipeline.yml
+++ b/src/_base/harness/config/pipeline.yml
@@ -59,7 +59,7 @@ command('app publish chart <release> <message>'):
     export GIT_SSH_COMMAND='ssh -i ../id_rsa -o "IdentitiesOnly yes" -F /dev/null -o StrictHostKeyChecking=no'
     run git -C ./build-artifacts-repository add .
     run "git -C ./build-artifacts-repository commit --allow-empty -m '${MESSAGE}'"
-    run git -C ./build-artifacts-repository push origin master
+    run git -C ./build-artifacts-repository push origin -u HEAD
 
 command('app deploy <environment>'):
   env:


### PR DESCRIPTION
Agnostic about main branch, so we can convert cluster repositories as we go.