### PR TITLE
Use correct distribution for akeneo db fixtures.

### DIFF
--- a/src/akeneo/harness.yml
+++ b/src/akeneo/harness.yml
@@ -75,7 +75,7 @@ attributes:
     install:
       steps:
         - task http:wait "${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}"
-        - passthru bin/console pim:installer:db --catalog vendor/akeneo/pim-community-dev/src/Akeneo/Platform/Bundle/InstallerBundle/Resources/fixtures/minimal
+        - = 'passthru bin/console pim:installer:db --catalog vendor/akeneo/pim-' ~ @('akeneo.edition') ~ '-dev/src/Akeneo/Platform/Bundle/InstallerBundle/Resources/fixtures/minimal'
         - task overlay:apply
         - task assets:dump
     init:


### PR DESCRIPTION
Note requires akeneo.edition to be populated, which may not be in earlier projects