### PR TITLE
Use the runtime environment APPLICATION_ENV for spryker install

### DIFF
--- a/src/spryker/application/skeleton/config/install/docker.yml.twig
+++ b/src/spryker/application/skeleton/config/install/docker.yml.twig
@@ -2,9 +2,6 @@
 # We have removed US store from database related steps as original file expects a separate database for US store
 # which is not the case in this setup
 
-env:
-    APPLICATION_ENV: {{ @('spryker.mode') }}
-
 stores:
     - DE
     - AT

--- a/src/spryker/harness/attributes/docker.yml
+++ b/src/spryker/harness/attributes/docker.yml
@@ -16,6 +16,10 @@ attributes:
         SPRYKER_OAUTH_CLIENT_SECRET: = @('spryker.oauth_client_secret')
         # not required for development env, must be set for remote (recommended size: 80)
         SPRYKER_ZED_REQUEST_TOKEN: = @('spryker.zed_request_token')
+    console:
+      build:
+        environment:
+          APPLICATION_ENV: = @('spryker.mode')
     jenkins:
       enabled: "= 'jenkins' in @('app.services')"
       image: jenkins/jenkins:2.263.1-lts-alpine


### PR DESCRIPTION
If it was in installer configuration, it couldn't be overriden.

Build-time mode will use the same mode for installer as for application (local 'development', pipeline 'production')