### PR TITLE
Fix drush updatedb hanging

### DIFF
--- a/src/drupal8/harness.yml
+++ b/src/drupal8/harness.yml
@@ -57,7 +57,7 @@ attributes:
     migrate:
       steps:
         - run drush cache:rebuild
-        - run drush updatedb
+        - passthru drush updatedb --yes
         - run drush cache:rebuild
     cron:
       jobs:


### PR DESCRIPTION
Need to provide `--yes` to automatically accept a prompt during `drush updatedb`
```
build@5fccb0f2e0f6:/app$ cat /tmp/my127ws-std*
The following updates are pending:

system module :
  8801 -   Remove 'path.temporary' config if redundant.
  8802 -   Fix system.theme:admin when the default theme is used as the admin theme.
  8803 -   Install the 'path_alias' entity type.
  8804 -   Convert path aliases to entities.
  8805 -   Change the provider of the 'path_alias' entity type and its base fields.
  8901 -   Update the stored schema data for entity identifier fields.

path module :
  Create the language content settings configuration object for path aliases.

search module :
  Configures default search page for instantiated blocks.
  Mark everything for reindexing after diacritics removal rule change.

system module :
  Populate the new 'match_limit' setting for the ER autocomplete widget.
  Update all entity form displays that contain extra fields.
  Clear the schema cache.

taxonomy module :
  Add status with settings to all form displays for taxonomy entities.

text module :
  Update text_with_summary fields to add summary required flags.
  Update text_with_summary widgets to add summary required flags.

views module :
  Update field names for multi-value base fields.
  Define default values for limit operators settings in all filters.
  Remove core key from views configuration.

Do you wish to run all pending updates? (y/n):
```