### PR TITLE
Prompt for the community or enterprise edition for Akeneo when creating a project

### DIFF
--- a/src/_base/harness/config/commands.yml
+++ b/src/_base/harness/config/commands.yml
@@ -6,7 +6,7 @@ command('enable'):
     APP_BUILD:            = @('app.build')
     APP_MODE:             = @('app.mode')
     NAMESPACE:            = @('namespace')
-    HAS_ASSETS:           = @('aws.bucket') !== null ? 'yes':'no'
+    HAS_ASSETS:           = @('aws.bucket') !== null and @('aws.bucket') !== '' ? 'yes':'no'
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)

--- a/src/akeneo/.ci/sample-dynamic/workspace.yml
+++ b/src/akeneo/.ci/sample-dynamic/workspace.yml
@@ -9,6 +9,11 @@ attribute('aws.key'): null
 
 attribute('docker.port_forward.enabled'): false
 
+attribute('akeneo.edition'): community
+attribute('akeneo.enterprise.distribution.project_name'): ''
+attribute('ssh.key.public'): ''
+attribute('ssh.key.private'): ''
+
 attribute('hostname_aliases'):
   - test-one-ci-akeneo-sample-dynamic
   - test-two-ci-akeneo-sample-dynamic

--- a/src/akeneo/.ci/sample-static/workspace.yml
+++ b/src/akeneo/.ci/sample-static/workspace.yml
@@ -10,4 +10,9 @@ attribute('app.repository'): null
 attribute('aws.id'): null
 attribute('aws.key'): null
 
+attribute('akeneo.edition'): community
+attribute('akeneo.enterprise.distribution.project_name'): ''
+attribute('ssh.key.public'): ''
+attribute('ssh.key.private'): ''
+
 attribute('composer.auth.github'): = decrypt("YTozOntpOjA7czo3OiJkZWZhdWx0IjtpOjE7czoyNDoiZfbsRN210rxOzGyHhH74tuXtFxak6prxIjtpOjI7czo1Njoi7NjB2oXZJ3/wQsccea2VPeYEjU72koVub89ezkdQzAzOaaFwD2Rm1pbhWXR7aYgpUdXmNmO8g5YiO30=")

--- a/src/akeneo/README.md
+++ b/src/akeneo/README.md
@@ -28,8 +28,8 @@ git commit -m "Initial commit"
 - A valid subscription with Akeneo to gain access to the enterprise edition codebase.
 - A dedicated user in the Akeneo Portal for the purposes of installing the enterprise edition with composer.
   https://help.akeneo.com/portal/articles/get-akeneo-pim-enterprise-archive.html
-- A public and private SSH keypair generated specifically for the dedicated user in the Akeneo Portal, with the public
-  key associated with the dedicated user.
+- A public and private SSH keypair generated for the purposes of installing the codebase, with the public
+  key associated with the dedicated user in the Akeneo Portal.
 
 ### Installation
 

--- a/src/akeneo/README.md
+++ b/src/akeneo/README.md
@@ -28,6 +28,8 @@ git commit -m "Initial commit"
 - A valid subscription with Akeneo to gain access to the enterprise edition codebase.
 - A dedicated user in the Akeneo Portal for the purposes of installing the enterprise edition with composer.
   https://help.akeneo.com/portal/articles/get-akeneo-pim-enterprise-archive.html
+- A public and private SSH keypair generated specifically for the dedicated user in the Akeneo Portal, with the public
+  key associated with the dedicated user.
 
 ### Installation
 

--- a/src/akeneo/README.md
+++ b/src/akeneo/README.md
@@ -1,10 +1,43 @@
 # Akeneo Harness for [Workspace]
 
-To use this harness:
+To use this harness, you will be asked if you wish to install the enterprise edition, which requires a subscription
+with Akeneo, or use the community edition which is open source.
+
+## Community Edition
 
 1. Install [Workspace]
 2. Run `ws create <projectName> inviqa/akeneo:v0.10.1`
-3. Fill in project-specific AWS and Github credentials, set as blank if you don't need them
+3. You will be asked a series of questions:
+  - For `akeneo.edition`, enter `community`
+  - For `akeneo.enterprise.distribution.project_name`, press enter to submit a blank string
+  - For `ssh.key.private`, press enter to submit a blank string
+  - For `ssh.key.public`, press enter to submit a blank string
+4. Change to the <projectName> directory: `cd <projectName>`
+5. Create an initial commit, ensuring that `workspace.override.yml` is not added to git:
+```bash
+git init
+git add .
+git commit -m "Initial commit"
+```
+6. Store the `workspace.override.yml` contents in a suitable location (such as LastPass).
+
+## Enterprise Edition
+
+### Prerequisites
+
+- A valid subscription with Akeneo to gain access to the enterprise edition codebase.
+- A dedicated user in the Akeneo Portal for the purposes of installing the enterprise edition with composer.
+  https://help.akeneo.com/portal/articles/get-akeneo-pim-enterprise-archive.html
+
+### Installation
+
+1. Install [Workspace]
+2. Run `ws create <projectName> inviqa/akeneo:v0.10.1`
+3. You will be asked a series of questions:
+  - For `akeneo.edition`, enter `enterprise`
+  - For `akeneo.enterprise.distribution.project_name`, enter the "Git repository" name listed on the Akeneo Portal
+  - For `ssh.key.private`, enter the output of `cat path/to/private/key | base64 -w0` for the private SSH key associated with the Akeneo Portal's dedicated user.
+  - For `ssh.key.public`, enter the public SSH key associated with the Akeneo Portal's dedicated user.
 4. Change to the <projectName> directory: `cd <projectName>`
 5. Create an initial commit, ensuring that `workspace.override.yml` is not added to git:
 ```bash

--- a/src/akeneo/README.md
+++ b/src/akeneo/README.md
@@ -36,8 +36,8 @@ git commit -m "Initial commit"
 3. You will be asked a series of questions:
   - For `akeneo.edition`, enter `enterprise`
   - For `akeneo.enterprise.distribution.project_name`, enter the "Git repository" name listed on the Akeneo Portal
-  - For `ssh.key.private`, enter the output of `cat path/to/private/key | base64 -w0` for the private SSH key associated with the Akeneo Portal's dedicated user.
   - For `ssh.key.public`, enter the public SSH key associated with the Akeneo Portal's dedicated user.
+  - For `File path to read for ssh.key.private`, enter the path to a private SSH key associated with the Akeneo Portal's dedicated user.
 4. Change to the <projectName> directory: `cd <projectName>`
 5. Create an initial commit, ensuring that `workspace.override.yml` is not added to git:
 ```bash

--- a/src/akeneo/README.md
+++ b/src/akeneo/README.md
@@ -11,7 +11,7 @@ with Akeneo, or use the community edition which is open source.
   - For `akeneo.edition`, enter `community`
   - For `akeneo.enterprise.distribution.project_name`, press enter to submit a blank string
   - For `ssh.key.private`, press enter to submit a blank string
-  - For `ssh.key.public`, press enter to submit a blank string
+  - For `File to read for ssh.key.public`, press enter to submit a blank string
 4. Change to the <projectName> directory: `cd <projectName>`
 5. Create an initial commit, ensuring that `workspace.override.yml` is not added to git:
 ```bash

--- a/src/akeneo/application/skeleton/composer.json.twig
+++ b/src/akeneo/application/skeleton/composer.json.twig
@@ -19,6 +19,15 @@
       "Inviqa\\Acceptance\\": "features/bootstrap"
     }
   },
+  "repositories": {
+    {%- if @('akeneo.edition') == 'enterprise' %}
+    "akeneo": {
+      "type": "vcs",
+      "url": "ssh://git@distribution.akeneo.com:443/{{ @('akeneo.enterprise.distribution.project_name') }}.git",
+      "no-api": true
+    }
+    {%- endif %}
+  },
   "require": {
     "php": ">= 7.3",
     "akeneo/pim-{{ @('akeneo.edition') }}-dev": "^4.0.0"

--- a/src/akeneo/application/skeleton/composer.json.twig
+++ b/src/akeneo/application/skeleton/composer.json.twig
@@ -10,8 +10,10 @@
       "Pim\\Upgrade\\": "upgrades/"
     },
     "exclude-from-classmap": [
-      "vendor/akeneo/pim-community-dev/src/Kernel.php"{% if @('akeneo.edition') == 'enterprise' %},
-      "vendor/akeneo/pim-enterprise-dev/src/Kernel.php"{% endif %}
+      "vendor/akeneo/pim-community-dev/src/Kernel.php"
+{%- if @('akeneo.edition') == 'enterprise' %},
+      "vendor/akeneo/pim-enterprise-dev/src/Kernel.php"
+{%- endif %}
     ]
   },
   "autoload-dev": {
@@ -19,15 +21,15 @@
       "Inviqa\\Acceptance\\": "features/bootstrap"
     }
   },
+{%- if @('akeneo.edition') == 'enterprise' %}
   "repositories": {
-    {%- if @('akeneo.edition') == 'enterprise' %}
     "akeneo": {
       "type": "vcs",
       "url": "ssh://git@distribution.akeneo.com:443/{{ @('akeneo.enterprise.distribution.project_name') }}.git",
       "no-api": true
     }
-    {%- endif %}
   },
+{%- endif %}
   "require": {
     "php": ">= 7.3",
     "akeneo/pim-{{ @('akeneo.edition') }}-dev": "^4.0.0"

--- a/src/akeneo/docker/image/console/root/home/build/.ssh/id_rsa.pub.twig
+++ b/src/akeneo/docker/image/console/root/home/build/.ssh/id_rsa.pub.twig
@@ -1,0 +1,1 @@
+{{ @('ssh.key.public') }}

--- a/src/akeneo/docker/image/console/root/home/build/.ssh/id_rsa.twig
+++ b/src/akeneo/docker/image/console/root/home/build/.ssh/id_rsa.twig
@@ -1,0 +1,1 @@
+{{ @('ssh.key.private') }}

--- a/src/akeneo/harness.yml
+++ b/src/akeneo/harness.yml
@@ -62,7 +62,7 @@ attributes:
     build:
       steps:
         - |
-          if [[ "@('akeneo.edition')" == "enterprise" ]]; then
+          if grep -q akeneo/pim-enterprise-dev composer.json; then
             run "ssh-keyscan github.com >> ~/.ssh/known_hosts"
             run "ssh-keyscan -p 443 distribution.akeneo.com >> ~/.ssh/known_hosts"
             run "chmod 0600 /home/build/.ssh/id_*"

--- a/src/akeneo/harness.yml
+++ b/src/akeneo/harness.yml
@@ -36,6 +36,10 @@ attributes:
     vendor_directory: /app/vendor
   akeneo:
     secret: AMjnA6QnWfkZ9s8vB2XXLALXuxZm7fmC
+    edition: ~
+    enterprise:
+      distribution:
+        project_name: ~
   php:
     version: 7.3
     ini:

--- a/src/akeneo/harness.yml
+++ b/src/akeneo/harness.yml
@@ -11,9 +11,9 @@ harness('inviqa/akeneo'):
       standard:
         - akeneo.edition
         - akeneo.enterprise.distribution.project_name
-      secret:
-        - ssh.key.private
         - ssh.key.public
+      secret_file:
+        - ssh.key.private
 ---
 attributes:
   app:

--- a/src/akeneo/harness.yml
+++ b/src/akeneo/harness.yml
@@ -36,10 +36,6 @@ attributes:
     vendor_directory: /app/vendor
   akeneo:
     secret: AMjnA6QnWfkZ9s8vB2XXLALXuxZm7fmC
-    edition: ~
-    enterprise:
-      distribution:
-        project_name: ~
   php:
     version: 7.3
     ini:

--- a/src/akeneo/harness.yml
+++ b/src/akeneo/harness.yml
@@ -1,12 +1,16 @@
 ---
 harness('inviqa/akeneo'):
-  description: A docker based development environment for akeneo
+  description: A docker based development environment for akeneo 4.x
   require:
     services:
       - proxy
       - mail
     confd:
       - harness:/
+    attributes:
+      standard:
+        - akeneo.edition
+        - akeneo.enterprise.distribution.project_name
 ---
 attributes:
   app:
@@ -29,7 +33,10 @@ attributes:
     vendor_directory: /app/vendor
   akeneo:
     secret: AMjnA6QnWfkZ9s8vB2XXLALXuxZm7fmC
-    edition: community
+    edition: ~
+    enterprise:
+      distribution:
+        project_name: ~
   php:
     version: 7.3
     ini:
@@ -55,6 +62,12 @@ attributes:
   backend:
     build:
       steps:
+        - |
+          if [[ "@('akeneo.edition')" == "enterprise" ]]; then
+            run "ssh-keyscan github.com >> ~/.ssh/known_hosts"
+            run "ssh-keyscan -p 443 distribution.akeneo.com >> ~/.ssh/known_hosts"
+            run "chmod 0600 /home/build/.ssh/id_*"
+          fi
         - task composer:install
     install:
       steps:

--- a/src/akeneo/harness.yml
+++ b/src/akeneo/harness.yml
@@ -11,6 +11,9 @@ harness('inviqa/akeneo'):
       standard:
         - akeneo.edition
         - akeneo.enterprise.distribution.project_name
+      secret:
+        - ssh.key.private
+        - ssh.key.public
 ---
 attributes:
   app:

--- a/src/akeneo/harness/config/confd.yml
+++ b/src/akeneo/harness/config/confd.yml
@@ -60,5 +60,7 @@ confd('harness:/'):
   - { src: application/skeleton/composer.json }
   - { src: docker/image/cron/Dockerfile }
   - { src: docker/image/cron/root/crontab }
+  - { src: docker/image/console/root/home/build/.ssh/id_rsa }
+  - { src: docker/image/console/root/home/build/.ssh/id_rsa.pub }
   - { src: docker/image/console/root/lib/task/composer/install.sh }
   - { src: docker/image/job-queue-consumer/Dockerfile }


### PR DESCRIPTION
Requires https://github.com/my127/workspace/pull/63 to add file encryption support to `ws create`.
It will work without that being present in the user's local `ws` tool. It just won't ask any the questions that have a null value in the harness already.

* Prompt for the edition of Akeneo (community/enterprise)
* Avoid needing to cancel the installation when creating a new project and updating composer.json when wanting to use enterprise edition
* Prompt for the project name in Akeneo's portal when using enterprise edition (can't stop this from happening if you answer "community")
* Prompt for SSH public key and a path to the SSH private key file to download from Akeneo's git repository.