### PR TITLE
Update magento2 NGINX config to 2.4.1

### DIFF
--- a/src/magento2/docker/image/nginx/root/etc/nginx/conf.d/default.conf.template.twig
+++ b/src/magento2/docker/image/nginx/root/etc/nginx/conf.d/default.conf.template.twig
@@ -185,7 +185,7 @@ server {
     location ~ ^/(index|get|static|errors/report|errors/404|errors/503|health_check)\.php$ {
         try_files $uri =404;
         fastcgi_pass    ${FPM_HOST}:9000;
-        fastcgi_buffers 1024 4k;
+        fastcgi_buffers 16 16k;
 
         fastcgi_param  PHP_FLAG  "session.auto_start=off \n suhosin.session.cryptua=off";
         fastcgi_param  PHP_VALUE "memory_limit=756M \n max_execution_time={{ @('php.fpm.ini.max_execution_time') }}";

--- a/src/magento2/harness.yml
+++ b/src/magento2/harness.yml
@@ -220,6 +220,8 @@ attributes:
     php_fpm:
       conf:
         fastcgi_buffer_size: 128k
+        # fastcgi_buffer_size (128k) + fastcgi_buffers's size (16k)
+        fastcgi_busy_buffers_size: 144k
 
 ---
 command('redis-flush'): |


### PR DESCRIPTION
Excluding `fastcgi_buffer_size 32k` as we already set to 128k in harness.yml

From https://github.com/magento/magento2/tree/2.4.1/nginx.conf.sample