### PR TITLE
Trust workspace or pipeline host for drupal

### DIFF
--- a/src/drupal8/application/overlay/docroot/sites/default/settings.local.php.twig
+++ b/src/drupal8/application/overlay/docroot/sites/default/settings.local.php.twig
@@ -17,6 +17,8 @@ $databases['default']['default'] = array (
   'driver'    => 'mysql',
 );
 
+$settings['trusted_host_patterns'][] = '^' . preg_quote(getenv('APP_HOST')) . '$';
+
 {% if @('app.build') == 'static' %}
 // TODO: come up with an approach which allows asset aggregation
 // to also work in static docker images where nginx and php-fpm


### PR DESCRIPTION
Using APP_HOST environment variable, configure drupal's trusted host settings.

Documentation: https://www.drupal.org/docs/installing-drupal/trusted-host-settings