### PR TITLE
Consolidate docker images used

### DIFF
--- a/src/drupal8/harness.yml
+++ b/src/drupal8/harness.yml
@@ -70,10 +70,12 @@ attributes:
     cron:
       jobs:
         - = '*/5 * * * * /cron-run-with-env.sh /app/bin/drush --root="/app/' ~ @('drupal.docroot') ~ '" cron'
-  docker:
-    image:
-      console: "= 'my127/drupal8:' ~ @('php.version') ~ '-fpm-' ~ (@('php.version') >= 7.4 ? 'buster' : 'stretch') ~ '-console'"
-      php-fpm: "= 'my127/drupal8:' ~ @('php.version') ~ '-fpm-' ~ (@('php.version') >= 7.4 ? 'buster' : 'stretch')"
+  php:
+    install_extensions:
+      - "= @('services.blackfire.enabled') ? 'blackfire' : ''"
+      - "= @('services.tideways.enabled') ? 'tideways' : ''"
+      - memcached
+      - redis
   persistence:
     enabled: false
     drupal:

--- a/src/magento1/harness.yml
+++ b/src/magento1/harness.yml
@@ -52,6 +52,11 @@ attributes:
     ini:
       opcache.max_accelerated_files: 32531
       opcache.memory_consumption: 320
+    install_extensions:
+      - "= @('services.blackfire.enabled') ? 'blackfire' : ''"
+      - "= @('services.tideways.enabled') ? 'tideways' : ''"
+      - memcached
+      - redis
   magento:
     edition: enterprise
     version: 1.14.4.5
@@ -110,10 +115,6 @@ attributes:
         - run n98-magerun.phar sys:setup:incremental -n
         - run n98-magerun.phar index:reindex:all
         - run n98-magerun.phar cache:clean
-  docker:
-    image:
-      console: "= 'my127/magento1:' ~ @('php.version') ~ '-fpm-' ~ (@('php.version') >= 7.4 ? 'buster' : 'stretch') ~ '-console'"
-      php-fpm: "= 'my127/magento1:' ~ @('php.version') ~ '-fpm-' ~ (@('php.version') >= 7.4 ? 'buster' : 'stretch')"
   persistence:
     enabled: false
     magento:

--- a/src/magento2/harness.yml
+++ b/src/magento2/harness.yml
@@ -43,6 +43,11 @@ attributes:
       opcache.interned_strings_buffer: 64
       opcache.max_accelerated_files: 65407
       opcache.memory_consumption: 512
+    install_extensions:
+      - "= @('services.blackfire.enabled') ? 'blackfire' : ''"
+      - "= @('services.tideways.enabled') ? 'tideways' : ''"
+      - redis
+      - sockets
   composer:
     auth:
       basic:
@@ -177,10 +182,6 @@ attributes:
     cron:
       jobs:
         - "= (@('app.mode') == 'production' ? '* * * * * /cron-run-with-env.sh \"/app/bin/magento cron:run & wait\"' : '')"
-  docker:
-    image:
-      console: "= 'my127/magento2:' ~ @('php.version') ~ '-fpm-' ~ (@('php.version') >= 7.4 ? 'buster' : 'stretch') ~ '-console'"
-      php-fpm: "= 'my127/magento2:' ~ @('php.version') ~ '-fpm-' ~ (@('php.version') >= 7.4 ? 'buster' : 'stretch')"
   framework:
     readme_blocks:
       - xml_urn_generation

--- a/src/wordpress/harness.yml
+++ b/src/wordpress/harness.yml
@@ -58,10 +58,11 @@ attributes:
         - run bin/wp-cli.phar "--path=${WORDPRESS_INSTALL_DIRECTORY}" option update home "$(eval echo "${WORDPRESS_URL}")"
         - run "bin/wp-cli.phar '--path=${WORDPRESS_INSTALL_DIRECTORY}' user create admin admin@localhost.local --role=administrator --user_pass=admin123 || exit 0"
         - run bin/wp-cli.phar "--path=${WORDPRESS_INSTALL_DIRECTORY}" user update admin --role=administrator --user_pass=admin123 --skip-email
-  docker:
-    image:
-      console: "= 'my127/wordpress:' ~ @('php.version') ~ '-fpm-' ~ (@('php.version') >= 7.4 ? 'buster' : 'stretch') ~ '-console'"
-      php-fpm: "= 'my127/wordpress:' ~ @('php.version') ~ '-fpm-' ~ (@('php.version') >= 7.4 ? 'buster' : 'stretch')"
+  php:
+    install_extensions:
+      - "= @('services.blackfire.enabled') ? 'blackfire' : ''"
+      - "= @('services.tideways.enabled') ? 'tideways' : ''"
+      - mysqli
 ---
 import:
   - harness/config/*.yml


### PR DESCRIPTION
Fixes #502 and depends on https://github.com/my127/docker-php/pull/45

Use https://hub.docker.com/r/my127/php/ for drupal8, magento1, magento2 and wordpress.

Akeneo and Spryker have extra package dependencies that we should keep a separate build for.