### PR TITLE
Fix external-images pull locally

### DIFF
--- a/src/_base/harness/config/external-images.yml
+++ b/src/_base/harness/config/external-images.yml
@@ -19,7 +19,7 @@ function('external_images', [services]): |
   = join(' ', $externalImages);
 
 
-command('external-images config --skip-exists'):
+command('external-images config [--skip-exists]'):
   env:
     IMAGES: = external_images(docker_service_images())
     SKIP_EXISTS: "= input.option('skip-exists') ? 1 : 0"


### PR DESCRIPTION
Fixes:
```
[/Users/kevans/Repositories/ws/harness-base-php/tests/magento2-test]:
■ > ws networks external
■ > docker-compose down
Removing network magento2-test_private
WARNING: Network magento2-test_private not found.
Network my127ws is external, skipping
[/Users/kevans/Repositories/ws/harness-base-php/tests/magento2-test]:
■ > ws external-images config ''  | docker-compose -f - pull
Traceback (most recent call last):
  File "docker-compose", line 3, in <module>
  File "compose/cli/main.py", line 67, in main
  File "compose/cli/main.py", line 123, in perform_command
  File "compose/cli/command.py", line 69, in project_from_options
  File "compose/cli/command.py", line 123, in get_project
  File "compose/config/config.py", line 299, in find
  File "site-packages/yaml/__init__.py", line 162, in safe_load
  File "site-packages/yaml/__init__.py", line 112, in load
  File "site-packages/yaml/loader.py", line 34, in __init__
  File "site-packages/yaml/reader.py", line 85, in __init__
  File "site-packages/yaml/reader.py", line 135, in determine_encoding
  File "site-packages/yaml/reader.py", line 169, in update
  File "site-packages/yaml/reader.py", line 144, in check_printable
yaml.reader.ReaderError: unacceptable character #x001b: special characters are not allowed
  in "<stdin>", position 1
[45128] Failed to execute script docker-compose
```

Where it failed due to `ws external-images config` not existing:
```
$ ws external-images config ''

ws external-images config

Sub Commands:
   --skip-exists

Global Options:
  -h, --help    Show help message
```