### PR TITLE
Use authoritative classmap for composer

### DIFF
--- a/src/_base/docker/image/console/root/lib/task/composer/install.sh.twig
+++ b/src/_base/docker/image/console/root/lib/task/composer/install.sh.twig
@@ -3,11 +3,13 @@
 function task_composer_install()
 {
     {% if @('app.mode') == 'development' and @('app.build') == 'static' %}
-        passthru composer install --no-interaction --optimize-autoloader --classmap-authoritative
+        passthru composer install --no-interaction --optimize-autoloader
+        passthru composer dump-autoload --optimize --classmap-authoritative
     {% elseif @('app.mode') == 'development' %}
         passthru composer install --no-interaction
     {% else %}
-        passthru composer install --no-interaction --no-dev --optimize-autoloader --classmap-authoritative
+        passthru composer install --no-interaction --no-dev --optimize-autoloader
+        passthru composer dump-autoload --optimize --classmap-authoritative
     {% endif %}
 
     {% if @('app.build') == 'static' %}

--- a/src/_base/docker/image/console/root/lib/task/composer/install.sh.twig
+++ b/src/_base/docker/image/console/root/lib/task/composer/install.sh.twig
@@ -3,14 +3,14 @@
 function task_composer_install()
 {
     {% if @('app.mode') == 'development' and @('app.build') == 'static' %}
-        passthru composer install --no-interaction --optimize-autoloader
+        passthru composer install --no-interaction --optimize-autoloader --classmap-authoritative
     {% elseif @('app.mode') == 'development' %}
         passthru composer install --no-interaction
     {% else %}
-        passthru composer install --no-interaction --no-dev --optimize-autoloader
+        passthru composer install --no-interaction --no-dev --optimize-autoloader --classmap-authoritative
     {% endif %}
 
     {% if @('app.build') == 'static' %}
-        run "composer clear-cache"
+        run composer clear-cache
     {% endif %}
 }

--- a/src/drupal8/application/skeleton/composer.json.twig
+++ b/src/drupal8/application/skeleton/composer.json.twig
@@ -44,6 +44,7 @@
     "drupal/token": "1.5",
     "drupal/ultimate_cron": "2.x-dev",
     "drush/drush": "^8",
+    "fenetikm/autoload-drupal": "^0.2",
     "oomphinc/composer-installers-extender": "^1.1"
   },
   "require-dev": {
@@ -58,6 +59,14 @@
     "phpcompatibility/php-compatibility": "dev-master",
     "phpstan/phpstan": "^0.12",
     "phpstan/phpstan-deprecation-rules": "^0.12"
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Drupal\\KernelTests\\": "docroot/core/tests/Drupal/KernelTests",
+      "Drupal\\Tests\\": "docroot/core/tests/Drupal/Tests",
+      "Drupal\\TestTools\\": "docroot/core/tests/Drupal/TestTools",
+      "Drupal\\views\\": "docroot/core/modules/views/src/"
+    }
   },
   "scripts": {
     "test": [
@@ -83,6 +92,13 @@
     "compatibility": "bin/phpcs -s --standard=vendor/phpcompatibility/php-compatibility/PHPCompatibility/ --runtime-set testVersion 7.4-"
   },
   "extra": {
+    "autoload-drupal": {
+      "modules": [
+        "docroot/core/modules/",
+        "docroot/modules/contrib/",
+        "docroot/modules/custom/"
+      ]
+    },
     "drupal-scaffold": {
       "locations": {
         "web-root": "docroot"

--- a/src/magento2/application/skeleton/composer.json.twig
+++ b/src/magento2/application/skeleton/composer.json.twig
@@ -42,6 +42,11 @@
             "Zend\\Mvc\\Controller\\": "setup/src/Zend/Mvc/Controller/",
             "": "src/"
         },
+        "psr-0": {
+            "": [
+                "generated/code/"
+            ]
+        },
         "files": [
             "app/etc/InviqaNonComposerComponentRegistration.php"
         ],

--- a/src/magento2/docker/image/console/root/lib/task/composer/development_dependencies.sh
+++ b/src/magento2/docker/image/console/root/lib/task/composer/development_dependencies.sh
@@ -2,7 +2,7 @@
 
 function task_composer_development_dependencies()
 {
-    passthru composer install --no-interaction --optimize-autoloader --classmap-authoritative
+    passthru composer install --no-interaction --optimize-autoloader
     passthru magento setup:upgrade --keep-generated
     passthru magento setup:di:compile
     passthru composer dump-autoload --optimize --classmap-authoritative

--- a/src/magento2/docker/image/console/root/lib/task/composer/development_dependencies.sh
+++ b/src/magento2/docker/image/console/root/lib/task/composer/development_dependencies.sh
@@ -2,8 +2,8 @@
 
 function task_composer_development_dependencies()
 {
-    passthru composer install --no-interaction --optimize-autoloader
-    passthru magento setup:upgrade
+    passthru composer install --no-interaction
+    passthru magento setup:upgrade --keep-generated
     passthru magento setup:di:compile
     passthru composer dump-autoload --optimize --classmap-authoritative
 }

--- a/src/magento2/docker/image/console/root/lib/task/composer/development_dependencies.sh
+++ b/src/magento2/docker/image/console/root/lib/task/composer/development_dependencies.sh
@@ -3,7 +3,7 @@
 function task_composer_development_dependencies()
 {
     passthru composer install --no-interaction --optimize-autoloader
-    passthru magento setup:upgrade --keep-generated
+    passthru magento setup:upgrade
     passthru magento setup:di:compile
     passthru composer dump-autoload --optimize --classmap-authoritative
 }

--- a/src/magento2/docker/image/console/root/lib/task/composer/development_dependencies.sh
+++ b/src/magento2/docker/image/console/root/lib/task/composer/development_dependencies.sh
@@ -2,8 +2,8 @@
 
 function task_composer_development_dependencies()
 {
-    passthru composer install --no-interaction --optimize-autoloader
+    passthru composer install --no-interaction --optimize-autoloader --classmap-authoritative
     passthru magento setup:upgrade --keep-generated
     passthru magento setup:di:compile
-    passthru composer dump-autoload --optimize
+    passthru composer dump-autoload --optimize --classmap-authoritative
 }

--- a/src/magento2/harness.yml
+++ b/src/magento2/harness.yml
@@ -76,7 +76,7 @@ attributes:
           if [ "$APP_BUILD" == "static" ] ; then
             run mv app/etc/env.php app/etc/env-backup.php
             passthru bin/magento setup:di:compile
-            run composer dump-autoload --optimize
+            run composer dump-autoload --optimize --classmap-authoritative
             run mv app/etc/env-backup.php app/etc/env.php
           fi
         - |

--- a/src/magento2/harness.yml
+++ b/src/magento2/harness.yml
@@ -75,6 +75,7 @@ attributes:
         - |
           if [ "$APP_BUILD" == "static" ] ; then
             run mv app/etc/env.php app/etc/env-backup.php
+            run composer dump-autoload --optimize
             passthru bin/magento setup:di:compile
             run composer dump-autoload --optimize --classmap-authoritative
             run mv app/etc/env-backup.php app/etc/env.php

--- a/src/spryker/docker/image/console/root/lib/task/composer/development_dependencies.sh
+++ b/src/spryker/docker/image/console/root/lib/task/composer/development_dependencies.sh
@@ -2,7 +2,7 @@
 
 function task_composer_development_dependencies()
 {
-    passthru composer install --no-interaction --optimize-autoloader
+    passthru composer install --no-interaction --optimize-autoloader --classmap-authoritative
     passthru composer generate
-    run composer dump-autoload --optimize
+    run composer dump-autoload --optimize --classmap-authoritative
 }

--- a/src/spryker/docker/image/console/root/lib/task/composer/development_dependencies.sh
+++ b/src/spryker/docker/image/console/root/lib/task/composer/development_dependencies.sh
@@ -2,7 +2,7 @@
 
 function task_composer_development_dependencies()
 {
-    passthru composer install --no-interaction --optimize-autoloader --classmap-authoritative
+    passthru composer install --no-interaction --optimize-autoloader
     passthru composer generate
     run composer dump-autoload --optimize --classmap-authoritative
 }


### PR DESCRIPTION
Makes it so if a class isn't listed in `vendor/composer/autoload_classmap.php`, the include paths configured are not scanned.

Avoids a lot of stat() calls.

* Imports https://github.com/magento/magento2/commit/6ba6abd9a3f6637191a38fd648ced20987254680 for magento2, which has been present since Magento 2.3.0, but we are missing!
* Drupal needs an extension to ensure all module classes are in the autoloader