### PR TITLE
Move the Spryker demoshop LICENSE to another filename

### DIFF
--- a/src/spryker/docker/image/console/root/lib/task/skeleton/apply.sh.twig
+++ b/src/spryker/docker/image/console/root/lib/task/skeleton/apply.sh.twig
@@ -15,6 +15,7 @@ function fetch_demoshop()
     run "shopt -s dotglob && mv /tmp/spryker/* /app"
     run rm -rf /tmp/spryker
     run rm -rf /app/.git
+    run mv /app/LICENSE /app/demoshop.LICENSE
 }
 
 # Merge core composer.json with composer-harness.json


### PR DESCRIPTION
To avoid it looking like only the LICENSE applies to the project's derivative works