### PR TITLE
Add Zed API hosts for supporting back-channel communication

### DIFF
--- a/src/_base/application/skeleton/README.md.twig
+++ b/src/_base/application/skeleton/README.md.twig
@@ -27,34 +27,7 @@ Please follow the below steps to get started, if you encounter any issues instal
 2. Copy the LastPass entry "{{ @('workspace.name') }}: Development Environment Key" to a new blank file named `workspace.override.yml` in the project root.
 3. Run `ws install`
 
-{% if not @('yves.external_hosts') -%}
-Once installed, the site should be available at [https://{{ @('hostname') }}](https://{{ @('hostname') }}).
-{% set additional_hostnames = @('hostname_aliases')|map(alias => "#{alias}." ~ @('domain')) %}
-{% if additional_hostnames %}
-
-**Additional sites**:
-{% for host in additional_hostnames -%}
-- [https://{{ host }}](https://{{ host }})
-{% endfor -%}
-{% endif -%}
-{% else -%}
-Once installed, the site should be available at the following URLs:
-
-**Yves**:
-{% for store, yves_external_host in @('yves.external_hosts') -%}
-- {{ store }} Store: [https://{{ yves_external_host }}](https://{{ yves_external_host }})
-{% endfor %}
-
-**Zed**:
-{% for store, zed_external_host in @('zed.external_hosts') -%}
-- {{ store }} Zed: [https://{{ zed_external_host }}](https://{{ zed_external_host }})
-{% endfor %}
-
-**Glue**:
-{% for store, glue_external_host in @('glue.external_hosts') -%}
-- {{ store }} Glue: [https://{{ glue_external_host }}](https://{{ glue_external_host }})
-{% endfor %}
-{% endif %}
+{% include blocks ~ 'websites.md.twig' %}
 
 **Additional services**:
 - Mailhog: [https://mail.my127.site](https://mail.my127.site)

--- a/src/_base/application/skeleton/_twig/README.md/websites.md.twig
+++ b/src/_base/application/skeleton/_twig/README.md/websites.md.twig
@@ -1,0 +1,9 @@
+Once installed, the site should be available at [https://{{ @('hostname') }}](https://{{ @('hostname') }}).
+{% set additional_hostnames = @('hostname_aliases')|map(alias => "#{alias}." ~ @('domain')) %}
+{% if additional_hostnames %}
+
+**Additional sites**:
+{% for host in additional_hostnames -%}
+- [https://{{ host }}](https://{{ host }})
+{% endfor -%}
+{% endif -%}

--- a/src/spryker/application/skeleton/_twig/README.md/websites.md.twig
+++ b/src/spryker/application/skeleton/_twig/README.md/websites.md.twig
@@ -2,20 +2,20 @@ Once installed, the site should be available at the following URLs:
 
 **Yves**:
 {% for store, host in @('yves.external_hosts') -%}
-- {{ store }} Store: [https://{{ host }}](https://{{ host }})
+- {{ store }}: [https://{{ host }}](https://{{ host }})
 {% endfor %}
 
 **Zed**:
 {% for store, host in @('zed.external_hosts') -%}
-- {{ store }} Zed: [https://{{ host }}](https://{{ host }})
+- {{ store }}: [https://{{ host }}](https://{{ host }})
 {% endfor %}
 
 **Zed API**:
 {% for store, host in @('zed_api.external_hosts') -%}
-- {{ store }} Zed: [https://{{ host }}](https://{{ host }})
+- {{ store }}: [https://{{ host }}](https://{{ host }})
 {% endfor %}
 
 **Glue**:
 {% for store, host in @('glue.external_hosts') -%}
-- {{ store }} Glue: [https://{{ host }}](https://{{ host }})
+- {{ store }}: [https://{{ host }}](https://{{ host }})
 {% endfor %}

--- a/src/spryker/application/skeleton/_twig/README.md/websites.md.twig
+++ b/src/spryker/application/skeleton/_twig/README.md/websites.md.twig
@@ -1,0 +1,21 @@
+Once installed, the site should be available at the following URLs:
+
+**Yves**:
+{% for store, host in @('yves.external_hosts') -%}
+- {{ store }} Store: [https://{{ host }}](https://{{ host }})
+{% endfor %}
+
+**Zed**:
+{% for store, host in @('zed.external_hosts') -%}
+- {{ store }} Zed: [https://{{ host }}](https://{{ host }})
+{% endfor %}
+
+**Zed API**:
+{% for store, host in @('zed_api.external_hosts') -%}
+- {{ store }} Zed: [https://{{ host }}](https://{{ host }})
+{% endfor %}
+
+**Glue**:
+{% for store, host in @('glue.external_hosts') -%}
+- {{ store }} Glue: [https://{{ host }}](https://{{ host }})
+{% endfor %}

--- a/src/spryker/application/skeleton/config/Shared/config_local.php
+++ b/src/spryker/application/skeleton/config/Shared/config_local.php
@@ -67,9 +67,17 @@ $config[ApplicationConstants::BASE_URL_SSL_ZED] = sprintf(
     $config[ApplicationConstants::HOST_ZED],
     ''
 );
-$config[ZedRequestConstants::HOST_ZED_API] = $config[ApplicationConstants::HOST_ZED];
-$config[ZedRequestConstants::BASE_URL_ZED_API] = $config[ApplicationConstants::BASE_URL_ZED];
-$config[ZedRequestConstants::BASE_URL_SSL_ZED_API] = $config[ApplicationConstants::BASE_URL_SSL_ZED];
+$config[ZedRequestConstants::HOST_ZED_API] = getenv('ZED_API_HOST_' . $CURRENT_STORE) ?: $config[ApplicationConstants::HOST_ZED];
+$config[ApplicationConstants::BASE_URL_ZED_API] = sprintf(
+    'http://%s%s',
+    $config[ApplicationConstants::HOST_ZED_API],
+    ''
+);
+$config[ApplicationConstants::BASE_URL_SSL_ZED_API] = sprintf(
+    'https://%s%s',
+    $config[ApplicationConstants::HOST_ZED_API],
+    ''
+);
 $config[ApplicationConstants::ZED_TRUSTED_HOSTS]
     = $config[HttpConstants::ZED_TRUSTED_HOSTS]
     = [];

--- a/src/spryker/application/skeleton/config/Shared/config_local.php
+++ b/src/spryker/application/skeleton/config/Shared/config_local.php
@@ -68,14 +68,14 @@ $config[ApplicationConstants::BASE_URL_SSL_ZED] = sprintf(
     ''
 );
 $config[ZedRequestConstants::HOST_ZED_API] = getenv('ZED_API_HOST_' . $CURRENT_STORE) ?: $config[ApplicationConstants::HOST_ZED];
-$config[ApplicationConstants::BASE_URL_ZED_API] = sprintf(
+$config[ZedRequestConstants::BASE_URL_ZED_API] = sprintf(
     'http://%s%s',
-    $config[ApplicationConstants::HOST_ZED_API],
+    $config[ZedRequestConstants::HOST_ZED_API],
     ''
 );
-$config[ApplicationConstants::BASE_URL_SSL_ZED_API] = sprintf(
+$config[ZedRequestConstants::BASE_URL_SSL_ZED_API] = sprintf(
     'https://%s%s',
-    $config[ApplicationConstants::HOST_ZED_API],
+    $config[ZedRequestConstants::HOST_ZED_API],
     ''
 );
 $config[ApplicationConstants::ZED_TRUSTED_HOSTS]

--- a/src/spryker/docker/image/nginx/root/etc/nginx/conf.d/zed.conf.template.twig
+++ b/src/spryker/docker/image/nginx/root/etc/nginx/conf.d/zed.conf.template.twig
@@ -3,7 +3,7 @@ server {
     listen 80;
     listen 443 ssl http2;
 
-    server_name ${ZED_HOST_{{ store_code }}};
+    server_name ${ZED_HOST_{{ store_code }}} ${ZED_API_HOST_{{ store_code }}};
 
     include snippets/certificate.conf;
     include snippets/ssl-params.conf;

--- a/src/spryker/harness.yml
+++ b/src/spryker/harness.yml
@@ -115,6 +115,11 @@ attributes:
       DE: = 'zed-de-' ~ @('hostname')
       AT: = 'zed-at-' ~ @('hostname')
       US: = 'zed-us-' ~ @('hostname')
+  zed_api:
+    external_hosts:
+      DE: = 'zed-api-de-' ~ @('hostname')
+      AT: = 'zed-api-at-' ~ @('hostname')
+      US: = 'zed-api-us-' ~ @('hostname')
   glue:
     external_hosts:
       DE: = 'glue-de-' ~ @('hostname')

--- a/src/spryker/harness.yml
+++ b/src/spryker/harness.yml
@@ -89,7 +89,8 @@ attributes:
   hostname_aliases: "= replace(flatten([
       @('glue.external_hosts'),
       @('yves.external_hosts'),
-      @('zed.external_hosts')
+      @('zed.external_hosts'),
+      @('zed_api.external_hosts')
     ]), @('hostname'), @('namespace'))"
   redis:
     protocol: redis
@@ -141,6 +142,11 @@ attributes:
           DE: = 'zed-de-' ~ @('pipeline.preview.hostname')
           AT: = 'zed-at-' ~ @('pipeline.preview.hostname')
           US: = 'zed-us-' ~ @('pipeline.preview.hostname')
+      zed_api:
+        external_hosts:
+          DE: = 'zed-api-de-' ~ @('pipeline.preview.hostname')
+          AT: = 'zed-api-at-' ~ @('pipeline.preview.hostname')
+          US: = 'zed-api-us-' ~ @('pipeline.preview.hostname')
       glue:
         external_hosts:
           DE: = 'glue-de-' ~ @('pipeline.preview.hostname')
@@ -162,6 +168,11 @@ attributes:
           DE: = 'zed-de-' ~ @('pipeline.qa.hostname')
           AT: = 'zed-at-' ~ @('pipeline.qa.hostname')
           US: = 'zed-us-' ~ @('pipeline.qa.hostname')
+      zed_api:
+        external_hosts:
+          DE: = 'zed-api-de-' ~ @('pipeline.qa.hostname')
+          AT: = 'zed-api-at-' ~ @('pipeline.qa.hostname')
+          US: = 'zed-api-us-' ~ @('pipeline.qa.hostname')
       glue:
         external_hosts:
           DE: = 'glue-de-' ~ @('pipeline.qa.hostname')

--- a/src/spryker/harness/attributes/docker.yml
+++ b/src/spryker/harness/attributes/docker.yml
@@ -13,7 +13,8 @@ attributes:
           template_key_value('GLUE_HOST_{{key}}', @('glue.external_hosts')),
           template_key_value('RABBITMQ_VHOST_{{key}}', @('rabbitmq.vhosts')),
           template_key_value('YVES_HOST_{{key}}', @('yves.external_hosts')),
-          template_key_value('ZED_HOST_{{key}}', @('zed.external_hosts'))
+          template_key_value('ZED_HOST_{{key}}', @('zed.external_hosts')),
+          template_key_value('ZED_API_HOST_{{key}}', @('zed_api.external_hosts'))
         ])"
       environment_secrets:
         SPRYKER_SALT: = @('spryker.salt')
@@ -74,13 +75,15 @@ attributes:
           environment_dynamic: "= deep_merge([
               template_key_value('GLUE_HOST_{{key}}', @('pipeline.preview.glue.external_hosts')),
               template_key_value('YVES_HOST_{{key}}', @('pipeline.preview.yves.external_hosts')),
-              template_key_value('ZED_HOST_{{key}}', @('pipeline.preview.zed.external_hosts'))
+              template_key_value('ZED_HOST_{{key}}', @('pipeline.preview.zed.external_hosts')),
+              template_key_value('ZED_API_HOST_{{key}}', @('pipeline.preview.zed_api.external_hosts'))
             ])"
         nginx:
           environment_dynamic: "= deep_merge([
               template_key_value('GLUE_HOST_{{key}}', @('pipeline.preview.glue.external_hosts')),
               template_key_value('YVES_HOST_{{key}}', @('pipeline.preview.yves.external_hosts')),
-              template_key_value('ZED_HOST_{{key}}', @('pipeline.preview.zed.external_hosts'))
+              template_key_value('ZED_HOST_{{key}}', @('pipeline.preview.zed.external_hosts')),
+              template_key_value('ZED_API_HOST_{{key}}', @('pipeline.preview.zed_api.external_hosts'))
             ])"
       persistence:
         enabled: true
@@ -95,11 +98,13 @@ attributes:
           environment_dynamic: "= deep_merge([
               template_key_value('GLUE_HOST_{{key}}', @('pipeline.qa.glue.external_hosts')),
               template_key_value('YVES_HOST_{{key}}', @('pipeline.qa.yves.external_hosts')),
-              template_key_value('ZED_HOST_{{key}}', @('pipeline.qa.zed.external_hosts'))
+              template_key_value('ZED_HOST_{{key}}', @('pipeline.qa.zed.external_hosts')),
+              template_key_value('ZED_API_HOST_{{key}}', @('pipeline.qa.zed_api.external_hosts'))
             ])"
         nginx:
           environment_dynamic: "= deep_merge([
               template_key_value('GLUE_HOST_{{key}}', @('pipeline.qa.glue.external_hosts')),
               template_key_value('YVES_HOST_{{key}}', @('pipeline.qa.yves.external_hosts')),
-              template_key_value('ZED_HOST_{{key}}', @('pipeline.qa.zed.external_hosts'))
+              template_key_value('ZED_HOST_{{key}}', @('pipeline.qa.zed.external_hosts')),
+              template_key_value('ZED_API_HOST_{{key}}', @('pipeline.qa.zed.external_hosts'))
             ])"

--- a/src/spryker/helm/app/templates/application/webapp/ingress-istio.yaml
+++ b/src/spryker/helm/app/templates/application/webapp/ingress-istio.yaml
@@ -15,7 +15,7 @@ metadata:
 spec:
   hosts:
 {{- range $key, $value := (mergeOverwrite (dict) .Values.services.nginx.environment .Values.services.nginx.environment_dynamic) }}
-{{- if contains "_HOST_" $key }}
+{{- if and (contains "_HOST_" $key) $value }}
   - {{ $value | quote }}
 {{- end }}
 {{- end }}

--- a/src/spryker/helm/app/templates/application/webapp/ingress.yaml
+++ b/src/spryker/helm/app/templates/application/webapp/ingress.yaml
@@ -16,7 +16,7 @@ metadata:
 spec:
   rules:
   {{- range $key, $value := (mergeOverwrite (dict) .environment .environment_dynamic) }}
-  {{- if contains "_HOST_" $key }}
+  {{- if and (contains "_HOST_" $key) $value }}
   - host: {{ $value | quote }}
     http:
       paths:


### PR DESCRIPTION
through private DNS

Previous behaviour can be achieved by setting the api hosts as empty strings