### PR TITLE
Fix JENKINS_HOST environment variable not being overridden in helm chart

### DIFF
--- a/src/spryker/harness/attributes/docker.yml
+++ b/src/spryker/harness/attributes/docker.yml
@@ -39,6 +39,7 @@ attributes:
         php-base:
           environment:
             JENKINS_HOST: = '{{ .Values.resourcePrefix  }}' ~ @('jenkins.host')
+            JENKINS_URL: = 'http://{{ .Values.resourcePrefix  }}' ~ @('jenkins.host') ~ ':' ~ @('jenkins.port') ~ '/'
     preview:
       services:
         php-base:

--- a/src/spryker/harness/attributes/docker.yml
+++ b/src/spryker/harness/attributes/docker.yml
@@ -37,7 +37,8 @@ attributes:
     base:
       services:
         php-base:
-          JENKINS_HOST: = '{{ .Values.resourcePrefix  }}' ~ @('jenkins.host')
+          environment:
+            JENKINS_HOST: = '{{ .Values.resourcePrefix  }}' ~ @('jenkins.host')
     preview:
       services:
         php-base:


### PR DESCRIPTION
Also fix JENKINS_URL being http://jenkins:8080 when the host is example-jenkins