### PR TITLE
Update external-images CI pull to skip pulling images locally existing

### DIFF
--- a/src/_base/harness/config/external-images.yml
+++ b/src/_base/harness/config/external-images.yml
@@ -43,4 +43,4 @@ command('external-images pull'): |
     CONF_ARGS+=(--skip-exists)
   fi
 
-  passthru "ws external-images config $(printf '%q ' "${CONF_ARGS}") | docker-compose -f - pull"
+  passthru "ws external-images config $(printf '%q ' "${CONF_ARGS[@]}") | docker-compose -f - pull"

--- a/src/_base/harness/config/external-images.yml
+++ b/src/_base/harness/config/external-images.yml
@@ -19,20 +19,28 @@ function('external_images', [services]): |
   = join(' ', $externalImages);
 
 
-command('external-images config'):
+command('external-images config --skip-exists'):
   env:
     IMAGES: = external_images(docker_service_images())
+    SKIP_EXISTS: "= input.option('skip-exists') ? 1 : 0"
   exec: |
     #!php
+    $exclude = [];
+    if ($env['SKIP_EXISTS']) {
+      $exclude = explode("\n", shell_exec('docker images -a --format \'{{ print .Repository ":" .Tag }}\''));
+    }
+    $include = explode(' ', $env['IMAGES']);
     $compose = ['version' => '3', 'services' => []];
-    foreach (explode(' ', $env['IMAGES']) as $image) {
+    foreach (array_diff($include, $exclude) as $image) {
       $compose['services'][str_replace(['/', ':'], '_', $image)] = ['image' => $image];
     }
     echo \Symfony\Component\Yaml\Yaml::dump($compose, 100, 2);
 
-command('external-images pull'):
-  env:
-    BASE_IMAGES: = external_images(docker_service_images())
-  exec: |
-    #!bash(workspace:/)|@
-    passthru 'ws external-images config | docker-compose -f - pull'
+command('external-images pull'): |
+  #!bash(workspace:/)|@
+  CONF_ARGS=()
+  if [ -n "${CI:-}" ] || [ -n "${BUILD_ID:-}" ]; then
+    CONF_ARGS+=(--skip-exists)
+  fi
+
+  passthru "ws external-images config $(printf '%q ' "${CONF_ARGS}") | docker-compose -f - pull"

--- a/src/_base/harness/config/functions.yml
+++ b/src/_base/harness/config/functions.yml
@@ -123,10 +123,14 @@ function('docker_service_images'): |
   $images = [];
 
   foreach ($config['services'] as $serviceName => $service) {
-    $image = [
+    $imageSpec = [
       'image' => $service['image'] ?? null,
       'upstream' => [],
     ];
+
+    if ($imageSpec['image'] && strpos($imageSpec['image'], ':') === false) {
+      $imageSpec['image'] .= ':latest';
+    }
 
     if (isset($service['build'])) {
       $context = rtrim($service['build']['context'], '/');
@@ -135,9 +139,15 @@ function('docker_service_images'): |
       if (preg_match_all('/^FROM\s+([^\s]*)/m', file_get_contents($context.'/'.$dockerfile), $matches) === false) {
         continue;
       }
-      $image['upstream'] = $matches[1];
+
+      foreach ($matches[1] as $image) {
+        if (strpos($image, ':') === false) {
+          $image .= ':latest';
+        }
+        $imageSpec['upstream'][] = $image;
+      }
     }
-    $images[$serviceName] = $image;
+    $images[$serviceName] = $imageSpec;
   }
 
   = $images;


### PR DESCRIPTION
This assumes the CI environment is clear of local docker images each day to ensure at least daily updates

It reduces the number of pulls in order to reduce possibility of reaching docker hub rate limits