### PR TITLE
Fix akeneo build

### DIFF
--- a/src/akeneo/application/skeleton/composer.json.twig
+++ b/src/akeneo/application/skeleton/composer.json.twig
@@ -16,6 +16,7 @@
   },
   "autoload-dev": {
     "psr-4": {
+      "AkeneoTest\\": "vendor/akeneo/pim-community-dev/tests/back",
       "Inviqa\\Acceptance\\": "features/bootstrap"
     }
   },
@@ -30,6 +31,7 @@
     "dmore/behat-chrome-extension": "^1.3",
     "dmore/chrome-mink-driver": "^2.7",
     "doctrine/doctrine-migrations-bundle": "1.3.2",
+    "league/flysystem-aws-s3-v3": "^1.0",
     "rector/rector": "^0.7",
     "phpcompatibility/php-compatibility": "dev-master",
     "phpmd/phpmd": "^2.7",


### PR DESCRIPTION
The akeneo builds in 0.9.x, 0.10.x and 0.11.x are now failing due to this reference to an AkeneoTest class in the `test` environment via behat: https://github.com/akeneo/pim-community-dev/compare/v4.0.72...v4.0.73#diff-b8edc4442a88aff1a33208738892777258baaa70e083b0f1147e2af00b919321R222