### PR TITLE
Xdebug 3 opt-in & config support

### DIFF
--- a/src/_base/application/skeleton/README.md.twig
+++ b/src/_base/application/skeleton/README.md.twig
@@ -134,7 +134,7 @@ To enable, run `ws feature xdebug on`. To turn off again, `ws feature xdebug off
 
 To enable on CLI in `ws console`, run `ws feature xdebug cli on`. To turn off again, `ws feature xdebug cli off`.
 
-Xdebug is set up to listen to your computer's 9000 port once enabled, so all you would need to do in your IDE is:
+Xdebug is set up to listen to your computer's 9000 (or 9003 for Xdebug v3) port once enabled, so all you would need to do in your IDE is:
 1. Create a mapping from the project root to `/app` for name `workspace`, hostname `localhost` and port 80.
 2. Depending on the IDE, you may have to configure the settings for the IDE to have idekey being `workspace`.
    Some IDEs also need to restart after changing this. Not required for PhpStorm.
@@ -150,6 +150,32 @@ Xdebug is set up to listen to your computer's 9000 port once enabled, so all you
 If you have trouble with triggered requests not starting connections to your IDE, check that
 `sudo lsof -i :9000 | grep LISTEN` on your host shows process from your IDE.
 If it doesn't, stop the indicated process (e.g. `php-fpm`) and toggle the Xdebug listen button off and on again in PhpStorm.
+
+#### Xdebug 3
+
+To upgrade to Xdebug 3, add the following to your `workspace.override.yml`:
+
+```yml
+attribute('php.ext-xdebug.version'): 3
+```
+
+then run `ws feature xdebug version-sync` which will upgrade the Xdebug version to the latest stable version.
+
+Xdebug 3 listens on port 9003, so you may need to update your IDE settings to match. PHPStorm 2020.3 and later has support for
+listening to both port 9000 and 9003 simultaneously.
+
+If you encounter issues on Xdebug 3, remove the above entry and re-run `ws feature xdebug version-sync` to downgrade.
+
+#### Xdebug 3 Modes
+
+Xdebug 3 now has the ability to run in different modes, such as step debugging or profiling. The default for Workspace is `debug` to
+enable step debugging, but this can be changed (or multiple modes enabled) by adding the following to your `workspace.override.yml`:
+
+```yml
+attribute('php.ext-xdebug.config.v3.mode'): debug,profile
+```
+
+then enable Xdebug using either `ws feature xdebug on` or `ws feature xdebug cli on`.
 
 ### Performance on macOS
 

--- a/src/_base/docker/image/console/Dockerfile.twig
+++ b/src/_base/docker/image/console/Dockerfile.twig
@@ -61,6 +61,10 @@ VOLUME /home/build/application
 
 USER root
 
+{% if version_compare(@('php.ext-xdebug.version'), '3', '>=') and version_compare(@('php.version'), '7', '>=') and version_compare(@('php.version'), '8', '<') %}
+RUN pecl -q upgrade xdebug
+{% endif %}
+
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["sleep", "infinity"]

--- a/src/_base/docker/image/console/root/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini.twig
+++ b/src/_base/docker/image/console/root/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini.twig
@@ -2,7 +2,7 @@
 
 {% if xdebug.cli.enable == 'yes' %}
   zend_extension=xdebug.so
-  {% for key, value in xdebug.config -%}
+  {% for key, value in xdebug.config['v' ~ xdebug.version] -%}
     xdebug.{{ key }}={{ value }}
   {% endfor %}
 {% endif %}

--- a/src/_base/docker/image/php-fpm/Dockerfile.twig
+++ b/src/_base/docker/image/php-fpm/Dockerfile.twig
@@ -19,6 +19,10 @@ RUN curl --fail --silent --location --output /sbin/tini https://github.com/krall
     {{ install_extensions|join(" \\\n    ") }}
 {% endif %}
 
+{% if version_compare(@('php.ext-xdebug.version'), '3', '>=') and version_compare(@('php.version'), '7', '>=') and version_compare(@('php.version'), '8', '<') %}
+RUN pecl -q upgrade xdebug
+{% endif %}
+
 {% if @('app.build') == 'static' %}
 COPY --from=console --chown=root:root /app /app
 RUN bash /fix_app_permissions.sh

--- a/src/_base/docker/image/php-fpm/root/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini.twig
+++ b/src/_base/docker/image/php-fpm/root/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini.twig
@@ -2,7 +2,7 @@
 
 {% if xdebug.enable == 'yes' %}
   zend_extension=xdebug.so
-  {% for key, value in xdebug.config -%}
+  {% for key, value in xdebug.config['v' ~ xdebug.version] -%}
     xdebug.{{ key }}={{ value }}
   {% endfor %}
 {% endif %}

--- a/src/_base/harness/attributes/common.yml
+++ b/src/_base/harness/attributes/common.yml
@@ -231,15 +231,22 @@ attributes.default:
         sample_rate: 25
         service: web
     ext-xdebug:
+      version: 2
       enable: no
       cli:
         enable: no
       config:
-        remote_enable: 1
-        remote_autostart: 1
-        remote_port: 9000
-        remote_host: host.docker.internal
-        idekey: workspace
+        v2:
+          remote_enable: 1
+          remote_autostart: 1
+          remote_port: 9000
+          remote_host: host.docker.internal
+          idekey: workspace
+        v3:
+          mode: debug
+          start_with_request: yes
+          client_port: 9003
+          client_host: host.docker.internal
 
   assets:
     remote: ="s3://"~@("aws.bucket")~"/development"

--- a/src/_base/harness/attributes/common.yml
+++ b/src/_base/harness/attributes/common.yml
@@ -231,7 +231,7 @@ attributes.default:
         sample_rate: 25
         service: web
     ext-xdebug:
-      version: 2
+      version: "= (@('php.version') >= 8.0 ? '3' : '2')"
       enable: no
       cli:
         enable: no

--- a/src/_base/harness/attributes/common.yml
+++ b/src/_base/harness/attributes/common.yml
@@ -231,7 +231,7 @@ attributes.default:
         sample_rate: 25
         service: web
     ext-xdebug:
-      version: "= (@('php.version') >= 8.0 ? '3' : '2')"
+      version: "= (version_compare(@('php.version'), '8.0', '>=') ? '3' : '2')"
       enable: no
       cli:
         enable: no

--- a/src/_base/harness/config/commands.yml
+++ b/src/_base/harness/config/commands.yml
@@ -250,32 +250,6 @@ command('feature tideways cli configure <server_key>'):
     docker-compose exec -T -u build console tideways import "$TIDEWAYS_SERVERKEY"
     echo "Imported Tideways CLI key"
 
-command('feature xdebug (on|off)'):
-  env:
-    ATTR_KEY: 'php.ext-xdebug.enable'
-    ATTR_VAL: = input.command(3) == 'on' ? 'yes':'no'
-  exec: |
-    #!bash(workspace:/)|=
-    ws set $ATTR_KEY $ATTR_VAL
-    echo 'Updating templates in .my127ws/'
-    run ws install --step=prepare
-    echo 'Bringing up php-fpm with the new setting'
-    run ws service php-fpm restart
-    echo 'Done'
-
-command('feature xdebug cli (on|off)'):
-  env:
-    ATTR_KEY: 'php.ext-xdebug.cli.enable'
-    ATTR_VAL: = input.command(4) == 'on' ? 'yes':'no'
-  exec: |
-    #!bash(workspace:/)|=
-    ws set $ATTR_KEY $ATTR_VAL
-    echo 'Updating templates in .my127ws/'
-    run ws install --step=prepare
-    echo 'Bringing up console with the new setting'
-    run ws service php-fpm restart
-    echo 'Done'
-
 command('db import <database_file>'):
   env:
     COMPOSE_PROJECT_NAME: = @('namespace')

--- a/src/_base/harness/config/xdebug.yml
+++ b/src/_base/harness/config/xdebug.yml
@@ -1,12 +1,10 @@
 command('feature xdebug version-sync'):
   env:
     XDEBUG_VERSION: = @('php.ext-xdebug.version')
+    COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)
     source .my127ws/harness/scripts/xdebug_version_sync.sh
-    run ws install --step=prepare
-    run ws service php-fpm restart
-    echo 'Done'
 
 command('feature xdebug (on|off)'):
   env:
@@ -34,6 +32,11 @@ command('feature xdebug cli (on|off)'):
     run ws service php-fpm restart
     echo 'Done'
 
-after('harness.install'): |
-  #!bash
-  ws feature xdebug version-sync
+after('harness.install'):
+  env:
+    APP_BUILD: = @('app.build')
+  exec: |
+    #!bash(workspace:/)|@
+    if [[ "$APP_BUILD" != "static" ]]; then
+      ws feature xdebug version-sync
+    fi

--- a/src/_base/harness/config/xdebug.yml
+++ b/src/_base/harness/config/xdebug.yml
@@ -1,0 +1,39 @@
+command('feature xdebug version-sync'):
+  env:
+    XDEBUG_VERSION: = @('php.ext-xdebug.version')
+  exec: |
+    #!bash(workspace:/)
+    source .my127ws/harness/scripts/xdebug_version_sync.sh
+    run ws install --step=prepare
+    run ws service php-fpm restart
+    echo 'Done'
+
+command('feature xdebug (on|off)'):
+  env:
+    ATTR_KEY: 'php.ext-xdebug.enable'
+    ATTR_VAL: = input.command(3) == 'on' ? 'yes':'no'
+  exec: |
+    #!bash(workspace:/)|=
+    ws set $ATTR_KEY $ATTR_VAL
+    echo 'Updating templates in .my127ws/'
+    run ws install --step=prepare
+    echo 'Bringing up php-fpm with the new setting'
+    run ws service php-fpm restart
+    echo 'Done'
+
+command('feature xdebug cli (on|off)'):
+  env:
+    ATTR_KEY: 'php.ext-xdebug.cli.enable'
+    ATTR_VAL: = input.command(4) == 'on' ? 'yes':'no'
+  exec: |
+    #!bash(workspace:/)|=
+    ws set $ATTR_KEY $ATTR_VAL
+    echo 'Updating templates in .my127ws/'
+    run ws install --step=prepare
+    echo 'Bringing up console with the new setting'
+    run ws service php-fpm restart
+    echo 'Done'
+
+after('harness.install'): |
+  #!bash
+  ws feature xdebug version-sync

--- a/src/_base/harness/config/xdebug.yml
+++ b/src/_base/harness/config/xdebug.yml
@@ -31,12 +31,3 @@ command('feature xdebug cli (on|off)'):
     echo 'Bringing up console with the new setting'
     run ws service php-fpm restart
     echo 'Done'
-
-after('harness.install'):
-  env:
-    APP_BUILD: = @('app.build')
-  exec: |
-    #!bash(workspace:/)|@
-    if [[ "$APP_BUILD" != "static" ]]; then
-      ws feature xdebug version-sync
-    fi

--- a/src/_base/harness/scripts/xdebug_version_sync.sh
+++ b/src/_base/harness/scripts/xdebug_version_sync.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+xdebug_version_sync()
+{
+  INSTALLED_VERSION=$(docker-compose exec -T -u root "$1" pecl info xdebug 2>&1 | grep "Release Version" | awk '{print $3}')
+  INSTALLED_MAJOR_VERSION=$(echo "$INSTALLED_VERSION" | cut -d '.' -f1)
+
+  if [ "$INSTALLED_MAJOR_VERSION" == "$XDEBUG_VERSION" ]; then
+    echo "Xdebug in $1 is already on the desired major version $XDEBUG_VERSION (found installed version $INSTALLED_VERSION)"
+    return 0
+  fi
+
+  case $XDEBUG_VERSION in
+    "3")
+      INSTALL_CANDIDATE="xdebug"
+      ;;
+    "2")
+      INSTALL_CANDIDATE="xdebug-2.9.8"
+      ;;
+    *)
+      echo "Invalid Xdebug version provided - please check the 'php.ext-xdebug.version' attribute is '2' or  '3'."
+      exit 1
+  esac
+
+  run docker-compose exec -T -u root "$1" pecl uninstall xdebug
+  run docker-compose exec -T -u root "$1" pecl install "$INSTALL_CANDIDATE"
+}
+
+xdebug_version_sync 'console'
+xdebug_version_sync 'php-fpm'


### PR DESCRIPTION
I've been tinkering with some ideas for allowing configuration based switching between Xdebug v2 and v3 and thought I'd open a PR to get some comments.

This updates the `ext-xdebug` configuration to have a version switch, as well as new config keys for the required ini settings for Xdebug 3 as they have all changed.

There's a new command which will check the major version installed on both the `console` and `php-fpm` containers and switch to the desired version if needed, so you should be able to switch by adding:

```yml
attribute('php.ext-xdebug.version'): 3
```

to your `workspace.override.yml` file and then running:


```shell
ws feature xdebug version-sync
```

I've also added this command as an event after `harness.install` so that projects can have Xdebug 3 set as the default, in which case it would update after the initial install. There might be a tidier way of adding this to the `Dockerfile` instead, maybe a conditional such as `{% if @('php.ext-xdebug.version') == '3' %}`, assuming we're keeping the default pinned at 2.9.8 in the base image.

I've set the default `mode` as just `debug` to allow for step-debugging. There's also the option of doing `develop,debug` which adds nicer output to `var_dump` and better exception output, at the cost of some overhead  - about 25% performance hit to enable both when I tested it.

I figured however that in most cases the framework is handling exception printing, and if you've got the Xdebug extension enabled you might not be using `var_dump` anyway. This is configurable by changing the `php.ext-xdebug.config.v3.mode` too, for example `debug,profile`.

The `start_with_request` config setting is also `yes` in the config as we had `remote_autostart` enabled previously, so keeps the same behaviour.

I've tested this by spinning up new sites with the Symfony and Wordpress harnesses so far.

There are likely better ways to handle the above, but worst case the ini settings from this might come in handy :smile: 

~I see this is failing the tests against the static builds containers, I'll try and fix that.~