### PR TITLE
Fix wrong indentation level for mailhog in preview environments

### DIFF
--- a/src/_base/harness/attributes/docker-base.yml
+++ b/src/_base/harness/attributes/docker-base.yml
@@ -199,7 +199,7 @@ attributes:
       services:
         console:
           enabled: false
-          php-base:
-            environment:
-              SMTP_HOST: = @('pipeline.preview.smtp.host')
-              SMTP_PORT: = @('pipeline.preview.smtp.port')
+        php-base:
+          environment:
+            SMTP_HOST: = @('pipeline.preview.smtp.host')
+            SMTP_PORT: = @('pipeline.preview.smtp.port')


### PR DESCRIPTION
Oopsie! Fixes indentation bug introduced in https://github.com/inviqa/harness-base-php/pull/444