### PR TITLE
Join lighthouse to the private network

### DIFF
--- a/src/_base/_twig/docker-compose.yml/service/lighthouse.yml.twig
+++ b/src/_base/_twig/docker-compose.yml/service/lighthouse.yml.twig
@@ -6,3 +6,5 @@
     volumes:
       - ./app:/app
 {% endif %}
+    networks:
+      - private


### PR DESCRIPTION
So that <projectName>.my127.site will point to the nginx container instead of the lighthouse container as localhost.