### PR TITLE
Move ingress annotations

### DIFF
--- a/src/_base/.ci/sample-dynamic/workspace.yml
+++ b/src/_base/.ci/sample-dynamic/workspace.yml
@@ -14,7 +14,7 @@ attribute('aws.secret_access_key'): null
 
 attribute('docker.port_forward.enabled'): false
 
-attribute('pipeline.base.services.nginx.ingress.annotations.example_nginx'): test
+attribute('pipeline.base.ingress.annotations.example_nginx'): test
 
 before('harness.install'): |
   #!bash(workspace:/)|@

--- a/src/_base/.ci/sample-dynamic/workspace.yml
+++ b/src/_base/.ci/sample-dynamic/workspace.yml
@@ -14,6 +14,8 @@ attribute('aws.secret_access_key'): null
 
 attribute('docker.port_forward.enabled'): false
 
+attribute('pipeline.base.services.nginx.ingress.annotations.example_nginx'): test
+
 before('harness.install'): |
   #!bash(workspace:/)|@
   if [ ! -d public/ ]; then

--- a/src/_base/.ci/sample-static/workspace.yml
+++ b/src/_base/.ci/sample-static/workspace.yml
@@ -19,8 +19,8 @@ attribute('database.platform_version'): 8.0
 attribute('php.cli.install_extensions'):
   - sockets
 
-attribute('pipeline.base.services.istio.enabled'): true
-attribute('pipeline.base.services.istio.ingress.annotations.example_istio'): test
+attribute('pipeline.base.istio.enabled'): true
+attribute('pipeline.base.istio.ingress.annotations.example_istio'): test
 
 before('harness.install'): |
   #!bash(workspace:/)|@

--- a/src/_base/.ci/sample-static/workspace.yml
+++ b/src/_base/.ci/sample-static/workspace.yml
@@ -19,6 +19,9 @@ attribute('database.platform_version'): 8.0
 attribute('php.cli.install_extensions'):
   - sockets
 
+attribute('pipeline.base.services.istio.enabled'): true
+attribute('pipeline.base.services.istio.ingress.annotations.example_istio'): test
+
 before('harness.install'): |
   #!bash(workspace:/)|@
   if [ ! -d public/ ]; then

--- a/src/_base/.ci/sample-static/workspace.yml
+++ b/src/_base/.ci/sample-static/workspace.yml
@@ -20,7 +20,7 @@ attribute('php.cli.install_extensions'):
   - sockets
 
 attribute('pipeline.base.istio.enabled'): true
-attribute('pipeline.base.istio.ingress.annotations.example_istio'): test
+attribute('pipeline.base.ingress.annotations.example_istio'): test
 
 before('harness.install'): |
   #!bash(workspace:/)|@

--- a/src/_base/harness/attributes/docker-base.yml
+++ b/src/_base/harness/attributes/docker-base.yml
@@ -221,7 +221,9 @@ attributes:
             TIDEWAYS_HOSTNAME: = @('pipeline.base.hostname')
       ingress:
         annotations: {}
-        type: standard # standard or istio
+        target_service: "= @('services.varnish.enabled') ? 'varnish' : 'webapp'"
+        # standard or istio
+        type: standard
       istio:
         gateways:
           - "istio-system/{{ .Release.Namespace }}-gateway"

--- a/src/_base/harness/attributes/docker-base.yml
+++ b/src/_base/harness/attributes/docker-base.yml
@@ -221,8 +221,8 @@ attributes:
             TIDEWAYS_HOSTNAME: = @('pipeline.base.hostname')
       ingress:
         annotations: {}
+        type: standard # standard or istio
       istio:
-        enabled: false
         gateways:
           - "istio-system/{{ .Release.Namespace }}-gateway"
         additionalGateways: []

--- a/src/_base/harness/attributes/docker-base.yml
+++ b/src/_base/harness/attributes/docker-base.yml
@@ -222,9 +222,12 @@ attributes:
           environment:
             TIDEWAYS_HOSTNAME: = @('pipeline.base.hostname')
       istio:
+        enabled: false
         gateways:
           - "istio-system/{{ .Release.Namespace }}-gateway"
         additionalGateways: []
+        ingress:
+          annotations: {}
     production:
       # assumption is that in a production style environment these would be
       # managed services outside of the applications control

--- a/src/_base/harness/attributes/docker-base.yml
+++ b/src/_base/harness/attributes/docker-base.yml
@@ -205,8 +205,6 @@ attributes:
         nginx:
           environment:
             FPM_HOST: localhost
-          ingress:
-            annotations: {}
           metricsEnabled: false
           metricsEndpoints:
             - port: http
@@ -221,13 +219,13 @@ attributes:
         tideways:
           environment:
             TIDEWAYS_HOSTNAME: = @('pipeline.base.hostname')
+      ingress:
+        annotations: {}
       istio:
         enabled: false
         gateways:
           - "istio-system/{{ .Release.Namespace }}-gateway"
         additionalGateways: []
-        ingress:
-          annotations: {}
     production:
       # assumption is that in a production style environment these would be
       # managed services outside of the applications control

--- a/src/_base/helm/app/templates/application/webapp/ingress-istio.yaml
+++ b/src/_base/helm/app/templates/application/webapp/ingress-istio.yaml
@@ -3,6 +3,12 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: {{ .Release.Namespace }}-{{ .Values.resourcePrefix }}webapp-virtualservice
+{{- if .Values.ingress.annotations }}
+  annotations:
+  {{- range $key, $value := .Values.ingress.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}
   labels:
     {{- include "chart.labels" $ | nindent 4 }}
     app.kubernetes.io/component: webapp

--- a/src/_base/helm/app/templates/application/webapp/ingress-istio.yaml
+++ b/src/_base/helm/app/templates/application/webapp/ingress-istio.yaml
@@ -3,11 +3,9 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: {{ .Release.Namespace }}-{{ .Values.resourcePrefix }}webapp-virtualservice
-{{- if .Values.ingress.annotations }}
+{{- with .Values.ingress.annotations }}
   annotations:
-  {{- range $key, $value := .Values.ingress.annotations }}
-    {{ $key }}: {{ $value | quote }}
-  {{- end }}
+    {{- . | toYaml | nindent 4 }}
 {{- end }}
   labels:
     {{- include "chart.labels" $ | nindent 4 }}

--- a/src/_base/helm/app/templates/application/webapp/ingress.yaml
+++ b/src/_base/helm/app/templates/application/webapp/ingress.yaml
@@ -3,9 +3,9 @@
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
-{{- if .ingress.annotations }}
+{{- if $.Values.ingress.annotations }}
   annotations:
-  {{- range $key, $value := .ingress.annotations }}
+  {{- range $key, $value := $.Values.ingress.annotations }}
     {{ $key }}: {{ $value | quote }}
   {{- end }}
 {{- end }}

--- a/src/_base/helm/app/templates/application/webapp/ingress.yaml
+++ b/src/_base/helm/app/templates/application/webapp/ingress.yaml
@@ -3,11 +3,9 @@
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
-{{- if $.Values.ingress.annotations }}
+{{- with $.Values.ingress.annotations }}
   annotations:
-  {{- range $key, $value := $.Values.ingress.annotations }}
-    {{ $key }}: {{ $value | quote }}
-  {{- end }}
+    {{- . | toYaml | nindent 4 }}
 {{- end }}
   creationTimestamp: null
   labels:

--- a/src/_base/helm/app/values.yaml.twig
+++ b/src/_base/helm/app/values.yaml.twig
@@ -3,8 +3,9 @@ appVersion: {{ @('app.version') | json_encode | raw }}
 feature: {{ to_nice_yaml(@('helm.feature'), 2, 2) | raw }}
 
 ingress:
+  annotations: {{ @('services.istio.enabled') ? @('services.istio.ingress.annotations') : @('services.nginx.ingress.annotations') }}
   target_service: {{ @('services.varnish.enabled') ? 'varnish' : 'webapp' }}
-  type: "standard" # standard or istio
+  type: {{ @('services.istio.enabled') ? 'istio' : 'standard' }}
 
 docker:
   image_pull_config: {{ @('docker.image_pull_config') | raw }}

--- a/src/_base/helm/app/values.yaml.twig
+++ b/src/_base/helm/app/values.yaml.twig
@@ -5,7 +5,7 @@ feature: {{ to_nice_yaml(@('helm.feature'), 2, 2) | raw }}
 ingress:
   annotations: {{ to_nice_yaml(@('pipeline.base.ingress.annotations'), 2, 4) | raw }}
   target_service: {{ @('services.varnish.enabled') ? 'varnish' : 'webapp' }}
-  type: {{ @('pipeline.base.istio.enabled') ? 'istio' : 'standard' }}
+  type: {{ @('pipeline.base.ingress.type') }}
 
 docker:
   image_pull_config: {{ @('docker.image_pull_config') | raw }}

--- a/src/_base/helm/app/values.yaml.twig
+++ b/src/_base/helm/app/values.yaml.twig
@@ -2,10 +2,7 @@ appVersion: {{ @('app.version') | json_encode | raw }}
 
 feature: {{ to_nice_yaml(@('helm.feature'), 2, 2) | raw }}
 
-ingress:
-  annotations: {{ to_nice_yaml(@('pipeline.base.ingress.annotations'), 2, 4) | raw }}
-  target_service: {{ @('services.varnish.enabled') ? 'varnish' : 'webapp' }}
-  type: {{ @('pipeline.base.ingress.type') }}
+ingress: {{ to_nice_yaml(@('pipeline.base.ingress'), 2, 2) | raw }}
 
 docker:
   image_pull_config: {{ @('docker.image_pull_config') | raw }}

--- a/src/_base/helm/app/values.yaml.twig
+++ b/src/_base/helm/app/values.yaml.twig
@@ -3,9 +3,7 @@ appVersion: {{ @('app.version') | json_encode | raw }}
 feature: {{ to_nice_yaml(@('helm.feature'), 2, 2) | raw }}
 
 ingress:
-  annotations: {{ to_nice_yaml(
-    (@('pipeline.base.istio.enabled') ? @('pipeline.base.istio.ingress.annotations') : @('pipeline.base.services.nginx.ingress.annotations')),
-    2, 4) | raw }}
+  annotations: {{ to_nice_yaml(@('pipeline.base.ingress.annotations'), 2, 4) | raw }}
   target_service: {{ @('services.varnish.enabled') ? 'varnish' : 'webapp' }}
   type: {{ @('pipeline.base.istio.enabled') ? 'istio' : 'standard' }}
 

--- a/src/_base/helm/app/values.yaml.twig
+++ b/src/_base/helm/app/values.yaml.twig
@@ -3,9 +3,11 @@ appVersion: {{ @('app.version') | json_encode | raw }}
 feature: {{ to_nice_yaml(@('helm.feature'), 2, 2) | raw }}
 
 ingress:
-  annotations: {{ @('services.istio.enabled') ? @('services.istio.ingress.annotations') : @('services.nginx.ingress.annotations') }}
+  annotations: {{ to_nice_yaml(
+    (@('pipeline.base.istio.enabled') ? @('pipeline.base.istio.ingress.annotations') : @('pipeline.base.services.nginx.ingress.annotations')),
+    2, 4) | raw }}
   target_service: {{ @('services.varnish.enabled') ? 'varnish' : 'webapp' }}
-  type: {{ @('services.istio.enabled') ? 'istio' : 'standard' }}
+  type: {{ @('pipeline.base.istio.enabled') ? 'istio' : 'standard' }}
 
 docker:
   image_pull_config: {{ @('docker.image_pull_config') | raw }}

--- a/src/spryker/helm/app/templates/application/webapp/ingress-istio.yaml
+++ b/src/spryker/helm/app/templates/application/webapp/ingress-istio.yaml
@@ -3,6 +3,12 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: {{ .Release.Namespace }}-{{ .Values.resourcePrefix }}webapp-virtualservice
+{{- if .Values.ingress.annotations }}
+  annotations:
+  {{- range $key, $value := .Values.ingress.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}
   labels:
     {{- include "chart.labels" $ | nindent 4 }}
     app.kubernetes.io/component: webapp

--- a/src/spryker/helm/app/templates/application/webapp/ingress-istio.yaml
+++ b/src/spryker/helm/app/templates/application/webapp/ingress-istio.yaml
@@ -3,11 +3,9 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: {{ .Release.Namespace }}-{{ .Values.resourcePrefix }}webapp-virtualservice
-{{- if .Values.ingress.annotations }}
+{{- with .Values.ingress.annotations }}
   annotations:
-  {{- range $key, $value := .Values.ingress.annotations }}
-    {{ $key }}: {{ $value | quote }}
-  {{- end }}
+    {{- . | toYaml | nindent 4 }}
 {{- end }}
   labels:
     {{- include "chart.labels" $ | nindent 4 }}

--- a/src/spryker/helm/app/templates/application/webapp/ingress.yaml
+++ b/src/spryker/helm/app/templates/application/webapp/ingress.yaml
@@ -3,9 +3,9 @@
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
-{{- if .ingress.annotations }}
+{{- if $.Values.ingress.annotations }}
   annotations:
-  {{- range $key, $value := .ingress.annotations }}
+  {{- range $key, $value := $.Values.ingress.annotations }}
     {{ $key }}: {{ $value | quote }}
   {{- end }}
 {{- end }}

--- a/src/spryker/helm/app/templates/application/webapp/ingress.yaml
+++ b/src/spryker/helm/app/templates/application/webapp/ingress.yaml
@@ -3,11 +3,9 @@
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
-{{- if $.Values.ingress.annotations }}
+{{- with $.Values.ingress.annotations }}
   annotations:
-  {{- range $key, $value := $.Values.ingress.annotations }}
-    {{ $key }}: {{ $value | quote }}
-  {{- end }}
+    {{- . | toYaml | nindent 4 }}
 {{- end }}
   creationTimestamp: null
   labels:


### PR DESCRIPTION
* Enable istio by setting `attribute('pipeline.base.istio.enabled'): true`.
* Switch between nginx and istio ingress annotations in values.yaml.twig to provide `.Values.ingress.annotations`
* 
Merges into #527 