### PR TITLE
Fix sealed secret template

### DIFF
--- a/src/_base/helm/app/templates/_base_helper.tpl
+++ b/src/_base/helm/app/templates/_base_helper.tpl
@@ -56,7 +56,7 @@ metadata:
     argocd.argoproj.io/sync-wave: "1"
 {{ if .root.Values.feature.sealed_secrets }}
 {{ if ne .root.Values.sealed_secrets.scope "strict" }}
-    sealedsecrets.bitnami.com/{{ .Values.sealed_secrets.scope }}: "true"
+    sealedsecrets.bitnami.com/{{ .root.Values.sealed_secrets.scope }}: "true"
 {{ end }}
 spec:
   encryptedData:


### PR DESCRIPTION
Fixes:
```
Error: template: example/templates/_base_helper.tpl:59:40: executing "service.environment.secret" at <.Values.sealed_secrets.scope>: nil pointer evaluating interface {}.sealed_secrets
```