### PR TITLE
Simplify cleanup in ws destroy

### DIFF
--- a/src/_base/docker/image/php-fpm/Dockerfile.twig
+++ b/src/_base/docker/image/php-fpm/Dockerfile.twig
@@ -1,6 +1,6 @@
 {% if @('app.build') == 'static' %}
 FROM {{ @('docker.repository') ~ ':' ~ @('app.version') }}-console as console
-LABEL build="{{ @('workspace.name') ~ ':' ~ @('app.version') }}"
+LABEL build="{{ @('namespace') ~ ':' ~ @('app.version') }}"
 RUN if [ -d /app/tools/assets/ ]; then rm -rf /app/tools/assets/; fi
 RUN if [ -d {{ @('frontend.path') }}/node_modules/ ]; then rm -rf {{ @('frontend.path') }}/node_modules/; fi
 {% endif %}

--- a/src/_base/harness/config/cleanup.yml
+++ b/src/_base/harness/config/cleanup.yml
@@ -7,13 +7,14 @@ function('built_images', [services]): |
       $builtImages[] = $service['image'];
     }
   }
+  $allImages = explode("\n", shell_exec('docker image ls -a --format \'{{ print .Repository ":" .Tag }}\''));
 
   # workspace commands don't allow non-string types
-  = join(' ', $builtImages);
+  = join(' ', array_intersect($builtImages, $allImages));
 
 command('cleanup built-images'):
   env:
-    BUILD_LABEL: = @('workspace.name') ~ ':' ~ @('app.version')
+    BUILD_LABEL: = @('namespace') ~ ':' ~ @('app.version')
     IMAGES: = built_images(docker_service_images())
   exec: |
     #!bash
@@ -21,6 +22,6 @@ command('cleanup built-images'):
     if [ "${#IMAGES[@]}" -gt 0 ]; then
       run docker image rm --force -- "${IMAGES[@]}"
     fi
-    if docker images --filter=label=build="$BUILD_LABEL" -q | grep '^.*$'; then
-      run "docker images --filter=label=build=$(printf '%q' "$BUILD_LABEL") -q | xargs docker image rm --force"
-    fi
+    run docker image prune --force --filter=label=build="$BUILD_LABEL"
+    [ -z "$(docker builder 2>&1)" ] || run docker builder prune --force --filter=label=build="$BUILD_LABEL"
+


### PR DESCRIPTION
* only clean actually built images
* prune accepts build labels, so no need for xargs
* if buildkit is enabled then builder prune the label