### PR TITLE
Fix setup:static-content:deploy before 2.4.1

### DIFF
--- a/src/magento2/docker/image/console/root/lib/task/magento/static_content_deploy.sh.twig
+++ b/src/magento2/docker/image/console/root/lib/task/magento/static_content_deploy.sh.twig
@@ -3,7 +3,7 @@
 {{ deploy_themes ? ' --theme ' ~ deploy_themes|join(' --theme ') : '' }}
 {%- endmacro %}
 {% macro languages(deploy_languages) -%}
-{{ deploy_languages ? ' --language ' ~ deploy_languages|join(' --language ') : '' }}
+{{ deploy_languages ? ' -- ' ~ deploy_languages|join(' ') : '' }}
 {%- endmacro %}
 function task_magento_static_content_deploy()
 {


### PR DESCRIPTION
The language option was broken until https://github.com/magento/magento2/pull/28922 landed in Magento 2.4.1