### PR TITLE
Implement ws external-images ls/rm and use for ws destroy --all

### DIFF
--- a/src/_base/harness/config/commands.yml
+++ b/src/_base/harness/config/commands.yml
@@ -20,7 +20,7 @@ command('disable'):
     #!bash(workspace:/)
     source .my127ws/harness/scripts/disable.sh
 
-command('destroy'):
+command('destroy [--all]'):
   env:
     NAMESPACE:            = @('namespace')
     APP_BUILD:            = @('app.build')
@@ -28,6 +28,7 @@ command('destroy'):
     DOCKER_REPOSITORY:    = @('docker.repository')
     USE_MUTAGEN:          = @('host.os') == 'darwin' and @('mutagen') == 'yes' ? 'yes':'no'
     COMPOSE_PROJECT_NAME: = @('namespace')
+    DESTROY_ALL:          = input.option('all') ? 'yes':'no'
   exec: |
     #!bash(workspace:/)|@
     source .my127ws/harness/scripts/destroy.sh

--- a/src/_base/harness/config/external-images.yml
+++ b/src/_base/harness/config/external-images.yml
@@ -27,7 +27,7 @@ command('external-images config [--skip-exists]'):
     #!php
     $exclude = [];
     if ($env['SKIP_EXISTS']) {
-      $exclude = explode("\n", shell_exec('docker images -a --format \'{{ print .Repository ":" .Tag }}\''));
+      $exclude = explode("\n", shell_exec('docker image ls -a --format \'{{ print .Repository ":" .Tag }}\''));
     }
     $include = explode(' ', $env['IMAGES']);
     $compose = ['version' => '3', 'services' => []];
@@ -44,3 +44,37 @@ command('external-images pull'): |
   fi
 
   passthru "ws external-images config $(printf '%q ' "${CONF_ARGS[@]}") | docker-compose -f - pull"
+
+command('external-images ls [--all]'):
+  env:
+    IMAGES: = external_images(docker_service_images())
+    SHOW_REMOTE: "= input.option('all') ? 1 : 0"
+  exec: |
+    #!php
+    $include = explode(' ', $env['IMAGES']);
+    if ($env['SHOW_REMOTE']) {
+      $images = $include;
+    } else {
+      $all = explode("\n", shell_exec('docker image ls -a --format \'{{ print .Repository ":" .Tag }}\''));
+      $images = array_intersect($include, $all);
+    }
+
+    if (count($images) > 0) {
+      echo join("\n", $images)."\n";
+    }
+
+command('external-images rm [--force]'):
+  env:
+    FORCE: = input.option('force') ? 'yes':'no'
+  exec: |
+    #!bash(workspace:/)|@
+    IMAGES=($(ws external-images ls))
+    OPTS=()
+
+    if [ "${FORCE}" = yes ]; then
+      OPTS+=(--force)
+    fi
+
+    if [ "${#IMAGES[@]}" -gt 0 ]; then
+      docker image rm "${OPTS[@]}" -- "${IMAGES[@]}"
+    fi

--- a/src/_base/harness/scripts/destroy.sh
+++ b/src/_base/harness/scripts/destroy.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 
-run docker-compose down --rmi local --volumes --remove-orphans --timeout 120
-
 if [ "${DESTROY_ALL}" = yes ]; then
-  passthru ws external-images rm --force
+  RMI=all
+else
+  RMI=local
 fi
+
+run docker-compose down --rmi "${RMI}" --volumes --remove-orphans --timeout 120
 
 if [ "${USE_MUTAGEN}" = yes ]; then
   run ws mutagen stop

--- a/src/_base/harness/scripts/destroy.sh
+++ b/src/_base/harness/scripts/destroy.sh
@@ -2,7 +2,11 @@
 
 run docker-compose down --rmi local --volumes --remove-orphans --timeout 120
 
-if [[ "$USE_MUTAGEN" = "yes" ]]; then
+if [ "${DESTROY_ALL}" = yes ]; then
+  passthru ws external-images rm --force
+fi
+
+if [ "${USE_MUTAGEN}" = yes ]; then
   run ws mutagen stop
   passthru ws mutagen rm
 fi


### PR DESCRIPTION
In order to allow developers to clear up as much space as they can per project when they've done with it.

It will complain if an image is already directly used by another project's container, but if it's not the direct commit but a FROM .., will just de-tag the image commit, keeping it around.