### PR TITLE
Raise opcache settings for Magento 1, Magento 2 and Spryker

### DIFF
--- a/src/magento1/harness.yml
+++ b/src/magento1/harness.yml
@@ -49,6 +49,9 @@ attributes:
           if [ -f /app/public/app/etc/local.xml.harness.template ]; then
             envsubst < /app/public/app/etc/local.xml.harness.template > /app/public/app/etc/local.xml
           fi
+    ini:
+      opcache.max_accelerated_files: 32531
+      opcache.memory_consumption: 320
   magento:
     edition: enterprise
     version: 1.14.4.5

--- a/src/magento2/harness.yml
+++ b/src/magento2/harness.yml
@@ -39,6 +39,10 @@ attributes:
     fpm:
       ini:
         max_execution_time: 18000
+    ini:
+      opcache.interned_strings_buffer: 64
+      opcache.max_accelerated_files: 65407
+      opcache.memory_consumption: 512
   composer:
     auth:
       basic:

--- a/src/spryker/harness.yml
+++ b/src/spryker/harness.yml
@@ -37,6 +37,7 @@ attributes:
     version: 7.4
     ini:
       opcache.max_accelerated_files: 65407
+      opcache.memory_consumption: 512
   database:
     platform: postgres
     host: postgres


### PR DESCRIPTION
Fixes #15 

Configures Magento 1, Magento 2 and Spryker with additional opcache settings to accommodate their larger amount of files.