### PR TITLE
Update ingress api version

### DIFF
--- a/src/_base/helm/app/templates/application/webapp/ingress.yaml
+++ b/src/_base/helm/app/templates/application/webapp/ingress.yaml
@@ -1,5 +1,5 @@
 {{ if and (index .Values.services .Values.ingress.target_service "enabled") (eq .Values.ingress.type "standard") }}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
 {{- if .Values.services.nginx.ingress.annotations }}

--- a/src/spryker/helm/app/templates/application/webapp/ingress.yaml
+++ b/src/spryker/helm/app/templates/application/webapp/ingress.yaml
@@ -1,5 +1,5 @@
 {{ if and (index .Values.services .Values.ingress.target_service "enabled") (eq .Values.ingress.type "standard") }}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
 {{- if .Values.services.nginx.ingress.annotations }}


### PR DESCRIPTION
https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/
describes how Kubernetes v1.22 will remove support for the old ingress
API. The new networking API is available from 1.14 onwards.

NGINX ingress controller has already moved to recommend `networking.k8s.io/v1beta1`
in v1.16+, or `networking.k8s.io/v1` for 1.19+
https://github.com/kubernetes/ingress-nginx/blob/master/Changelog.md#0400