### PR TITLE
Enable Spryker Jenkins CSRF support

### DIFF
--- a/src/spryker/application/skeleton/config/Shared/config_local.php
+++ b/src/spryker/application/skeleton/config/Shared/config_local.php
@@ -184,6 +184,7 @@ if (getenv('HAS_JENKINS_RUNNER') === 'true') {
             SchedulerJenkinsConfig::SCHEDULER_JENKINS_BASE_URL => 'http://' . getenv('JENKINS_HOST') . ':' . getenv('JENKINS_PORT') . '/',
         ],
     ];
+    $config[SchedulerJenkinsConfig::SCHEDULER_JENKINS_CSRF_ENABLED] = true;
 }
 
 // ---------- Mail configuration


### PR DESCRIPTION
The Jenkins newer versions require CSRF if not using an api token