### PR TITLE
Add standard k8s/helm labels

### DIFF
--- a/src/_base/_twig/docker-compose.yml/service/mongodb.yml.twig
+++ b/src/_base/_twig/docker-compose.yml/service/mongodb.yml.twig
@@ -1,0 +1,14 @@
+  mongodb:
+    image: {{ @('services.mongodb.image') }}
+    environment: {{ to_nice_yaml(deep_merge([
+        @('services.mongodb.environment'),
+        @('services.mongodb.environment_secrets')
+      ]), 2, 6) | raw }}
+    labels:
+      - traefik.enable=false
+    networks:
+      - private
+    expose:
+      - 27017
+    volumes:
+      - /data/db

--- a/src/_base/harness/attributes/common.yml
+++ b/src/_base/harness/attributes/common.yml
@@ -360,6 +360,10 @@ attributes.default:
       enabled: true
       accessMode: ReadWriteOnce
       size: 2Gi
+    mongodb:
+      enabled: true
+      accessMode: ReadWriteOnce
+      size: 1Gi
     mysql:
       enabled: true
       accessMode: ReadWriteOnce

--- a/src/_base/harness/attributes/docker-base.yml
+++ b/src/_base/harness/attributes/docker-base.yml
@@ -91,6 +91,14 @@ attributes:
     memcached:
       enabled: "= 'memcached' in @('app.services')"
       image: memcached:1-alpine
+    mongodb:
+      image: mongo:4.4
+      environment:
+        MONGO_INITDB_ROOT_USERNAME: admin
+      environment_secrets:
+        MONGO_INITDB_ROOT_PASSWORD: password
+      resources:
+        memory: "512Mi"
     mysql:
       enabled: "= 'mysql' in @('app.services')"
       image: = @('mysql.image') ~ ':' ~ @('mysql.tag')

--- a/src/_base/helm/app/templates/_base_helper.tpl
+++ b/src/_base/helm/app/templates/_base_helper.tpl
@@ -1,3 +1,22 @@
+{{/*
+Common labels
+*/}}
+{{- define "chart.labels" -}}
+app.kubernetes.io/name: {{ .Chart.Name }}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Values.appVersion | default .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Common selectors
+*/}}
+{{- define "chart.selectors" -}}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
 {{- define "application.volumes.backend" }}{{ end }}
 {{- define "application.volumeMounts.backend" }}{{ end }}
 
@@ -21,7 +40,7 @@
 
 {{- define "service.environment.secret" }}
 {{ if and .service.environment_secrets (.service.enabled | default true) }}
-{{ if .Values.feature.sealed_secrets }}
+{{ if .root.Values.feature.sealed_secrets }}
 apiVersion: bitnami.com/v1alpha1
 kind: SealedSecret
 {{ else }}
@@ -29,16 +48,24 @@ apiVersion: v1
 kind: Secret
 {{ end }}
 metadata:
-  name: {{ .Values.resourcePrefix }}{{ .service_name }}
+  name: {{ .root.Values.resourcePrefix }}{{ .service_name }}
+  labels:
+    {{- include "chart.labels" .root | nindent 4 }}
+    app.kubernetes.io/component: {{ .component | default .service_name }}
   annotations:
     argocd.argoproj.io/sync-wave: "1"
-{{ if .Values.feature.sealed_secrets }}
-{{ if ne .Values.sealed_secrets.scope "strict" }}
+{{ if .root.Values.feature.sealed_secrets }}
+{{ if ne .root.Values.sealed_secrets.scope "strict" }}
     sealedsecrets.bitnami.com/{{ .Values.sealed_secrets.scope }}: "true"
 {{ end }}
 spec:
   encryptedData:
-{{ index .service.environment_secrets | toYaml | nindent 4 -}}
+{{ index .service.environment_secrets | toYaml | nindent 4 }}
+  template:
+    metadata:
+      labels:
+        {{- include "chart.labels" .root | nindent 8 }}
+        app.kubernetes.io/component: {{ .component | default .service_name }}
 {{ else }}
 stringData:
 {{ index .service.environment_secrets | toYaml | nindent 2 -}}

--- a/src/_base/helm/app/templates/application/app-init.yaml
+++ b/src/_base/helm/app/templates/application/app-init.yaml
@@ -9,9 +9,16 @@ metadata:
     argocd.argoproj.io/hook: "Sync"
     argocd.argoproj.io/hook-delete-policy: "BeforeHookCreation"
     argocd.argoproj.io/sync-wave: "5"
+  labels:
+    {{- include "chart.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: app-init
 spec:
   backoffLimit: 0
   template:
+    metadata:
+      labels:
+        {{- include "chart.labels" $ | nindent 8 }}
+        app.kubernetes.io/component: app-init
     spec:
       restartPolicy: Never
       containers:

--- a/src/_base/helm/app/templates/application/app-migrate.yaml
+++ b/src/_base/helm/app/templates/application/app-migrate.yaml
@@ -9,8 +9,15 @@ metadata:
     argocd.argoproj.io/hook: "Sync"
     argocd.argoproj.io/hook-delete-policy: "BeforeHookCreation"
     argocd.argoproj.io/sync-wave: "10"
+  labels:
+    {{- include "chart.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: app-migrate
 spec:
   template:
+    metadata:
+      labels:
+        {{- include "chart.labels" $ | nindent 8 }}
+        app.kubernetes.io/component: app-migrate
     spec:
       containers:
       - env:

--- a/src/_base/helm/app/templates/application/console/deployment.yaml
+++ b/src/_base/helm/app/templates/application/console/deployment.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "chart.labels" $ | nindent 8 }}
+        {{- include "chart.selectors" $ | nindent 8 }}
         app.kubernetes.io/component: console
         app.service: {{ $.Values.resourcePrefix }}console
     spec:

--- a/src/_base/helm/app/templates/application/console/deployment.yaml
+++ b/src/_base/helm/app/templates/application/console/deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   name: {{ $.Values.resourcePrefix }}console
   labels:
+    {{- include "chart.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: console
     app.service: {{ $.Values.resourcePrefix }}console
   annotations:
     argocd.argoproj.io/sync-wave: "15"
@@ -17,6 +19,8 @@ spec:
   template:
     metadata:
       labels:
+        {{- include "chart.labels" $ | nindent 8 }}
+        app.kubernetes.io/component: console
         app.service: {{ $.Values.resourcePrefix }}console
     spec:
       containers:

--- a/src/_base/helm/app/templates/application/console/secret.yaml
+++ b/src/_base/helm/app/templates/application/console/secret.yaml
@@ -1,2 +1,2 @@
 {{- $service := mergeOverwrite (dict) (index .Values.docker.services "php-base") (index .Values.docker.services "console") -}}
-{{ template "service.environment.secret" (dict "service_name" "console" "service" $service "Values" .Values) }}
+{{ template "service.environment.secret" (dict "service_name" "console" "service" $service "root" $) }}

--- a/src/_base/helm/app/templates/application/cron/deployment.yaml
+++ b/src/_base/helm/app/templates/application/cron/deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   name: {{ $.Values.resourcePrefix }}cron
   labels:
+    {{- include "chart.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: console
     app.service: {{ $.Values.resourcePrefix }}cron
   annotations:
     argocd.argoproj.io/sync-wave: "15"
@@ -17,6 +19,8 @@ spec:
   template:
     metadata:
       labels:
+        {{- include "chart.labels" $ | nindent 8 }}
+        app.kubernetes.io/component: cron
         app.service: {{ $.Values.resourcePrefix }}cron
     spec:
       {{- if not (eq "" (include "application.volumes.wwwDataPaths" $)) }}

--- a/src/_base/helm/app/templates/application/cron/deployment.yaml
+++ b/src/_base/helm/app/templates/application/cron/deployment.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "chart.labels" $ | nindent 8 }}
+        {{- include "chart.selectors" $ | nindent 8 }}
         app.kubernetes.io/component: cron
         app.service: {{ $.Values.resourcePrefix }}cron
     spec:

--- a/src/_base/helm/app/templates/application/cron/deployment.yaml
+++ b/src/_base/helm/app/templates/application/cron/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ $.Values.resourcePrefix }}cron
   labels:
     {{- include "chart.labels" $ | nindent 4 }}
-    app.kubernetes.io/component: console
+    app.kubernetes.io/component: cron
     app.service: {{ $.Values.resourcePrefix }}cron
   annotations:
     argocd.argoproj.io/sync-wave: "15"

--- a/src/_base/helm/app/templates/application/cron/secret.yaml
+++ b/src/_base/helm/app/templates/application/cron/secret.yaml
@@ -1,2 +1,2 @@
 {{- $service := mergeOverwrite (dict) (index .Values.docker.services "php-base") (index .Values.docker.services "cron") -}}
-{{ template "service.environment.secret" (dict "service_name" "cron" "service" $service "Values" .Values) }}
+{{ template "service.environment.secret" (dict "service_name" "cron" "service" $service "root" $) }}

--- a/src/_base/helm/app/templates/application/image-pull-config.yaml
+++ b/src/_base/helm/app/templates/application/image-pull-config.yaml
@@ -12,9 +12,14 @@ metadata:
     argocd.argoproj.io/sync-wave: "1"
 {{ if .Values.feature.sealed_secrets }}
     sealedsecrets.bitnami.com/cluster-wide: "true"
+  labels:
+    {{- include "chart.labels" $ | nindent 4 }}
 spec:
   template:
     type: kubernetes.io/dockerconfigjson
+    metadata:
+      labels:
+        {{- include "chart.labels" $ | nindent 8 }}
   encryptedData:
     .dockerconfigjson: {{ .Values.docker.image_pull_config }}
 {{ else }}

--- a/src/_base/helm/app/templates/application/webapp/deployment.yaml
+++ b/src/_base/helm/app/templates/application/webapp/deployment.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "chart.labels" $ | nindent 8 }}
+        {{- include "chart.selectors" $ | nindent 8 }}
         app.kubernetes.io/component: webapp
         app.service: {{ .Values.resourcePrefix }}webapp
     spec:

--- a/src/_base/helm/app/templates/application/webapp/deployment.yaml
+++ b/src/_base/helm/app/templates/application/webapp/deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   name: {{ .Values.resourcePrefix }}webapp
   labels:
+    {{- include "chart.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: webapp
     app.service: {{ .Values.resourcePrefix }}webapp
   annotations:
     argocd.argoproj.io/sync-wave: "15"
@@ -17,6 +19,8 @@ spec:
   template:
     metadata:
       labels:
+        {{- include "chart.labels" $ | nindent 8 }}
+        app.kubernetes.io/component: webapp
         app.service: {{ .Values.resourcePrefix }}webapp
     spec:
       {{- if and $service_php_fpm.enabled (not (eq "" (include "application.volumes.wwwDataPaths" .))) }}

--- a/src/_base/helm/app/templates/application/webapp/ingress-istio.yaml
+++ b/src/_base/helm/app/templates/application/webapp/ingress-istio.yaml
@@ -4,6 +4,8 @@ kind: VirtualService
 metadata:
  name: {{ .Release.Namespace }}-{{ .Values.resourcePrefix }}webapp-virtualservice
  labels:
+   {{- include "chart.labels" $ | nindent 4 }}
+   app.kubernetes.io/component: webapp
    app: {{ .Values.resourcePrefix }}webapp
    app.service: {{ .Values.resourcePrefix }}webapp
 spec:

--- a/src/_base/helm/app/templates/application/webapp/ingress.yaml
+++ b/src/_base/helm/app/templates/application/webapp/ingress.yaml
@@ -10,6 +10,8 @@ metadata:
 {{- end }}
   creationTimestamp: null
   labels:
+    {{- include "chart.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: webapp
     app.service: {{ .Values.resourcePrefix }}webapp
   name: {{ .Values.resourcePrefix }}webapp
 spec:

--- a/src/_base/helm/app/templates/application/webapp/podmonitor.yaml
+++ b/src/_base/helm/app/templates/application/webapp/podmonitor.yaml
@@ -4,6 +4,8 @@ kind: PodMonitor
 metadata:
   name: {{ .Values.resourcePrefix }}webapp
   labels:
+    {{- include "chart.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: webapp
     app.service: {{ .Values.resourcePrefix }}webapp
 spec:
   selector:

--- a/src/_base/helm/app/templates/application/webapp/secret-nginx.yaml
+++ b/src/_base/helm/app/templates/application/webapp/secret-nginx.yaml
@@ -1,1 +1,1 @@
-{{ template "service.environment.secret" (dict "service_name" "nginx" "service" .Values.docker.services.nginx "Values" .Values) }}
+{{ template "service.environment.secret" (dict "component" "webapp" "service_name" "nginx" "service" .Values.docker.services.nginx "root" $) }}

--- a/src/_base/helm/app/templates/application/webapp/secret-php-fpm.yaml
+++ b/src/_base/helm/app/templates/application/webapp/secret-php-fpm.yaml
@@ -1,2 +1,2 @@
 {{- $service := mergeOverwrite (dict) (index .Values.docker.services "php-base") (index .Values.docker.services "php-fpm") -}}
-{{ template "service.environment.secret" (dict "service_name" "php-fpm" "service" $service "Values" .Values) }}
+{{ template "service.environment.secret" (dict "component" "webapp" "service_name" "php-fpm" "service" $service "root" $) }}

--- a/src/_base/helm/app/templates/application/webapp/service.yaml
+++ b/src/_base/helm/app/templates/application/webapp/service.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
+    {{- include "chart.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: webapp
     app.service: {{ .Values.resourcePrefix }}webapp
   name: {{ .Values.resourcePrefix }}webapp
 spec:

--- a/src/_base/helm/app/templates/service/elasticsearch/deployment.yaml
+++ b/src/_base/helm/app/templates/service/elasticsearch/deployment.yaml
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "chart.labels" $ | nindent 8 }}
+        {{- include "chart.selectors" $ | nindent 8 }}
         app.kubernetes.io/component: elasticsearch
         app.service: {{ $.Values.resourcePrefix }}elasticsearch
     spec:

--- a/src/_base/helm/app/templates/service/elasticsearch/deployment.yaml
+++ b/src/_base/helm/app/templates/service/elasticsearch/deployment.yaml
@@ -7,6 +7,8 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "4"
   labels:
+    {{- include "chart.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: elasticsearch
     app.service: {{ $.Values.resourcePrefix }}elasticsearch
 spec:
   replicas: 1
@@ -20,6 +22,8 @@ spec:
   template:
     metadata:
       labels:
+        {{- include "chart.labels" $ | nindent 8 }}
+        app.kubernetes.io/component: elasticsearch
         app.service: {{ $.Values.resourcePrefix }}elasticsearch
     spec:
       securityContext:

--- a/src/_base/helm/app/templates/service/elasticsearch/pvc.yaml
+++ b/src/_base/helm/app/templates/service/elasticsearch/pvc.yaml
@@ -7,6 +7,8 @@ apiVersion: v1
 metadata:
   name: {{ $.Values.resourcePrefix }}elasticsearch-pv-claim
   labels:
+    {{- include "chart.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: elasticsearch
     app.service: {{ $.Values.resourcePrefix }}elasticsearch
 spec:
   accessModes:

--- a/src/_base/helm/app/templates/service/elasticsearch/service.yaml
+++ b/src/_base/helm/app/templates/service/elasticsearch/service.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
+    {{- include "chart.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: elasticsearch
     app.service: {{ .Values.resourcePrefix }}elasticsearch
   name: {{ .Values.resourcePrefix }}elasticsearch
 spec:

--- a/src/_base/helm/app/templates/service/mongodb/deployment.yaml
+++ b/src/_base/helm/app/templates/service/mongodb/deployment.yaml
@@ -1,0 +1,69 @@
+{{- with .Values.docker.services.mongodb -}}
+{{- if .enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $.Values.resourcePrefix }}mongodb
+  annotations:
+    argocd.argoproj.io/sync-wave: "4"
+  labels:
+    {{- include "chart.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: mongodb
+    app.service: {{ $.Values.resourcePrefix }}mongodb
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.service: {{ $.Values.resourcePrefix }}mongodb
+{{- if $.Values.persistence.mongodb.enabled }}
+  strategy:
+    type: Recreate
+{{- end }}
+  template:
+    metadata:
+      labels:
+        {{- include "chart.labels" $ | nindent 8 }}
+        app.kubernetes.io/component: mongodb
+        app.service: {{ $.Values.resourcePrefix }}mongodb
+    spec:
+      containers:
+      - env:
+        {{- range $key, $value := .environment }}
+        - name: {{ $key | quote }}
+          value: {{ $value | quote }}
+        {{- end }}
+        {{- if .environment_secrets }}
+        envFrom:
+          - secretRef:
+              name: {{ $.Values.resourcePrefix }}mongodb
+        {{- end }}
+        image: {{ .image | quote }}
+        imagePullPolicy: Always
+        name: mongodb
+        ports:
+        - containerPort: 27017
+        resources:
+          limits:
+            memory: {{ .resources.memory }}
+          requests:
+            memory: {{ .resources.memory }}
+        readinessProbe:
+          tcpSocket:
+            port: 27017
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        volumeMounts:
+        - name: data-db
+          mountPath: /data/db
+      restartPolicy: Always
+      volumes:
+      - name: data-db
+{{- if $.Values.persistence.mongodb.enabled }}
+        persistentVolumeClaim:
+          claimName: {{ $.Values.resourcePrefix }}mongodb
+{{- else }}
+        emptyDir: {}
+{{- end }}
+status: {}
+{{- end }}
+{{- end }}

--- a/src/_base/helm/app/templates/service/mongodb/pvc.yaml
+++ b/src/_base/helm/app/templates/service/mongodb/pvc.yaml
@@ -1,0 +1,32 @@
+{{ if and .Values.docker.services.mongodb.enabled .Values.persistence.mongodb.enabled -}}
+{{- with .Values.persistence.mongodb -}}
+
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ $.Values.resourcePrefix }}mongodb
+  labels:
+    {{- include "chart.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: mongodb
+    app.service: {{ $.Values.resourcePrefix }}mongodb
+spec:
+  accessModes:
+    - {{ .accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .size | quote }}
+{{- if .storageClass }}
+{{- if (eq "-" .storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: {{ .storageClass | quote }}
+{{- end }}
+{{- end }}
+{{- if .selector }}
+  selector:
+  {{- .selector | toYaml | nindent 4 }}
+{{- end }}
+
+{{- end }}
+
+{{- end }}

--- a/src/_base/helm/app/templates/service/mongodb/secret.yaml
+++ b/src/_base/helm/app/templates/service/mongodb/secret.yaml
@@ -1,0 +1,1 @@
+{{ template "service.environment.secret" (dict "service_name" "mongodb" "service" .Values.docker.services.mongodb "root" $) }}

--- a/src/_base/helm/app/templates/service/mongodb/service.yaml
+++ b/src/_base/helm/app/templates/service/mongodb/service.yaml
@@ -1,0 +1,21 @@
+{{ if .Values.docker.services.mongodb.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    {{- include "chart.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: mongodb
+    app.service: {{ $.Values.resourcePrefix }}mongodb
+  name: {{ .Values.resourcePrefix }}mongodb
+spec:
+  ports:
+  - name: wire
+    port: 27017
+    targetPort: 27017
+  selector:
+    {{- include "chart.selectors" $ | nindent 4 }}
+    app.kubernetes.io/component: mongodb
+    app.service: {{ $.Values.resourcePrefix }}mongodb
+status:
+  loadBalancer: {}
+{{ end }}

--- a/src/_base/helm/app/templates/service/mysql/deployment.yaml
+++ b/src/_base/helm/app/templates/service/mysql/deployment.yaml
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "chart.labels" $ | nindent 8 }}
+        {{- include "chart.selectors" $ | nindent 8 }}
         app.kubernetes.io/component: mysql
         app.service: {{ $.Values.resourcePrefix }}mysql
     spec:

--- a/src/_base/helm/app/templates/service/mysql/deployment.yaml
+++ b/src/_base/helm/app/templates/service/mysql/deployment.yaml
@@ -7,6 +7,8 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "4"
   labels:
+    {{- include "chart.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: mysql
     app.service: {{ $.Values.resourcePrefix }}mysql
 spec:
   replicas: 1
@@ -20,6 +22,8 @@ spec:
   template:
     metadata:
       labels:
+        {{- include "chart.labels" $ | nindent 8 }}
+        app.kubernetes.io/component: mysql
         app.service: {{ $.Values.resourcePrefix }}mysql
     spec:
       containers:

--- a/src/_base/helm/app/templates/service/mysql/pvc.yaml
+++ b/src/_base/helm/app/templates/service/mysql/pvc.yaml
@@ -7,6 +7,8 @@ apiVersion: v1
 metadata:
   name: {{ $.Values.resourcePrefix }}mysql-pv-claim
   labels:
+    {{- include "chart.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: mysql
     app.service: {{ $.Values.resourcePrefix }}mysql
 spec:
   accessModes:

--- a/src/_base/helm/app/templates/service/mysql/secret.yaml
+++ b/src/_base/helm/app/templates/service/mysql/secret.yaml
@@ -1,1 +1,1 @@
-{{ template "service.environment.secret" (dict "service_name" "mysql" "service" .Values.docker.services.mysql "Values" .Values) }}
+{{ template "service.environment.secret" (dict "service_name" "mysql" "service" .Values.docker.services.mysql "root" $) }}

--- a/src/_base/helm/app/templates/service/mysql/service.yaml
+++ b/src/_base/helm/app/templates/service/mysql/service.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
+    {{- include "chart.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: mysql
     app.service: {{ .Values.resourcePrefix }}mysql
   name: {{ .Values.resourcePrefix }}mysql
 spec:

--- a/src/_base/helm/app/templates/service/postgres/deployment.yaml
+++ b/src/_base/helm/app/templates/service/postgres/deployment.yaml
@@ -7,6 +7,8 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "4"
   labels:
+    {{- include "chart.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: postgres
     app.service: {{ $.Values.resourcePrefix }}postgres
 spec:
   replicas: 1
@@ -20,6 +22,8 @@ spec:
   template:
     metadata:
       labels:
+        {{- include "chart.labels" $ | nindent 8 }}
+        app.kubernetes.io/component: postgres
         app.service: {{ $.Values.resourcePrefix }}postgres
     spec:
       containers:

--- a/src/_base/helm/app/templates/service/postgres/deployment.yaml
+++ b/src/_base/helm/app/templates/service/postgres/deployment.yaml
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "chart.labels" $ | nindent 8 }}
+        {{- include "chart.selectors" $ | nindent 8 }}
         app.kubernetes.io/component: postgres
         app.service: {{ $.Values.resourcePrefix }}postgres
     spec:

--- a/src/_base/helm/app/templates/service/postgres/pvc.yaml
+++ b/src/_base/helm/app/templates/service/postgres/pvc.yaml
@@ -7,6 +7,8 @@ apiVersion: v1
 metadata:
   name: {{ $.Values.resourcePrefix }}postgres-pv-claim
   labels:
+    {{- include "chart.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: postgres
     app.service: {{ $.Values.resourcePrefix }}postgres
 spec:
   accessModes:

--- a/src/_base/helm/app/templates/service/postgres/secret.yaml
+++ b/src/_base/helm/app/templates/service/postgres/secret.yaml
@@ -1,1 +1,1 @@
-{{ template "service.environment.secret" (dict "service_name" "postgres" "service" .Values.docker.services.postgres "Values" .Values) }}
+{{ template "service.environment.secret" (dict "service_name" "postgres" "service" .Values.docker.services.postgres "root" $) }}

--- a/src/_base/helm/app/templates/service/postgres/service.yaml
+++ b/src/_base/helm/app/templates/service/postgres/service.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
+    {{- include "chart.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: postgres
     app.service: {{ .Values.resourcePrefix }}postgres
   name: {{ .Values.resourcePrefix }}postgres
 spec:

--- a/src/_base/helm/app/templates/service/rabbitmq/deployment.yaml
+++ b/src/_base/helm/app/templates/service/rabbitmq/deployment.yaml
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "chart.labels" $ | nindent 8 }}
+        {{- include "chart.selectors" $ | nindent 8 }}
         app.kubernetes.io/component: rabbitmq
         app.service: {{ $.Values.resourcePrefix }}rabbitmq
     spec:

--- a/src/_base/helm/app/templates/service/rabbitmq/deployment.yaml
+++ b/src/_base/helm/app/templates/service/rabbitmq/deployment.yaml
@@ -7,6 +7,8 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "4"
   labels:
+    {{- include "chart.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: rabbitmq
     app.service: {{ $.Values.resourcePrefix }}rabbitmq
 spec:
   replicas: 1
@@ -20,6 +22,8 @@ spec:
   template:
     metadata:
       labels:
+        {{- include "chart.labels" $ | nindent 8 }}
+        app.kubernetes.io/component: rabbitmq
         app.service: {{ $.Values.resourcePrefix }}rabbitmq
     spec:
       containers:

--- a/src/_base/helm/app/templates/service/rabbitmq/pvc.yaml
+++ b/src/_base/helm/app/templates/service/rabbitmq/pvc.yaml
@@ -7,6 +7,8 @@ apiVersion: v1
 metadata:
   name: {{ $.Values.resourcePrefix }}rabbitmq-pv-claim
   labels:
+    {{- include "chart.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: rabbitmq
     app.service: {{ $.Values.resourcePrefix }}rabbitmq
 spec:
   accessModes:

--- a/src/_base/helm/app/templates/service/rabbitmq/secret.yaml
+++ b/src/_base/helm/app/templates/service/rabbitmq/secret.yaml
@@ -1,1 +1,1 @@
-{{ template "service.environment.secret" (dict "service_name" "rabbitmq" "service" .Values.docker.services.rabbitmq "Values" .Values) }}
+{{ template "service.environment.secret" (dict "service_name" "rabbitmq" "service" .Values.docker.services.rabbitmq "root" $) }}

--- a/src/_base/helm/app/templates/service/rabbitmq/service.yaml
+++ b/src/_base/helm/app/templates/service/rabbitmq/service.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
+    {{- include "chart.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: rabbitmq
     app.service: {{ .Values.resourcePrefix }}rabbitmq
   name: {{ .Values.resourcePrefix }}rabbitmq
 spec:

--- a/src/_base/helm/app/templates/service/redis-session/deployment.yaml
+++ b/src/_base/helm/app/templates/service/redis-session/deployment.yaml
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "chart.labels" $ | nindent 8 }}
+        {{- include "chart.selectors" $ | nindent 8 }}
         app.kubernetes.io/component: redis-session
         app.service: {{ $.Values.resourcePrefix }}redis-session
     spec:

--- a/src/_base/helm/app/templates/service/redis-session/deployment.yaml
+++ b/src/_base/helm/app/templates/service/redis-session/deployment.yaml
@@ -7,6 +7,8 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "4"
   labels:
+    {{- include "chart.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: redis-session
     app.service: {{ $.Values.resourcePrefix }}redis-session
 spec:
   replicas: 1
@@ -20,6 +22,8 @@ spec:
   template:
     metadata:
       labels:
+        {{- include "chart.labels" $ | nindent 8 }}
+        app.kubernetes.io/component: redis-session
         app.service: {{ $.Values.resourcePrefix }}redis-session
     spec:
       containers:

--- a/src/_base/helm/app/templates/service/redis-session/pvc.yaml
+++ b/src/_base/helm/app/templates/service/redis-session/pvc.yaml
@@ -7,6 +7,8 @@ apiVersion: v1
 metadata:
   name: {{ $.Values.resourcePrefix }}redis-session-pv-claim
   labels:
+    {{- include "chart.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: redis-session
     app.service: {{ $.Values.resourcePrefix }}redis-session
 spec:
   accessModes:

--- a/src/_base/helm/app/templates/service/redis-session/service.yaml
+++ b/src/_base/helm/app/templates/service/redis-session/service.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
+    {{- include "chart.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: redis-session
     app.service: {{ .Values.resourcePrefix }}redis-session
   name: {{ .Values.resourcePrefix }}redis-session
 spec:

--- a/src/_base/helm/app/templates/service/redis/deployment.yaml
+++ b/src/_base/helm/app/templates/service/redis/deployment.yaml
@@ -23,7 +23,7 @@ spec:
     metadata:
       creationTimestamp: null
       labels:
-        {{- include "chart.labels" $ | nindent 8 }}
+        {{- include "chart.selectors" $ | nindent 8 }}
         app.kubernetes.io/component: redis
         app.service: {{ $.Values.resourcePrefix }}redis
     spec:

--- a/src/_base/helm/app/templates/service/redis/deployment.yaml
+++ b/src/_base/helm/app/templates/service/redis/deployment.yaml
@@ -7,6 +7,8 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "4"
   labels:
+    {{- include "chart.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: redis
     app.service: {{ $.Values.resourcePrefix }}redis
 spec:
   replicas: 1
@@ -21,6 +23,8 @@ spec:
     metadata:
       creationTimestamp: null
       labels:
+        {{- include "chart.labels" $ | nindent 8 }}
+        app.kubernetes.io/component: redis
         app.service: {{ $.Values.resourcePrefix }}redis
     spec:
       containers:

--- a/src/_base/helm/app/templates/service/redis/pvc.yaml
+++ b/src/_base/helm/app/templates/service/redis/pvc.yaml
@@ -7,6 +7,8 @@ apiVersion: v1
 metadata:
   name: {{ $.Values.resourcePrefix }}redis-pv-claim
   labels:
+    {{- include "chart.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: redis
     app.service: {{ $.Values.resourcePrefix }}redis
 spec:
   accessModes:

--- a/src/_base/helm/app/templates/service/redis/service.yaml
+++ b/src/_base/helm/app/templates/service/redis/service.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
+    {{- include "chart.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: redis
     app.service: {{ .Values.resourcePrefix }}redis
   name: {{ .Values.resourcePrefix }}redis
 spec:

--- a/src/_base/helm/app/templates/service/tideways/deployment.yaml
+++ b/src/_base/helm/app/templates/service/tideways/deployment.yaml
@@ -7,6 +7,8 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "4"
   labels:
+    {{- include "chart.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: tideways
     app.service: {{ $.Values.resourcePrefix }}tideways
 spec:
   replicas: 1
@@ -17,6 +19,8 @@ spec:
     metadata:
       creationTimestamp: null
       labels:
+        {{- include "chart.labels" $ | nindent 8 }}
+        app.kubernetes.io/component: tideways
         app.service: {{ $.Values.resourcePrefix }}tideways
     spec:
       containers:

--- a/src/_base/helm/app/templates/service/tideways/deployment.yaml
+++ b/src/_base/helm/app/templates/service/tideways/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     metadata:
       creationTimestamp: null
       labels:
-        {{- include "chart.labels" $ | nindent 8 }}
+        {{- include "chart.selectors" $ | nindent 8 }}
         app.kubernetes.io/component: tideways
         app.service: {{ $.Values.resourcePrefix }}tideways
     spec:

--- a/src/_base/helm/app/templates/service/tideways/service.yaml
+++ b/src/_base/helm/app/templates/service/tideways/service.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
+    {{- include "chart.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: tideways
     app.service: {{ .Values.resourcePrefix }}tideways
   name: {{ .Values.resourcePrefix }}tideways
 spec:

--- a/src/_base/helm/app/templates/service/varnish/headless-service.yaml
+++ b/src/_base/helm/app/templates/service/varnish/headless-service.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
+    {{- include "chart.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: varnish
     app.service: {{ .Values.resourcePrefix }}varnish
   name: {{ .Values.resourcePrefix }}varnish-headless
 spec:

--- a/src/_base/helm/app/templates/service/varnish/service.yaml
+++ b/src/_base/helm/app/templates/service/varnish/service.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
+    {{- include "chart.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: varnish
     app.service: {{ .Values.resourcePrefix }}varnish
   name: {{ .Values.resourcePrefix }}varnish
 spec:

--- a/src/_base/helm/app/templates/service/varnish/statefulset.yaml
+++ b/src/_base/helm/app/templates/service/varnish/statefulset.yaml
@@ -7,6 +7,8 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "4"
   labels:
+    {{- include "chart.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: varnish
     app.service: {{ $.Values.resourcePrefix }}varnish
 spec:
   replicas: {{ $.Values.replicas.varnish }}
@@ -21,6 +23,8 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/service/varnish/configmap.yaml") $ | sha256sum }}
       labels:
+        {{- include "chart.labels" $ | nindent 8 }}
+        app.kubernetes.io/component: varnish
         app.service: {{ $.Values.resourcePrefix }}varnish
     spec:
       containers:

--- a/src/_base/helm/app/templates/service/varnish/statefulset.yaml
+++ b/src/_base/helm/app/templates/service/varnish/statefulset.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/service/varnish/configmap.yaml") $ | sha256sum }}
       labels:
-        {{- include "chart.labels" $ | nindent 8 }}
+        {{- include "chart.selectors" $ | nindent 8 }}
         app.kubernetes.io/component: varnish
         app.service: {{ $.Values.resourcePrefix }}varnish
     spec:

--- a/src/_base/helm/app/values.yaml.twig
+++ b/src/_base/helm/app/values.yaml.twig
@@ -1,5 +1,7 @@
 {% set blocks  = 'helm/app/_twig/values.yaml/' %}
 
+appVersion: {{ @('app.version') | json_encode | raw }}
+
 environment:
 {% include blocks ~ 'environment.yml.twig' %}
 

--- a/src/akeneo/helm/app/templates/application/akeneo-file-storage-pvc.yaml
+++ b/src/akeneo/helm/app/templates/application/akeneo-file-storage-pvc.yaml
@@ -5,6 +5,8 @@
 kind: PersistentVolume
 metadata:
   name: akeneo-file-storage
+  labels:
+    {{- include "chart.labels" $ | nindent 4 }}
 spec:
   capacity: {{ .size | quote }}
   accessModes:
@@ -19,6 +21,8 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ tpl .claimName $ | quote }}
+  labels:
+    {{- include "chart.labels" $ | nindent 4 }}
 spec:
   accessModes:
     - {{ .accessMode | quote }}

--- a/src/akeneo/helm/app/templates/application/akeneo-uploads-pvc.yaml
+++ b/src/akeneo/helm/app/templates/application/akeneo-uploads-pvc.yaml
@@ -5,6 +5,8 @@
 kind: PersistentVolume
 metadata:
   name: akeneo-uploads
+  labels:
+    {{- include "chart.labels" $ | nindent 4 }}
 spec:
   capacity: {{ .size | quote }}
   accessModes:
@@ -19,6 +21,8 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ tpl .claimName $ | quote }}
+  labels:
+    {{- include "chart.labels" $ | nindent 4 }}
 spec:
   accessModes:
     - {{ .accessMode | quote }}

--- a/src/akeneo/helm/app/templates/application/job-queue-consumer/deployment.yaml
+++ b/src/akeneo/helm/app/templates/application/job-queue-consumer/deployment.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "chart.labels" $ | nindent 8 }}
+        {{- include "chart.selectors" $ | nindent 8 }}
         app.kubernetes.io/component: job-queue-consumer
         app.service: {{ $.Values.resourcePrefix }}job-queue-consumer
     spec:

--- a/src/akeneo/helm/app/templates/application/job-queue-consumer/deployment.yaml
+++ b/src/akeneo/helm/app/templates/application/job-queue-consumer/deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   name: {{ $.Values.resourcePrefix }}job-queue-consumer
   labels:
+    {{- include "chart.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: job-queue-consumer
     app.service: {{ $.Values.resourcePrefix }}job-queue-consumer
   annotations:
     argocd.argoproj.io/sync-wave: "15"
@@ -17,6 +19,8 @@ spec:
   template:
     metadata:
       labels:
+        {{- include "chart.labels" $ | nindent 8 }}
+        app.kubernetes.io/component: job-queue-consumer
         app.service: {{ $.Values.resourcePrefix }}job-queue-consumer
     spec:
       {{- if not (eq "" (include "application.volumes.wwwDataPaths" $)) }}

--- a/src/akeneo/helm/app/templates/application/job-queue-consumer/secret.yaml
+++ b/src/akeneo/helm/app/templates/application/job-queue-consumer/secret.yaml
@@ -1,2 +1,2 @@
 {{- $service := mergeOverwrite (dict) (index .Values.docker.services "php-base") (index .Values.docker.services "job-queue-consumer") -}}
-{{ template "service.environment.secret" (dict "service_name" "job-queue-consumer" "service" $service "Values" .Values) }}
+{{ template "service.environment.secret" (dict "service_name" "job-queue-consumer" "service" $service "root" $) }}

--- a/src/akeneo/helm/app/values.yaml.twig
+++ b/src/akeneo/helm/app/values.yaml.twig
@@ -1,5 +1,7 @@
 {% set blocks  = 'helm/app/_twig/values.yaml/' %}
 
+appVersion: {{ @('app.version') | json_encode | raw }}
+
 environment:
 {% include blocks ~ 'environment.yml.twig' %}
 

--- a/src/drupal8/helm/app/templates/application/drupal-files-pvc.yaml
+++ b/src/drupal8/helm/app/templates/application/drupal-files-pvc.yaml
@@ -5,6 +5,8 @@
 kind: PersistentVolume
 metadata:
   name: drupal-files
+  labels:
+    {{- include "chart.labels" $ | nindent 4 }}
 spec:
   capacity: {{ .size | quote }}
   accessModes:
@@ -19,6 +21,8 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ tpl .claimName $ | quote }}
+  labels:
+    {{- include "chart.labels" $ | nindent 4 }}
 spec:
   accessModes:
     - {{ .accessMode | quote }}

--- a/src/magento1/helm/app/templates/application/magento-media-pvc.yaml
+++ b/src/magento1/helm/app/templates/application/magento-media-pvc.yaml
@@ -5,6 +5,8 @@
 kind: PersistentVolume
 metadata:
   name: magento-media
+  labels:
+    {{- include "chart.labels" $ | nindent 4 }}
 spec:
   capacity: {{ .size | quote }}
   accessModes:
@@ -19,6 +21,8 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ tpl .claimName $ | quote }}
+  labels:
+    {{- include "chart.labels" $ | nindent 4 }}
 spec:
   accessModes:
     - {{ .accessMode | quote }}

--- a/src/magento2/helm/app/templates/application/magento-export-pvc.yaml
+++ b/src/magento2/helm/app/templates/application/magento-export-pvc.yaml
@@ -5,6 +5,8 @@
 kind: PersistentVolume
 metadata:
   name: magento-export
+  labels:
+    {{- include "chart.labels" $ | nindent 4 }}
 spec:
   capacity: {{ .size | quote }}
   accessModes:
@@ -19,6 +21,8 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ tpl .claimName $ | quote }}
+  labels:
+    {{- include "chart.labels" $ | nindent 4 }}
 spec:
   accessModes:
     - {{ .accessMode | quote }}

--- a/src/magento2/helm/app/templates/application/magento-media-pvc.yaml
+++ b/src/magento2/helm/app/templates/application/magento-media-pvc.yaml
@@ -5,6 +5,8 @@
 kind: PersistentVolume
 metadata:
   name: magento-media
+  labels:
+    {{- include "chart.labels" $ | nindent 4 }}
 spec:
   capacity: {{ .size | quote }}
   accessModes:
@@ -19,6 +21,8 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ tpl .claimName $ | quote }}
+  labels:
+    {{- include "chart.labels" $ | nindent 4 }}
 spec:
   accessModes:
     - {{ .accessMode | quote }}

--- a/src/spryker/helm/app/templates/application/jenkins-runner/deployment.yaml
+++ b/src/spryker/helm/app/templates/application/jenkins-runner/deployment.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "chart.labels" $ | nindent 8 }}
+        {{- include "chart.selectors" $ | nindent 8 }}
         app.kubernetes.io/component: jenkins-runner
         app.service: {{ $.Values.resourcePrefix }}jenkins-runner
     spec:

--- a/src/spryker/helm/app/templates/application/jenkins-runner/deployment.yaml
+++ b/src/spryker/helm/app/templates/application/jenkins-runner/deployment.yaml
@@ -5,6 +5,8 @@ kind: Deployment
 metadata:
   name: {{ $.Values.resourcePrefix }}jenkins-runner
   labels:
+    {{- include "chart.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: jenkins-runner
     app.service: {{ $.Values.resourcePrefix }}jenkins-runner
   annotations:
     argocd.argoproj.io/sync-wave: "15"
@@ -17,6 +19,8 @@ spec:
   template:
     metadata:
       labels:
+        {{- include "chart.labels" $ | nindent 8 }}
+        app.kubernetes.io/component: jenkins-runner
         app.service: {{ $.Values.resourcePrefix }}jenkins-runner
     spec:
       containers:

--- a/src/spryker/helm/app/templates/application/jenkins-runner/secret.yaml
+++ b/src/spryker/helm/app/templates/application/jenkins-runner/secret.yaml
@@ -1,2 +1,2 @@
 {{- $service := mergeOverwrite (dict) (index .Values.docker.services "php-base") (index .Values.docker.services "jenkins-runner") -}}
-{{ template "service.environment.secret" (dict "service_name" "jenkins-runner" "service" $service "Values" .Values) }}
+{{ template "service.environment.secret" (dict "service_name" "jenkins-runner" "service" $service "root" $) }}

--- a/src/spryker/helm/app/templates/application/spryker-data-pvc.yaml
+++ b/src/spryker/helm/app/templates/application/spryker-data-pvc.yaml
@@ -5,6 +5,8 @@
 kind: PersistentVolume
 metadata:
   name: spryker-data
+  labels:
+    {{- include "chart.labels" $ | nindent 4 }}
 spec:
   capacity: {{ .size | quote }}
   accessModes:
@@ -19,6 +21,8 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ tpl .claimName $ | quote }}
+  labels:
+    {{- include "chart.labels" $ | nindent 4 }}
 spec:
   accessModes:
     - {{ .accessMode | quote }}

--- a/src/spryker/helm/app/templates/application/webapp/ingress-istio.yaml
+++ b/src/spryker/helm/app/templates/application/webapp/ingress-istio.yaml
@@ -4,8 +4,10 @@ kind: VirtualService
 metadata:
  name: {{ .Release.Namespace }}-{{ .Values.resourcePrefix }}webapp-virtualservice
  labels:
-   app: {{ .Values.resourcePrefix }}webapp
-   app.service: {{ .Values.resourcePrefix }}webapp
+    {{- include "chart.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: webapp
+    app: {{ .Values.resourcePrefix }}webapp
+    app.service: {{ .Values.resourcePrefix }}webapp
 spec:
  hosts:
 {{- range $key, $value := .Values.docker.services.nginx.environment }}

--- a/src/spryker/helm/app/templates/application/webapp/ingress.yaml
+++ b/src/spryker/helm/app/templates/application/webapp/ingress.yaml
@@ -10,6 +10,8 @@ metadata:
 {{- end }}
   creationTimestamp: null
   labels:
+    {{- include "chart.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: webapp
     app.service: {{ .Values.resourcePrefix }}webapp
   name: {{ .Values.resourcePrefix }}webapp
 spec:

--- a/src/spryker/helm/app/templates/service/jenkins/deployment.yaml
+++ b/src/spryker/helm/app/templates/service/jenkins/deployment.yaml
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "chart.labels" $ | nindent 8 }}
+        {{- include "chart.selectors" $ | nindent 8 }}
         app.kubernetes.io/component: jenkins
         app.service: {{ $.Values.resourcePrefix }}jenkins
     spec:

--- a/src/spryker/helm/app/templates/service/jenkins/deployment.yaml
+++ b/src/spryker/helm/app/templates/service/jenkins/deployment.yaml
@@ -7,6 +7,8 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "4"
   labels:
+    {{- include "chart.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: jenkins
     app.service: {{ $.Values.resourcePrefix }}jenkins
 spec:
   replicas: 1
@@ -20,6 +22,8 @@ spec:
   template:
     metadata:
       labels:
+        {{- include "chart.labels" $ | nindent 8 }}
+        app.kubernetes.io/component: jenkins
         app.service: {{ $.Values.resourcePrefix }}jenkins
     spec:
       securityContext:

--- a/src/spryker/helm/app/templates/service/jenkins/service.yaml
+++ b/src/spryker/helm/app/templates/service/jenkins/service.yaml
@@ -4,6 +4,8 @@ kind: Service
 metadata:
   name: {{ .Values.resourcePrefix }}jenkins
   labels:
+    {{- include "chart.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: jenkins
     app.service: {{ .Values.resourcePrefix }}jenkins
 spec:
   ports:

--- a/src/spryker/helm/app/values.yaml.twig
+++ b/src/spryker/helm/app/values.yaml.twig
@@ -1,5 +1,7 @@
 {% set blocks  = 'helm/app/_twig/values.yaml/' %}
 
+appVersion: {{ @('app.version') | json_encode | raw }}
+
 console:
   enabled: true
 


### PR DESCRIPTION
These can't be used for selectors yet though as:
a) deployment selectors are immutable, so would require deployments to be deleted
b) service selectors would get updated before there are pods with the labels in, causing partial downtime during a deployment