### PR TITLE
Override zed session cookie domain from zed.de.suite.local

### DIFF
--- a/src/spryker/application/skeleton/config/Shared/config_local.php
+++ b/src/spryker/application/skeleton/config/Shared/config_local.php
@@ -96,6 +96,7 @@ $config[ApplicationConstants::BASE_URL_SSL_STATIC_MEDIA] = $config[ApplicationCo
 
 // ---------- Session
 $config[SessionConstants::ZED_SESSION_COOKIE_NAME] = $config[ApplicationConstants::HOST_ZED];
+$config[SessionConstants::ZED_SESSION_COOKIE_DOMAIN] = $config[ApplicationConstants::HOST_ZED];
 
 // ---------- Database credentials
 $config[PropelConstants::ZED_DB_USERNAME] = getenv('DB_USER');


### PR DESCRIPTION
zed.de.suite.local seems to be the default though I can't see it mentioned in code anywhere.

To be able to log in to zed, the CSRF token needs to match a session value. The session cookie was trying to be set for zed.de.suite.local, so was not then forwarded in the POST request to Zed's login screen.