### PR TITLE
Configure file based opcache for cli

### DIFF
--- a/src/_base/docker/image/console/Dockerfile.twig
+++ b/src/_base/docker/image/console/Dockerfile.twig
@@ -12,7 +12,9 @@ RUN chown -R build:build /home/build \
  && curl --fail --silent --location --output /sbin/tini https://github.com/krallin/tini/releases/download/v0.19.0/tini \
  && chmod +x /sbin/tini \
  && curl --fail --silent --location --output /usr/local/bin/mhsendmail https://github.com/mailhog/mhsendmail/releases/download/v0.2.0/mhsendmail_linux_amd64 \
- && chmod +x /usr/local/bin/mhsendmail
+ && chmod +x /usr/local/bin/mhsendmail \
+ && mkdir -p /tmp/php-file-cache \
+ && chown -R build:build /tmp/php-file-cache
 {%- set install_extensions=@('php.install_extensions')|merge(@('php.cli.install_extensions'))|filter(v => v is not empty) %}
 {%- if install_extensions %} \
  && cd /root/installer \

--- a/src/_base/docker/image/console/root/lib/task/composer/autoload.sh
+++ b/src/_base/docker/image/console/root/lib/task/composer/autoload.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+function task_composer_autoload()
+{
+    passthru composer dump-autoload --optimize --classmap-authoritative
+    run rm -rf /tmp/php-file-cache/*/app/vendor/composer || true
+}

--- a/src/_base/docker/image/console/root/lib/task/composer/autoload.sh
+++ b/src/_base/docker/image/console/root/lib/task/composer/autoload.sh
@@ -2,5 +2,5 @@
 function task_composer_autoload()
 {
     passthru composer dump-autoload --optimize --classmap-authoritative
-    run rm -rf /tmp/php-file-cache/*/app/vendor/composer || true
+    run rm -rf /tmp/php-file-cache/*/app/vendor/composer /tmp/php-file-cache/*/app/vendor/autoload.php* || true
 }

--- a/src/_base/docker/image/console/root/lib/task/composer/autoload.sh
+++ b/src/_base/docker/image/console/root/lib/task/composer/autoload.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 function task_composer_autoload()
 {
     passthru composer dump-autoload --optimize --classmap-authoritative

--- a/src/_base/docker/image/console/root/lib/task/composer/development_dependencies.sh
+++ b/src/_base/docker/image/console/root/lib/task/composer/development_dependencies.sh
@@ -2,5 +2,6 @@
 
 function task_composer_development_dependencies()
 {
-    passthru composer install --no-interaction --optimize-autoloader
+    passthru php -d opcache.file_cache_only=0 /usr/bin/composer install --no-interaction --optimize-autoloader
+    task composer:autoload
 }

--- a/src/_base/docker/image/console/root/lib/task/composer/install.sh.twig
+++ b/src/_base/docker/image/console/root/lib/task/composer/install.sh.twig
@@ -2,14 +2,11 @@
 
 function task_composer_install()
 {
-    {% if @('app.mode') == 'development' and @('app.build') == 'static' %}
-        passthru composer install --no-interaction --optimize-autoloader
-        passthru composer dump-autoload --optimize --classmap-authoritative
-    {% elseif @('app.mode') == 'development' %}
+    {% if @('app.mode') == 'development' and @('app.build') != 'static' %}
         passthru composer install --no-interaction
     {% else %}
-        passthru composer install --no-interaction --no-dev --optimize-autoloader
-        passthru composer dump-autoload --optimize --classmap-authoritative
+        passthru php -d opcache.file_cache_only=0 /usr/bin/composer install --no-interaction{% if @('app.mode') != 'development' %} --no-dev{% endif %} --optimize-autoloader
+        task composer:autoload
     {% endif %}
 
     {% if @('app.build') == 'static' %}

--- a/src/_base/docker/image/cron/Dockerfile.twig
+++ b/src/_base/docker/image/cron/Dockerfile.twig
@@ -16,7 +16,7 @@ RUN apt-get update -qq \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* \
  && mkdir -p /tmp/php-file-cache \
- && chown -R build:build /tmp/php-file-cache
+ && chown -R www-data:www-data /tmp/php-file-cache
 
 WORKDIR /app
 COPY .my127ws/docker/image/cron/root /

--- a/src/_base/docker/image/cron/Dockerfile.twig
+++ b/src/_base/docker/image/cron/Dockerfile.twig
@@ -14,7 +14,9 @@ RUN apt-get update -qq \
  # clean \
  && apt-get auto-remove -qq -y \
  && apt-get clean \
- && rm -rf /var/lib/apt/lists/*
+ && rm -rf /var/lib/apt/lists/* \
+ && mkdir -p /tmp/php-file-cache \
+ && chown -R build:build /tmp/php-file-cache
 
 WORKDIR /app
 COPY .my127ws/docker/image/cron/root /

--- a/src/_base/docker/image/cron/root/usr/local/etc/php/php.ini.twig
+++ b/src/_base/docker/image/cron/root/usr/local/etc/php/php.ini.twig
@@ -1,0 +1,10 @@
+{% for name, value in @('php.ini') %}
+{{ name }} = {{ value }}
+{% endfor %}
+{% for name, value in @('php.cron.ini') %}
+{{ name }} = {{ value }}
+{% endfor %}
+
+; UTC for consistent logging that doesn't vary for Daylight Savings
+; If you need to change it, configure your application to display dates offset from UTC.
+date.timezone = UTC

--- a/src/_base/harness/attributes/common.yml
+++ b/src/_base/harness/attributes/common.yml
@@ -1,7 +1,4 @@
-
-
 attributes.default:
-
   app:
     # build - static|dynamic
     #   dynamic - volumes are mounted and the build step is run once the containers have started
@@ -185,6 +182,9 @@ attributes.default:
       ini:
         max_execution_time: 0
         memory_limit: -1
+        opcache.file_cache: "= (@('app.build') == 'static' ? '/tmp/php-file-cache' : '')"
+        opcache.file_cache_only: "= (@('app.build') == 'static' ? '1' : '0')"
+        opcache.file_cache_consistency_checks: "= (@('app.build') == 'static' ? '1' : '0')"
       install_extensions: []
     cron:
       ini: = @('php.cli.ini')

--- a/src/_base/harness/attributes/common.yml
+++ b/src/_base/harness/attributes/common.yml
@@ -186,6 +186,8 @@ attributes.default:
         max_execution_time: 0
         memory_limit: -1
       install_extensions: []
+    cron:
+      ini: = @('php.cli.ini')
     entrypoint:
       steps: []
     fpm:

--- a/src/_base/harness/config/confd.yml
+++ b/src/_base/harness/config/confd.yml
@@ -39,6 +39,7 @@ confd('harness:/'):
   - { src: docker/image/cron/Dockerfile }
   - { src: docker/image/cron/root/crontab }
   - { src: docker/image/cron/root/entrypoint.sh }
+  - { src: docker/image/cron/root/usr/local/etc/php/php.ini }
   - { src: application/overlay/Jenkinsfile }
   - { src: application/overlay/auth.json }
   - { src: application/overlay/.dockerignore, dst: workspace:/.dockerignore }

--- a/src/akeneo/docker/image/console/Dockerfile.twig
+++ b/src/akeneo/docker/image/console/Dockerfile.twig
@@ -12,7 +12,9 @@ RUN chown -R build:build /home/build \
  && curl --fail --silent --location --output /sbin/tini https://github.com/krallin/tini/releases/download/v0.19.0/tini \
  && chmod +x /sbin/tini \
  && curl --fail --silent --location --output /usr/local/bin/mhsendmail https://github.com/mailhog/mhsendmail/releases/download/v0.2.0/mhsendmail_linux_amd64 \
- && chmod +x /usr/local/bin/mhsendmail
+ && chmod +x /usr/local/bin/mhsendmail \
+ && mkdir -p /tmp/php-file-cache \
+ && chown -R build:build /tmp/php-file-cache
 {%- set install_extensions=@('php.install_extensions')|merge(@('php.cli.install_extensions'))|filter(v => v is not empty) %}
 {%- if install_extensions %} \
  && cd /root/installer \

--- a/src/akeneo/docker/image/job-queue-consumer/Dockerfile.twig
+++ b/src/akeneo/docker/image/job-queue-consumer/Dockerfile.twig
@@ -7,6 +7,9 @@ FROM {{ @('workspace.name') ~ '-php-fpm:dev' }}
 WORKDIR /app
 COPY .my127ws/docker/image/job-queue-consumer/root /
 
+RUN mkdir -p /tmp/php-file-cache \
+ && chown -R build:build /tmp/php-file-cache
+
 {% if @('app.build') == 'static' %}
 RUN bash /fix_app_permissions.sh
 {% else %}

--- a/src/akeneo/docker/image/job-queue-consumer/Dockerfile.twig
+++ b/src/akeneo/docker/image/job-queue-consumer/Dockerfile.twig
@@ -8,7 +8,7 @@ WORKDIR /app
 COPY .my127ws/docker/image/job-queue-consumer/root /
 
 RUN mkdir -p /tmp/php-file-cache \
- && chown -R build:build /tmp/php-file-cache
+ && chown -R www-data:www-data /tmp/php-file-cache
 
 {% if @('app.build') == 'static' %}
 RUN bash /fix_app_permissions.sh

--- a/src/akeneo/docker/image/job-queue-consumer/root/usr/local/etc/php/php.ini.twig
+++ b/src/akeneo/docker/image/job-queue-consumer/root/usr/local/etc/php/php.ini.twig
@@ -1,0 +1,10 @@
+{% for name, value in @('php.ini') %}
+{{ name }} = {{ value }}
+{% endfor %}
+{% for name, value in @('php.job_queue_consumer.ini') %}
+{{ name }} = {{ value }}
+{% endfor %}
+
+; UTC for consistent logging that doesn't vary for Daylight Savings
+; If you need to change it, configure your application to display dates offset from UTC.
+date.timezone = UTC

--- a/src/akeneo/harness/attributes/docker.yml
+++ b/src/akeneo/harness/attributes/docker.yml
@@ -2,6 +2,9 @@ attributes:
   akeneo:
     app:
       mode: dev # dev or prod
+  php:
+    job_queue_consumer:
+      ini: = @('php.cli.ini')
   services:
     php-base:
       environment:

--- a/src/akeneo/harness/config/confd.yml
+++ b/src/akeneo/harness/config/confd.yml
@@ -39,6 +39,7 @@ confd('harness:/'):
   - { src: docker/image/cron/Dockerfile }
   - { src: docker/image/cron/root/crontab }
   - { src: docker/image/cron/root/entrypoint.sh }
+  - { src: docker/image/cron/root/usr/local/etc/php/php.ini }
   - { src: application/overlay/Jenkinsfile }
   - { src: application/overlay/auth.json }
   - { src: application/overlay/.dockerignore, dst: workspace:/.dockerignore }
@@ -64,3 +65,4 @@ confd('harness:/'):
   - { src: docker/image/console/root/home/build/.ssh/id_rsa.pub }
   - { src: docker/image/console/root/lib/task/composer/install.sh }
   - { src: docker/image/job-queue-consumer/Dockerfile }
+  - { src: docker/image/job-queue-consumer/root/usr/local/etc/php/php.ini }

--- a/src/drupal8/harness.yml
+++ b/src/drupal8/harness.yml
@@ -74,6 +74,10 @@ attributes:
     image:
       console: "= 'my127/drupal8:' ~ @('php.version') ~ '-fpm-' ~ (@('php.version') >= 7.4 ? 'buster' : 'stretch') ~ '-console'"
       php-fpm: "= 'my127/drupal8:' ~ @('php.version') ~ '-fpm-' ~ (@('php.version') >= 7.4 ? 'buster' : 'stretch')"
+  php:
+    cli:
+      ini:
+        opcache.file_cache_only: '0'
   persistence:
     enabled: false
     drupal:

--- a/src/drupal8/harness/config/confd.yml
+++ b/src/drupal8/harness/config/confd.yml
@@ -39,6 +39,7 @@ confd('harness:/'):
   - { src: docker/image/cron/Dockerfile }
   - { src: docker/image/cron/root/crontab }
   - { src: docker/image/cron/root/entrypoint.sh }
+  - { src: docker/image/cron/root/usr/local/etc/php/php.ini }
   - { src: application/overlay/Jenkinsfile }
   - { src: application/overlay/auth.json }
   - { src: application/overlay/.dockerignore, dst: workspace:/.dockerignore }

--- a/src/magento1/harness/config/confd.yml
+++ b/src/magento1/harness/config/confd.yml
@@ -39,6 +39,7 @@ confd('harness:/'):
   - { src: docker/image/cron/Dockerfile }
   - { src: docker/image/cron/root/crontab }
   - { src: docker/image/cron/root/entrypoint.sh }
+  - { src: docker/image/cron/root/usr/local/etc/php/php.ini }
   - { src: application/overlay/Jenkinsfile }
   - { src: application/overlay/auth.json }
   - { src: application/overlay/.dockerignore, dst: workspace:/.dockerignore }

--- a/src/magento2/docker/image/console/Dockerfile.twig
+++ b/src/magento2/docker/image/console/Dockerfile.twig
@@ -12,7 +12,9 @@ RUN chown -R build:build /home/build \
  && curl --fail --silent --location --output /sbin/tini https://github.com/krallin/tini/releases/download/v0.19.0/tini \
  && chmod +x /sbin/tini \
  && curl --fail --silent --location --output /usr/local/bin/mhsendmail https://github.com/mailhog/mhsendmail/releases/download/v0.2.0/mhsendmail_linux_amd64 \
- && chmod +x /usr/local/bin/mhsendmail
+ && chmod +x /usr/local/bin/mhsendmail \
+ && mkdir -p /tmp/php-file-cache \
+ && chown -R build:build /tmp/php-file-cache
 {%- set install_extensions=@('php.install_extensions')|merge(@('php.cli.install_extensions'))|filter(v => v is not empty) %}
 {%- if install_extensions %} \
  && cd /root/installer \

--- a/src/magento2/docker/image/console/root/lib/task/composer/autoload.sh
+++ b/src/magento2/docker/image/console/root/lib/task/composer/autoload.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+function task_composer_autoload()
+{
+    passthru composer dump-autoload --optimize --classmap-authoritative
+    run rm -rf /tmp/php-file-cache/*/app/app/etc/ /tmp/php-file-cache/*/app/vendor/composer /tmp/php-file-cache/*/app/vendor/autoload.php* || true
+}

--- a/src/magento2/docker/image/console/root/lib/task/composer/development_dependencies.sh
+++ b/src/magento2/docker/image/console/root/lib/task/composer/development_dependencies.sh
@@ -2,8 +2,9 @@
 
 function task_composer_development_dependencies()
 {
-    passthru composer install --no-interaction
+    passthru php -d opcache.file_cache_only=0 /usr/bin/composer install --no-interaction
+    run rm -rf /tmp/php-file-cache/*/app/vendor/composer || true
     passthru magento setup:upgrade --keep-generated
     passthru magento setup:di:compile
-    passthru composer dump-autoload --optimize --classmap-authoritative
+    task composer:autoload
 }

--- a/src/magento2/docker/image/console/root/lib/task/composer/development_dependencies.sh
+++ b/src/magento2/docker/image/console/root/lib/task/composer/development_dependencies.sh
@@ -3,7 +3,7 @@
 function task_composer_development_dependencies()
 {
     passthru php -d opcache.file_cache_only=0 /usr/bin/composer install --no-interaction
-    run rm -rf /tmp/php-file-cache/*/app/vendor/composer || true
+    run rm -rf /tmp/php-file-cache/*/app/vendor/composer /tmp/php-file-cache/*/app/vendor/autoload.php* || true
     passthru magento setup:upgrade --keep-generated
     passthru magento setup:di:compile
     task composer:autoload

--- a/src/magento2/docker/image/console/root/lib/task/magento/dump-config.sh
+++ b/src/magento2/docker/image/console/root/lib/task/magento/dump-config.sh
@@ -5,6 +5,7 @@ function task_magento_dump-config()
     run cp /app/app/etc/env.php /app/app/etc/env.php.bak
 
     run magento app:config:dump
+    run rm -rf /tmp/php-file-cache/*/app/app/etc/ || true
     run strip-magento-config
 
     run mv /app/app/etc/env.php.bak /app/app/etc/env.php

--- a/src/magento2/docker/image/console/root/lib/task/magento/static_content_deploy.sh.twig
+++ b/src/magento2/docker/image/console/root/lib/task/magento/static_content_deploy.sh.twig
@@ -7,10 +7,14 @@
 {%- endmacro %}
 function task_magento_static_content_deploy()
 {
+    run mv app/etc/env.php app/etc/env-backup.php
+    run rm -rf /tmp/php-file-cache/*/app/app/etc/ || true
 {% if @('magento.static_content.backend') == @('magento.static_content.frontend') %}
     passthru bin/magento setup:static-content:deploy --jobs 8 --symlink-locale --no-interaction --ansi{{  _self.themes(@('magento.static_content.backend.themes'))}}{{  _self.languages(@('magento.static_content.backend.languages')) }}
 {% else %}
     passthru bin/magento setup:static-content:deploy --jobs 8 --symlink-locale --no-interaction --ansi --area backend{{  _self.themes(@('magento.static_content.backend.themes'))}}{{  _self.languages(@('magento.static_content.backend.languages')) }}
     passthru bin/magento setup:static-content:deploy --jobs 8 --symlink-locale --no-interaction --ansi --area frontend{{  _self.themes(@('magento.static_content.frontend.themes'))}}{{  _self.languages(@('magento.static_content.frontend.languages')) }}
 {% endif %}
+    run mv app/etc/env-backup.php app/etc/env.php
+    run rm -rf /tmp/php-file-cache/*/app/app/etc/ || true
 }

--- a/src/magento2/harness.yml
+++ b/src/magento2/harness.yml
@@ -81,7 +81,7 @@ attributes:
             run mv app/etc/env.php app/etc/env-backup.php
             run composer dump-autoload --optimize
             passthru bin/magento setup:di:compile
-            run composer dump-autoload --optimize --classmap-authoritative
+            task composer:autoload
             run mv app/etc/env-backup.php app/etc/env.php
           fi
         - |

--- a/src/magento2/harness.yml
+++ b/src/magento2/harness.yml
@@ -81,14 +81,12 @@ attributes:
             run mv app/etc/env.php app/etc/env-backup.php
             run composer dump-autoload --optimize
             passthru bin/magento setup:di:compile
-            task composer:autoload
             run mv app/etc/env-backup.php app/etc/env.php
+            task composer:autoload
           fi
         - |
           if [ "$APP_BUILD" == "static" ] && validate-magento-config ; then
-            run mv app/etc/env.php app/etc/env-backup.php
             task magento:static_content_deploy
-            run mv app/etc/env-backup.php app/etc/env.php
           else
             echo -n "$(date +%s)" > pub/static/deployed_version.txt
           fi
@@ -99,6 +97,7 @@ attributes:
         # restore it after installation.
         - run rm -f /app/app/etc/env.php
         - run rm -f /app/app/etc/config.php
+        - run rm -rf /tmp/php-file-cache/*/app/app/etc/ || true
         - |
           if [[ "$HAS_ELASTICSEARCH" == "true" ]]; then
             task http:wait "${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}"
@@ -149,6 +148,7 @@ attributes:
         - run rm -f /app/app/etc/env.php
         - task overlay:apply
         - task magento:dump-config
+        - run rm -rf /tmp/php-file-cache/*/app/app/etc/ || true
         - task assets:dump
     init:
       steps:

--- a/src/magento2/harness/config/confd.yml
+++ b/src/magento2/harness/config/confd.yml
@@ -39,6 +39,7 @@ confd('harness:/'):
   - { src: docker/image/cron/Dockerfile }
   - { src: docker/image/cron/root/crontab }
   - { src: docker/image/cron/root/entrypoint.sh }
+  - { src: docker/image/cron/root/usr/local/etc/php/php.ini }
   - { src: application/overlay/Jenkinsfile }
   - { src: application/overlay/auth.json }
   - { src: application/overlay/.dockerignore, dst: workspace:/.dockerignore }

--- a/src/spryker/docker/image/console/root/lib/task/composer/development_dependencies.sh
+++ b/src/spryker/docker/image/console/root/lib/task/composer/development_dependencies.sh
@@ -3,7 +3,7 @@
 function task_composer_development_dependencies()
 {
     passthru php -d opcache.file_cache_only=0 /usr/bin/composer install --no-interaction --optimize-autoloader
-    run rm -rf /tmp/php-file-cache/*/app/vendor/composer || true
+    run rm -rf /tmp/php-file-cache/*/app/vendor/composer /tmp/php-file-cache/*/app/vendor/autoload.php* || true
     passthru composer generate
     task composer:autoload
 }

--- a/src/spryker/docker/image/console/root/lib/task/composer/development_dependencies.sh
+++ b/src/spryker/docker/image/console/root/lib/task/composer/development_dependencies.sh
@@ -2,7 +2,8 @@
 
 function task_composer_development_dependencies()
 {
-    passthru composer install --no-interaction --optimize-autoloader
+    passthru php -d opcache.file_cache_only=0 /usr/bin/composer install --no-interaction --optimize-autoloader
+    run rm -rf /tmp/php-file-cache/*/app/vendor/composer || true
     passthru composer generate
-    run composer dump-autoload --optimize --classmap-authoritative
+    task composer:autoload
 }

--- a/src/spryker/docker/image/console/root/lib/task/spryker/build.sh.twig
+++ b/src/spryker/docker/image/console/root/lib/task/spryker/build.sh.twig
@@ -9,7 +9,7 @@ function task_spryker_build()
     passthru vendor/bin/install -r docker -s cache
     {% if @('app.mode') == 'development' %}
         passthru composer dump-autoload
-        run rm -rf /tmp/php-file-cache/*/app/vendor/composer || true
+        run rm -rf /tmp/php-file-cache/*/app/vendor/composer /tmp/php-file-cache/*/app/vendor/autoload.php* || true
     {% else %}
         task composer:autoload
     {% endif %}

--- a/src/spryker/docker/image/console/root/lib/task/spryker/build.sh.twig
+++ b/src/spryker/docker/image/console/root/lib/task/spryker/build.sh.twig
@@ -4,11 +4,13 @@ function task_spryker_build()
 {
     task composer:install
     passthru composer dump-autoload --optimize
+    run rm -rf /tmp/php-file-cache/*/app/vendor/composer || true
     passthru vendor/bin/install -r docker -s generate
     passthru vendor/bin/install -r docker -s cache
     {% if @('app.mode') == 'development' %}
         passthru composer dump-autoload
+        run rm -rf /tmp/php-file-cache/*/app/vendor/composer || true
     {% else %}
-        passthru composer dump-autoload --optimize --classmap-authoritative
+        task composer:autoload
     {% endif %}
 }

--- a/src/spryker/docker/image/jenkins-runner/root/usr/local/etc/php/php.ini.twig
+++ b/src/spryker/docker/image/jenkins-runner/root/usr/local/etc/php/php.ini.twig
@@ -1,0 +1,10 @@
+{% for name, value in @('php.ini') %}
+{{ name }} = {{ value }}
+{% endfor %}
+{% for name, value in @('php.jenkins_runner.ini') %}
+{{ name }} = {{ value }}
+{% endfor %}
+
+; UTC for consistent logging that doesn't vary for Daylight Savings
+; If you need to change it, configure your application to display dates offset from UTC.
+date.timezone = UTC

--- a/src/spryker/harness/config/confd.yml
+++ b/src/spryker/harness/config/confd.yml
@@ -39,6 +39,7 @@ confd('harness:/'):
   - { src: docker/image/cron/Dockerfile }
   - { src: docker/image/cron/root/crontab }
   - { src: docker/image/cron/root/entrypoint.sh }
+  - { src: docker/image/cron/root/usr/local/etc/php/php.ini }
   - { src: application/overlay/Jenkinsfile }
   - { src: application/overlay/auth.json }
   - { src: application/overlay/.dockerignore, dst: workspace:/.dockerignore }
@@ -64,5 +65,6 @@ confd('harness:/'):
   - { src: docker/image/nginx/root/etc/nginx/conf.d/yves.conf.template }
   - { src: docker/image/nginx/root/etc/nginx/conf.d/zed.conf.template }
   - { src: docker/image/jenkins-runner/Dockerfile }
+  - { src: docker/image/jenkins-runner/root/usr/local/etc/php/php.ini }
   - { src: helm/preview/requirements.yaml }
   - { src: helm/preview/values.yaml }

--- a/src/symfony/docker/image/console/Dockerfile.twig
+++ b/src/symfony/docker/image/console/Dockerfile.twig
@@ -12,7 +12,9 @@ RUN chown -R build:build /home/build \
  && curl --fail --silent --location --output /sbin/tini https://github.com/krallin/tini/releases/download/v0.19.0/tini \
  && chmod +x /sbin/tini \
  && curl --fail --silent --location --output /usr/local/bin/mhsendmail https://github.com/mailhog/mhsendmail/releases/download/v0.2.0/mhsendmail_linux_amd64 \
- && chmod +x /usr/local/bin/mhsendmail
+ && chmod +x /usr/local/bin/mhsendmail \
+ && mkdir -p /tmp/php-file-cache \
+ && chown -R build:build /tmp/php-file-cache
 {%- set install_extensions=@('php.install_extensions')|merge(@('php.cli.install_extensions'))|filter(v => v is not empty) %}
 {%- if install_extensions %} \
  && cd /root/installer \

--- a/src/symfony/harness/config/confd.yml
+++ b/src/symfony/harness/config/confd.yml
@@ -39,6 +39,7 @@ confd('harness:/'):
   - { src: docker/image/cron/Dockerfile }
   - { src: docker/image/cron/root/crontab }
   - { src: docker/image/cron/root/entrypoint.sh }
+  - { src: docker/image/cron/root/usr/local/etc/php/php.ini }
   - { src: application/overlay/Jenkinsfile }
   - { src: application/overlay/auth.json }
   - { src: application/overlay/.dockerignore, dst: workspace:/.dockerignore }

--- a/src/wordpress/harness/config/confd.yml
+++ b/src/wordpress/harness/config/confd.yml
@@ -39,6 +39,7 @@ confd('harness:/'):
   - { src: docker/image/cron/Dockerfile }
   - { src: docker/image/cron/root/crontab }
   - { src: docker/image/cron/root/entrypoint.sh }
+  - { src: docker/image/cron/root/usr/local/etc/php/php.ini }
   - { src: application/overlay/Jenkinsfile }
   - { src: application/overlay/auth.json }
   - { src: application/overlay/.dockerignore, dst: workspace:/.dockerignore }


### PR DESCRIPTION
Fixes #495 

* Allow customising php.ini settings in cron, jenkins-runner and job-queue-consumer
* Set opcache.file_cache_only when in static mode for console, cron, jenkins-runner and job-queue-consumer. Static mode applies whilst in Jenkins and running on kubernetes
* Ship /tmp/php-file-cache as part of the console docker image. We might consider applying this to php-fpm too, falling back to the file cache if the in-memory cache is empty. This might open more cans of worms than we want to deal with however.
* Drupal CLI seems incompatible with file cache (segfaults!)
