### PR TITLE
Add persistence for Spryker jenkins home

### DIFF
--- a/src/spryker/harness.yml
+++ b/src/spryker/harness.yml
@@ -181,6 +181,10 @@ attributes:
         size: 1Gi
     redis:
       enabled: true
+    jenkins:
+      enabled: true
+      accessMode: ReadWriteOnce
+      size: 2Gi
 
 ---
 command('frontend yves watch'):

--- a/src/spryker/helm/app/templates/service/jenkins/deployment.yaml
+++ b/src/spryker/helm/app/templates/service/jenkins/deployment.yaml
@@ -13,11 +13,17 @@ spec:
   selector:
     matchLabels:
       app.service: {{ $.Values.resourcePrefix }}jenkins
+{{- if $.Values.persistence.postgres.enabled }}
+  strategy:
+    type: Recreate
+{{- end }}
   template:
     metadata:
       labels:
         app.service: {{ $.Values.resourcePrefix }}jenkins
     spec:
+      securityContext:
+        fsGroup: 1000
       containers:
       - env:
         - name: JAVA_OPTS
@@ -37,7 +43,18 @@ spec:
             port: 8080
           initialDelaySeconds: 5
           periodSeconds: 10
+        volumeMounts:
+        - name: home
+          mountPath: /var/jenkins_home
       restartPolicy: Always
+      volumes:
+      - name: home
+{{- if $.Values.persistence.jenkins.enabled }}
+        persistentVolumeClaim:
+          claimName: {{ $.Values.resourcePrefix }}jenkins-home
+{{- else }}
+        emptyDir: {}
+{{- end }}
 status: {}
 {{- end }}
 {{- end }}

--- a/src/spryker/helm/app/templates/service/jenkins/deployment.yaml
+++ b/src/spryker/helm/app/templates/service/jenkins/deployment.yaml
@@ -13,7 +13,7 @@ spec:
   selector:
     matchLabels:
       app.service: {{ $.Values.resourcePrefix }}jenkins
-{{- if $.Values.persistence.postgres.enabled }}
+{{- if $.Values.persistence.jenkins.enabled }}
   strategy:
     type: Recreate
 {{- end }}

--- a/src/spryker/helm/app/templates/service/jenkins/pvc.yaml
+++ b/src/spryker/helm/app/templates/service/jenkins/pvc.yaml
@@ -1,0 +1,30 @@
+{{ if and (.Values.service.jenkins | default .Values.docker.services.jenkins.enabled) .Values.persistence.jenkins.enabled -}}
+{{- with .Values.persistence.jenkins -}}
+
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ $.Values.resourcePrefix }}jenkins-home
+  labels:
+    app.service: {{ $.Values.resourcePrefix }}jenkins
+spec:
+  accessModes:
+    - {{ .accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .size | quote }}
+{{- if .storageClass }}
+{{- if (eq "-" .storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: {{ .storageClass | quote }}
+{{- end }}
+{{- end }}
+{{- if .selector }}
+  selector:
+  {{- .selector | toYaml | nindent 4 }}
+{{- end }}
+
+{{- end }}
+
+{{- end }}


### PR DESCRIPTION
It has job logs in that shouldn't be lost on rescheduling, and spryker app-migrate doesn't add jobs back in on new deployments