### PR TITLE
Fix Magento 1 app init not running migrations

### DIFF
--- a/src/magento1/harness.yml
+++ b/src/magento1/harness.yml
@@ -89,9 +89,7 @@ attributes:
       steps:
         - run n98-magerun.phar config:set 'web/unsecure/base_url' "https://${APP_HOST}/"
         - run n98-magerun.phar config:set 'web/secure/base_url'   "https://${APP_HOST}/"
-        - run n98-magerun.phar sys:setup:incremental -n
-        - run n98-magerun.phar index:reindex:all
-        - run n98-magerun.phar cache:clean
+        - task migrate
     migrate:
       steps:
         - run n98-magerun.phar sys:setup:incremental -n

--- a/src/magento1/harness.yml
+++ b/src/magento1/harness.yml
@@ -89,6 +89,9 @@ attributes:
       steps:
         - run n98-magerun.phar config:set 'web/unsecure/base_url' "https://${APP_HOST}/"
         - run n98-magerun.phar config:set 'web/secure/base_url'   "https://${APP_HOST}/"
+        - run n98-magerun.phar sys:setup:incremental -n
+        - run n98-magerun.phar index:reindex:all
+        - run n98-magerun.phar cache:clean
     migrate:
       steps:
         - run n98-magerun.phar sys:setup:incremental -n


### PR DESCRIPTION
Seems to be when we introduced `app migrate` for deployments in https://github.com/inviqa/harness-base-php/pull/120