### PR TITLE
Add Magento 2 var/export PersistentVolumeClaim

### DIFF
--- a/src/magento2/harness.yml
+++ b/src/magento2/harness.yml
@@ -32,6 +32,7 @@ attributes:
       - redis-session
       - elasticsearch
     web_directory: /app/pub
+    export_directory: /app/var/export
     media_directory: = @('app.web_directory') ~ '/media'
   php:
     fpm:
@@ -175,6 +176,13 @@ attributes:
   persistence:
     enabled: false
     magento:
+      export:
+        claimName: magento-export-pvc
+        mountPath: = @('app.export_directory')
+        accessMode: ReadWriteMany # the requirement if persistence is enabled
+        #storageClass: "..." most clusters need a custom storageclass
+        #hostPath: "..." alternatively for single node testing
+        size: 512Mi
       media:
         claimName: magento-media-pvc
         mountPath: = @('app.media_directory')

--- a/src/magento2/harness.yml
+++ b/src/magento2/harness.yml
@@ -22,6 +22,7 @@ attributes:
       - '/app/pub/media'
       - '/app/pub/static'
       - '/app/var'
+      - '/app/var/export'
       - '/app/pub/static/frontend'
       - "= (@('app.mode') !== 'production' ? '/app/generated' : '')"
     services:
@@ -79,6 +80,7 @@ attributes:
           else
             echo -n "$(date +%s)" > pub/static/deployed_version.txt
           fi
+        - run mkdir -p /app/var/export
     install:
       steps:
         # the magento installer will not work if the dpeloyment config is present so we remove and

--- a/src/magento2/harness/attributes/docker.yml
+++ b/src/magento2/harness/attributes/docker.yml
@@ -18,5 +18,7 @@ attributes:
       persistence:
         enabled: true
         magento:
+          export:
+            storageClass: nfs
           media:
             storageClass: nfs

--- a/src/magento2/helm/app/templates/application/_helper.tpl
+++ b/src/magento2/helm/app/templates/application/_helper.tpl
@@ -3,6 +3,11 @@
   name: magento-media-volume
 {{- end }}
 
+{{- define "application.volumeMounts.backend" }}
+- mountPath: {{ .Values.persistence.magento.export.mountPath | quote }}
+  name: magento-export-volume
+{{- end }}
+
 {{- define "application.volumes.all" }}
 - name: magento-media-volume
 {{- if .Values.persistence.enabled }}
@@ -13,6 +18,17 @@
 {{- end }}
 {{- end }}
 
+{{- define "application.volumes.backend" }}
+- name: magento-export-volume
+{{- if .Values.persistence.enabled }}
+  persistentVolumeClaim:
+    claimName: {{ tpl .Values.persistence.magento.export.claimName $ | quote }}
+{{- else }}
+  emptyDir: {}
+{{- end }}
+{{- end }}
+
 {{- define "application.volumes.wwwDataPaths" }}
+- {{ .Values.persistence.magento.export.mountPath | quote }}
 - {{ .Values.persistence.magento.media.mountPath | quote }}
 {{- end }}

--- a/src/magento2/helm/app/templates/application/magento-export-pvc.yaml
+++ b/src/magento2/helm/app/templates/application/magento-export-pvc.yaml
@@ -1,0 +1,45 @@
+{{- if .Values.persistence.enabled -}}
+{{- with .Values.persistence.magento.export -}}
+{{- if .hostPath }}
+---
+kind: PersistentVolume
+metadata:
+  name: magento-export
+spec:
+  capacity: {{ .size | quote }}
+  accessModes:
+    - {{ .accessMode | quote }}
+  hostPath:
+    path: {{ .hostPath | quote }}
+  storageClassName: host-magento-export
+...
+{{- end }}
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ tpl .claimName $ | quote }}
+spec:
+  accessModes:
+    - {{ .accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .size | quote }}
+{{- if .hostPath }}
+      storageClassName: host-magento-export
+{{- else }}
+{{- if .storageClass }}
+{{- if (eq "-" .storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: {{ .storageClass | quote }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- if .selector }}
+  selector:
+  {{- .selector | toYaml | nindent 4 }}
+{{- end }}
+...
+{{- end -}}
+{{- end -}}


### PR DESCRIPTION
To be able to generate reports via cron that are downloadable via admin, the var/export folder should be shared between cron and php-fpm as well as being persistent.