### PR TITLE
Use PHP 8.0 for no-framework and symfony

### DIFF
--- a/src/_base/harness/attributes/common.yml
+++ b/src/_base/harness/attributes/common.yml
@@ -212,8 +212,8 @@ attributes.default:
       # Use PHP 8+ Just In Time (JIT) optimisations
       # 1255 means a tracing JIT optimiser that analyses code for hot paths on the fly for whole scripts.
       # One step up from the default of "tracing" which is 1254 which uses callgraph
-      opcache.jit: "= (@('php.version') >= 8.0 ? '1255' : ~)"
-      opcache.jit_buffer_size: "= (@('php.version') >= 8.0 ? '100M' : ~)"
+      opcache.jit: "= (@('php.version') >= 8.0 ? '1255' : null)"
+      opcache.jit_buffer_size: "= (@('php.version') >= 8.0 ? '100M' : null)"
       realpath_cache_ttl: 600
       sendmail_path: /usr/local/bin/send_mail
       short_open_tag: Off

--- a/src/_base/harness/attributes/common.yml
+++ b/src/_base/harness/attributes/common.yml
@@ -177,7 +177,7 @@ attributes.default:
     version: null
 
   php:
-    version: 7.4
+    version: 8.0
     cli:
       ini:
         max_execution_time: 0
@@ -209,6 +209,11 @@ attributes.default:
       enable_dl: Off
       error_reporting: "E_ALL"
       opcache.enable_cli: On
+      # Use PHP 8+ Just In Time (JIT) optimisations
+      # 1255 means a tracing JIT optimiser that analyses code for hot paths on the fly for whole scripts.
+      # One step up from the default of "tracing" which is 1254 which uses callgraph
+      opcache.jit: "= (@('php.version') >= 8.0 ? '1255' : ~)"
+      opcache.jit_buffer_size: "= (@('php.version') >= 8.0 ? '100M' : ~)"
       realpath_cache_ttl: 600
       sendmail_path: /usr/local/bin/send_mail
       short_open_tag: Off

--- a/src/_base/harness/attributes/common.yml
+++ b/src/_base/harness/attributes/common.yml
@@ -212,8 +212,8 @@ attributes.default:
       # Use PHP 8+ Just In Time (JIT) optimisations
       # 1255 means a tracing JIT optimiser that analyses code for hot paths on the fly for whole scripts.
       # One step up from the default of "tracing" which is 1254 which uses callgraph
-      opcache.jit: "= (@('php.version') >= 8.0 ? '1255' : null)"
-      opcache.jit_buffer_size: "= (@('php.version') >= 8.0 ? '100M' : null)"
+      opcache.jit: "= (version_compare(@('php.version'), '8.0', '>=') ? '1255' : null)"
+      opcache.jit_buffer_size: "= (version_compare(@('php.version'), '8.0', '>=') ? '100M' : null)"
       realpath_cache_ttl: 600
       sendmail_path: /usr/local/bin/send_mail
       short_open_tag: Off

--- a/src/_base/harness/attributes/common.yml
+++ b/src/_base/harness/attributes/common.yml
@@ -177,7 +177,7 @@ attributes.default:
     version: null
 
   php:
-    version: 8.0
+    version: "8.0"
     cli:
       ini:
         max_execution_time: 0

--- a/src/drupal8/harness.yml
+++ b/src/drupal8/harness.yml
@@ -79,6 +79,7 @@ attributes:
     cli:
       ini:
         opcache.file_cache_only: '0'
+    version: 7.4
   persistence:
     enabled: false
     drupal:

--- a/src/magento2/harness.yml
+++ b/src/magento2/harness.yml
@@ -50,6 +50,7 @@ attributes:
       - "= @('services.tideways.enabled') ? 'tideways' : ''"
       - redis
       - sockets
+    version: 7.4
   composer:
     auth:
       basic:

--- a/src/wordpress/harness.yml
+++ b/src/wordpress/harness.yml
@@ -63,6 +63,7 @@ attributes:
       - "= @('services.blackfire.enabled') ? 'blackfire' : ''"
       - "= @('services.tideways.enabled') ? 'tideways' : ''"
       - mysqli
+    version: 7.4
 ---
 import:
   - harness/config/*.yml


### PR DESCRIPTION
Fixes #496 and depends on https://github.com/my127/docker-php/pull/44

Use PHP 8 and configure JIT to use tracing with 100MB.