### PR TITLE
Add Jaeger Relay

### DIFF
--- a/src/_base/_twig/docker-compose.yml/service/relay.yml.twig
+++ b/src/_base/_twig/docker-compose.yml/service/relay.yml.twig
@@ -5,5 +5,6 @@
     networks:
       private:
         aliases:
+          - jaeger-relay
           - mailhog-relay
       shared: {}

--- a/src/_base/docker/image/relay/root/etc/nginx/nginx.conf
+++ b/src/_base/docker/image/relay/root/etc/nginx/nginx.conf
@@ -13,7 +13,7 @@ stream {
   server {
     listen 1025;
 
-    # Avoid crashes on boot if jaeger isn't running
+    # Avoid crashes on boot if mailhog isn't running
     resolver 127.0.0.11 valid=30s;
     set $upstream_mailhog mailhog;
 

--- a/src/_base/docker/image/relay/root/etc/nginx/nginx.conf
+++ b/src/_base/docker/image/relay/root/etc/nginx/nginx.conf
@@ -21,4 +21,22 @@ stream {
 
     proxy_pass mailhog:8025;
   }
+
+  server {
+    listen 6831 udp;
+
+    # Avoid crashes on boot if jaeger isn't running
+    set $upstream_jaeger jaeger;
+
+    proxy_pass $upstream_jaeger:6831;
+  }
+
+  server {
+    listen 6832 udp;
+
+    # Avoid crashes on boot if jaeger isn't running
+    set $upstream_jaeger jaeger;
+
+    proxy_pass $upstream_jaeger:6832;
+  }
 }

--- a/src/_base/docker/image/relay/root/etc/nginx/nginx.conf
+++ b/src/_base/docker/image/relay/root/etc/nginx/nginx.conf
@@ -49,4 +49,14 @@ stream {
 
     proxy_pass $upstream_jaeger:6832;
   }
+  
+  server {
+    listen 9411;
+
+    # Avoid crashes on boot if jaeger isn't running
+    resolver 127.0.0.11 valid=30s;
+    set $upstream_jaeger jaeger;
+
+    proxy_pass $upstream_jaeger:9411;
+  }
 }

--- a/src/_base/docker/image/relay/root/etc/nginx/nginx.conf
+++ b/src/_base/docker/image/relay/root/etc/nginx/nginx.conf
@@ -13,19 +13,28 @@ stream {
   server {
     listen 1025;
 
-    proxy_pass mailhog:1025;
+    # Avoid crashes on boot if jaeger isn't running
+    resolver 127.0.0.11 valid=30s;
+    set $upstream_mailhog mailhog;
+
+    proxy_pass $upstream_mailhog:1025;
   }
 
   server {
     listen 8025;
 
-    proxy_pass mailhog:8025;
+    # Avoid crashes on boot if mailhog isn't running
+    resolver 127.0.0.11 valid=30s;
+    set $upstream_mailhog mailhog;
+
+    proxy_pass $upstream_mailhog:8025;
   }
 
   server {
     listen 6831 udp;
 
     # Avoid crashes on boot if jaeger isn't running
+    resolver 127.0.0.11 valid=30s;
     set $upstream_jaeger jaeger;
 
     proxy_pass $upstream_jaeger:6831;
@@ -35,6 +44,7 @@ stream {
     listen 6832 udp;
 
     # Avoid crashes on boot if jaeger isn't running
+    resolver 127.0.0.11 valid=30s;
     set $upstream_jaeger jaeger;
 
     proxy_pass $upstream_jaeger:6832;


### PR DESCRIPTION
Forwards Jaeger traces to a global Jaeger instance provided by https://github.com/my127/workspace/pull/66 without having to put php-fpm and console in the shared my127 network and run into issues with docker-compose's DNS round robin for "mysql" or similar.