### PR TITLE
Prepare console build as early as possible

### DIFF
--- a/src/_base/harness/config/commands.yml
+++ b/src/_base/harness/config/commands.yml
@@ -9,6 +9,20 @@ command('enable'):
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)
+    set -- all
+    source .my127ws/harness/scripts/enable.sh
+
+command('enable console'):
+  env:
+    USE_MUTAGEN:          = @('host.os') == 'darwin' and @('mutagen') == 'yes' ? 'yes':'no'
+    APP_BUILD:            = @('app.build')
+    APP_MODE:             = @('app.mode')
+    NAMESPACE:            = @('namespace')
+    HAS_ASSETS:           = @('aws.bucket') !== null and @('aws.bucket') !== '' ? 'yes':'no'
+    COMPOSE_PROJECT_NAME: = @('namespace')
+  exec: |
+    #!bash(workspace:/)
+    set -- console
     source .my127ws/harness/scripts/enable.sh
 
 command('disable'):

--- a/src/_base/harness/config/external-images.yml
+++ b/src/_base/harness/config/external-images.yml
@@ -18,10 +18,9 @@ function('external_images', [services]): |
   # workspace commands don't allow non-string types
   = join(' ', $externalImages);
 
-
-command('external-images config [--skip-exists]'):
+command('external-images config [--skip-exists] [<service>]'):
   env:
-    IMAGES: = external_images(docker_service_images())
+    IMAGES: = external_images(docker_service_images(input.argument('service')))
     SKIP_EXISTS: "= input.option('skip-exists') ? 1 : 0"
   exec: |
     #!php
@@ -36,14 +35,21 @@ command('external-images config [--skip-exists]'):
     }
     echo \Symfony\Component\Yaml\Yaml::dump($compose, 100, 2);
 
-command('external-images pull'): |
-  #!bash(workspace:/)|@
-  CONF_ARGS=()
-  if [ -n "${CI:-}" ] || [ -n "${BUILD_ID:-}" ]; then
-    CONF_ARGS+=(--skip-exists)
-  fi
+command('external-images pull [<service>]'):
+  env:
+    SERVICE: = input.argument('service')
+  exec: |
+    #!bash(workspace:/)|@
+    CONF_ARGS=()
+    if [ -n "${CI:-}" ] || [ -n "${BUILD_ID:-}" ]; then
+      CONF_ARGS+=(--skip-exists)
+    fi
 
-  passthru "ws external-images config $(printf '%q ' "${CONF_ARGS[@]}") | docker-compose -f - pull"
+    if [ -n "${SERVICE}" ]; then
+      CONF_ARGS+=("$SERVICE")
+    fi
+
+    passthru "ws external-images config $(printf '%q ' "${CONF_ARGS[@]}") | docker-compose -f - pull"
 
 command('external-images ls [--all]'):
   env:

--- a/src/_base/harness/config/functions.yml
+++ b/src/_base/harness/config/functions.yml
@@ -99,7 +99,7 @@ function('get_docker_external_networks'): |
   }
   = join(" ", $externalNetworks);
 
-function('docker_service_images'): |
+function('docker_service_images', [filterService]): |
   #!php
   $configRaw = shell_exec('docker-compose config');
   if ($configRaw === null) {
@@ -109,6 +109,10 @@ function('docker_service_images'): |
   $images = [];
 
   foreach ($config['services'] as $serviceName => $service) {
+    if ($filterService && $serviceName != $filterService) {
+      continue;
+    }
+
     $imageSpec = [
       'image' => $service['image'] ?? null,
       'upstream' => [],

--- a/src/_base/harness/scripts/destroy.sh
+++ b/src/_base/harness/scripts/destroy.sh
@@ -15,4 +15,4 @@ fi
 
 passthru ws cleanup built-images
 
-run rm -f .my127ws/.flag-built
+run rm -f .my127ws/{.flag-built,.flag-synced}

--- a/src/_base/harness/scripts/destroy.sh
+++ b/src/_base/harness/scripts/destroy.sh
@@ -15,4 +15,4 @@ fi
 
 passthru ws cleanup built-images
 
-run rm -f .my127ws/{.flag-built,.flag-synced}
+run rm -f .my127ws/{.flag-built,.flag-console-built}

--- a/src/_base/harness/scripts/enable.sh.twig
+++ b/src/_base/harness/scripts/enable.sh.twig
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-main()
+enable_all()
 {
     local IS_BUILT=no
     local HAS_FLAG=no
@@ -37,6 +37,12 @@ main()
         passthru docker-compose up -d
         passthru docker-compose exec -T -u build console app welcome
     fi
+}
+
+enable_console() {
+    passthru ws networks external
+    passthru ws external-images pull console
+    "${APP_BUILD}_console"
 }
 
 dynamic_console()
@@ -85,6 +91,11 @@ dynamic()
     {% endif %}
 }
 
+static_console()
+{
+    passthru docker-compose up --build -d console
+}
+
 static()
 {
     ws app build
@@ -102,4 +113,4 @@ initial_start()
     {% endif %}
 }
 
-main
+"enable_$1"

--- a/src/_base/harness/scripts/enable.sh.twig
+++ b/src/_base/harness/scripts/enable.sh.twig
@@ -25,6 +25,9 @@ main()
         fi
 
         "$APP_BUILD"
+
+        initial_start
+
         touch .my127ws/.flag-built
     else
         if [ "$APP_BUILD" = dynamic ] && [ "$USE_MUTAGEN" = yes ]; then
@@ -75,29 +78,17 @@ dynamic()
     {% if @('services.job-queue-consumer.enabled') %}
         passthru docker-compose build job-queue-consumer
     {% endif %}
-
-    # Bring up all services apart from console (already started) and cron
-    passthru "docker-compose config --services | grep -v -Fwe console -Fwe cron | xargs docker-compose up -d"
-
-    passthru docker-compose exec -T -u build console app init
-
-    {% if @('services.cron.enabled') %}
-    # Bring up cron
-    passthru docker-compose up -d cron
-    {% endif %}
 }
 
 static()
 {
     ws app build
+}
 
-    {% if @('services.cron.enabled') %}
-        # Bring up all but cron
-        passthru "docker-compose config --services | grep -v -Fwe cron | xargs docker-compose up -d"
-    {% else %}
-        # Bring up all services
-        passthru docker-compose up -d
-    {% endif %}
+initial_start()
+{
+    # Bring up all services apart from cron
+    passthru "docker-compose config --services | grep -v -Fwe cron | xargs docker-compose up -d"
 
     passthru docker-compose exec -T -u build console app init
 

--- a/src/_base/harness/scripts/enable.sh.twig
+++ b/src/_base/harness/scripts/enable.sh.twig
@@ -93,7 +93,7 @@ static()
 
     {% if @('services.cron.enabled') %}
         # Bring up all but cron
-        passthru "docker-compose config --services | grep -v cron | xargs docker-compose up -d"
+        passthru "docker-compose config --services | grep -v -Fwe cron | xargs docker-compose up -d"
     {% else %}
         # Bring up all services
         passthru docker-compose up -d

--- a/src/_base/harness/scripts/enable.sh.twig
+++ b/src/_base/harness/scripts/enable.sh.twig
@@ -76,13 +76,15 @@ dynamic()
         passthru docker-compose build job-queue-consumer
     {% endif %}
 
-    # Bring up all services apart from cron, jenkins-runner and job-queue-consumer
-    passthru "docker-compose config --services | grep -v -Fwe console -Fwe cron -Fwe jenkins-runner | xargs docker-compose up -d"
+    # Bring up all services apart from console (already started) and cron
+    passthru "docker-compose config --services | grep -v -Fwe console -Fwe cron | xargs docker-compose up -d"
 
     passthru docker-compose exec -T -u build console app init
 
-    # Bring up all services
-    passthru docker-compose up -d
+    {% if @('services.cron.enabled') %}
+    # Bring up cron
+    passthru docker-compose up -d cron
+    {% endif %}
 }
 
 static()

--- a/src/_base/harness/scripts/enable.sh.twig
+++ b/src/_base/harness/scripts/enable.sh.twig
@@ -26,7 +26,7 @@ enable_all()
         if [ "$HAS_FLAG" = no ]; then
             # remove all services, keeping console if considered built
             if [ -f .my127ws/.flag-console-built ]; then
-                if [ -n "$(grep -v -Fxe console <<< "$SERVICES_CREATED")" ]
+                if [ -n "$(grep -v -Fxe console <<< "$SERVICES_CREATED")" ]; then
                     passthru "docker-compose ps --services | grep -v -Fxe console | xargs docker-compose rm --stop --)"
                 fi
             else

--- a/src/_base/harness/scripts/enable.sh.twig
+++ b/src/_base/harness/scripts/enable.sh.twig
@@ -4,20 +4,34 @@ enable_all()
 {
     local IS_BUILT=no
     local HAS_FLAG=no
+    local SERVICES_CREATED="$(docker-compose ps --services)"
 
     if [ -f .my127ws/.flag-built ]; then
         HAS_FLAG=yes
         IS_BUILT=yes
-        # If no lines for `docker-compose ps`, the containers no longer exist so we need to rebuild them
-        if [ "$(docker-compose ps --quiet | wc -l | awk '{ print $1 }')" = "0" ]; then
+        # If the containers no longer exist, we need to rebuild them
+        if [ -z "$SERVICES_CREATED" ]; then
             IS_BUILT=no
+        fi
+    fi
+
+    if [ -f .my127ws/.flag-console-built ]; then
+        if grep -v -Fxe console <<< "$SERVICES_CREATED"; then
+            rm .my127ws/.flag-console-built
         fi
     fi
 
     passthru ws networks external
     if [ "$IS_BUILT" = no ]; then
         if [ "$HAS_FLAG" = no ]; then
-          passthru docker-compose down
+            # remove all services, keeping console if considered built
+            if [ -f .my127ws/.flag-console-built ]; then
+                if [ -n "$(grep -v -Fxe console <<< "$SERVICES_CREATED")" ]
+                    passthru "docker-compose ps --services | grep -v -Fxe console | xargs docker-compose rm --stop --)"
+                fi
+            else
+                passthru docker-compose down
+            fi
         fi
 
         if [ "$HAS_ASSETS" = yes ]; then
@@ -78,7 +92,7 @@ dynamic()
 
     dynamic_console
 
-    passthru "docker-compose config --services | grep -v -Fwe console -Fwe cron -Fwe jenkins-runner -Fwe job-queue-consumer | xargs docker-compose build"
+    passthru "docker-compose config --services | grep -v -Fwe console -Fxe cron -Fxe jenkins-runner -Fxe job-queue-consumer | xargs docker-compose build"
 
     {% if @('services.cron.enabled') %}
         passthru docker-compose build cron
@@ -104,7 +118,7 @@ static()
 initial_start()
 {
     # Bring up all services apart from cron
-    passthru "docker-compose config --services | grep -v -Fwe cron | xargs docker-compose up -d"
+    passthru "docker-compose config --services | grep -v -Fxe cron | xargs docker-compose up -d"
 
     passthru docker-compose exec -T -u build console app init
 

--- a/src/_base/harness/scripts/enable.sh.twig
+++ b/src/_base/harness/scripts/enable.sh.twig
@@ -39,23 +39,20 @@ main()
     fi
 }
 
-dynamic()
+dynamic_console()
 {
-    local IS_SYNCED=no
-    if [ -f .my127ws/.flag-synced ]; then
-        IS_SYNCED=yes
+    if [ -f .my127ws/.flag-console-built ]; then
+        if [ -n "$(docker image list -q "${COMPOSE_PROJECT_NAME}_console")" ]; then
+            return
+        fi
+        rm .my127ws/.flag-console-built
     fi
 
     # we synchronise then stop mutagen to avoid impacting CPU usage during the build
-
     if [ "$USE_MUTAGEN" = yes ]; then
-        if [ "$IS_SYNCED" = no ]; then
-            passthru ws mutagen start
-        fi
+        passthru ws mutagen start
         passthru ws mutagen pause
     fi
-
-    ws external-images pull
 
     find .my127ws/docker/image/ -type d ! -perm u+rwx,go+rx,o-w -exec chmod u+rwx,go+rx,o-w {} +
 
@@ -64,8 +61,16 @@ dynamic()
 
     if [ "$USE_MUTAGEN" = yes ]; then
         ws mutagen resume
-        touch .my127ws/.flag-synced
     fi
+
+    touch .my127ws/.flag-console-built
+}
+
+dynamic()
+{
+    ws external-images pull
+
+    dynamic_console
 
     passthru "docker-compose config --services | grep -v -Fwe console -Fwe cron -Fwe jenkins-runner -Fwe job-queue-consumer | xargs docker-compose build"
 

--- a/src/_base/harness/scripts/enable.sh.twig
+++ b/src/_base/harness/scripts/enable.sh.twig
@@ -56,7 +56,15 @@ dynamic()
 
     find .my127ws/docker/image/ -type d ! -perm u+rwx,go+rx,o-w -exec chmod u+rwx,go+rx,o-w {} +
 
-    passthru "docker-compose config --services | grep -v cron | grep -v jenkins-runner | grep -v job-queue-consumer | xargs docker-compose build"
+    passthru docker-compose up --build -d console
+    passthru docker-compose exec -T -u build console app build
+
+    if [ "$USE_MUTAGEN" = yes ]; then
+        ws mutagen resume
+        touch .my127ws/.flag-synced
+    fi
+
+    passthru "docker-compose config --services | grep -v -Fwe console -Fwe cron -Fwe jenkins-runner -Fwe job-queue-consumer | xargs docker-compose build"
 
     {% if @('services.cron.enabled') %}
         passthru docker-compose build cron
@@ -68,18 +76,8 @@ dynamic()
         passthru docker-compose build job-queue-consumer
     {% endif %}
 
-    # Bring up console to fix file permissions
-    passthru docker-compose up -d console
-
     # Bring up all services apart from cron, jenkins-runner and job-queue-consumer
-    passthru "docker-compose config --services | grep -v cron | grep -v jenkins-runner | xargs docker-compose up -d"
-
-    passthru docker-compose exec -T -u build console app build
-
-    if [ "$USE_MUTAGEN" = yes ]; then
-        ws mutagen resume
-        touch .my127ws/.flag-synced
-    fi
+    passthru "docker-compose config --services | grep -v -Fwe console -Fwe cron -Fwe jenkins-runner | xargs docker-compose up -d"
 
     passthru docker-compose exec -T -u build console app init
 

--- a/src/_base/harness/scripts/enable.sh.twig
+++ b/src/_base/harness/scripts/enable.sh.twig
@@ -15,34 +15,40 @@ main()
     fi
 
     passthru ws networks external
-    if [ "$IS_BUILT" = "no" ]; then
-        if [ "$HAS_FLAG" = "no" ]; then
+    if [ "$IS_BUILT" = no ]; then
+        if [ "$HAS_FLAG" = no ]; then
           passthru docker-compose down
         fi
 
-        if [[ "$HAS_ASSETS" = "yes" ]]; then
+        if [ "$HAS_ASSETS" = yes ]; then
             ws assets download
         fi
 
-        $APP_BUILD
+        "$APP_BUILD"
         touch .my127ws/.flag-built
-
     else
+        if [ "$APP_BUILD" = dynamic ] && [ "$USE_MUTAGEN" = yes ]; then
+            passthru ws mutagen resume
+        fi
+
         passthru docker-compose up -d
         passthru docker-compose exec -T -u build console app welcome
-    fi
-
-    if [[ "$APP_BUILD" = "dynamic" && "$USE_MUTAGEN" = "yes" ]]; then
-        passthru ws mutagen resume
     fi
 }
 
 dynamic()
 {
+    local IS_SYNCED=no
+    if [ -f .my127ws/.flag-synced ]; then
+        IS_SYNCED=yes
+    fi
+
     # we synchronise then stop mutagen to avoid impacting CPU usage during the build
 
-    if [[ "$USE_MUTAGEN" = "yes" ]]; then
-        passthru ws mutagen start
+    if [ "$USE_MUTAGEN" = yes ]; then
+        if [ "$IS_SYNCED" = no ]; then
+            passthru ws mutagen start
+        fi
         passthru ws mutagen pause
     fi
 
@@ -69,6 +75,12 @@ dynamic()
     passthru "docker-compose config --services | grep -v cron | grep -v jenkins-runner | xargs docker-compose up -d"
 
     passthru docker-compose exec -T -u build console app build
+
+    if [ "$USE_MUTAGEN" = yes ]; then
+        ws mutagen resume
+        touch .my127ws/.flag-synced
+    fi
+
     passthru docker-compose exec -T -u build console app init
 
     # Bring up all services

--- a/src/_base/harness/scripts/enable.sh.twig
+++ b/src/_base/harness/scripts/enable.sh.twig
@@ -1,34 +1,38 @@
 #!/usr/bin/env bash
 
+console_enabled()
+{
+    if [ "$APP_BUILD" = dynamic ]; then
+        [ -f .my127ws/.flag-console-built ]
+    else
+        [ -n "$(docker-compose ps --quiet console)" ]
+    fi
+}
+
 enable_all()
 {
     local IS_BUILT=no
     local HAS_FLAG=no
-    local SERVICES_CREATED="$(docker-compose ps --services)"
 
     if [ -f .my127ws/.flag-built ]; then
         HAS_FLAG=yes
         IS_BUILT=yes
         # If the containers no longer exist, we need to rebuild them
-        if [ -z "$SERVICES_CREATED" ]; then
+        if [ -z "$(docker-compose ps --quiet)" ]; then
             IS_BUILT=no
         fi
     fi
 
-    if [ -f .my127ws/.flag-console-built ]; then
-        if grep -v -Fxe console <<< "$SERVICES_CREATED"; then
-            rm .my127ws/.flag-console-built
-        fi
+    if [ "$APP_BUILD" = dynamic ] && console_enabled && [ -z "$(docker-compose ps --quiet console)" ]; then
+        rm .my127ws/.flag-console-built
     fi
 
     passthru ws networks external
     if [ "$IS_BUILT" = no ]; then
         if [ "$HAS_FLAG" = no ]; then
             # remove all services, keeping console if considered built
-            if [ -f .my127ws/.flag-console-built ]; then
-                if [ -n "$(grep -v -Fxe console <<< "$SERVICES_CREATED")" ]; then
-                    passthru "docker-compose ps --services | grep -v -Fxe console | xargs docker-compose rm --stop --)"
-                fi
+            if console_enabled; then
+                passthru "docker-compose ps --services | grep -v -Fxe console | xargs docker-compose rm --stop --"
             else
                 passthru docker-compose down
             fi
@@ -54,6 +58,10 @@ enable_all()
 }
 
 enable_console() {
+    if [ "$APP_BUILD" = dynamic ] && console_enabled && [ -z "$(docker-compose ps --quiet console)" ]; then
+        rm .my127ws/.flag-console-built
+    fi
+
     passthru ws networks external
     passthru ws external-images pull console
     "${APP_BUILD}_console"
@@ -61,11 +69,12 @@ enable_console() {
 
 dynamic_console()
 {
-    if [ -f .my127ws/.flag-console-built ]; then
-        if [ -n "$(docker image list -q "${COMPOSE_PROJECT_NAME}_console")" ]; then
-            return
+    if console_enabled; then
+        # ensure it is started
+        if [ -z "$(docker-compose ps --quiet console)" ]; then
+            passthru docker-compose up -d console
         fi
-        rm .my127ws/.flag-console-built
+        return;
     fi
 
     # we synchronise then stop mutagen to avoid impacting CPU usage during the build

--- a/src/_base/harness/scripts/rebuild.sh
+++ b/src/_base/harness/scripts/rebuild.sh
@@ -4,6 +4,6 @@ run docker-compose down --rmi local --volumes --remove-orphans --timeout 120
 
 passthru ws cleanup built-images
 
-run rm -f .my127ws/.flag-built
+run rm -f .my127ws/.flag-built .my127ws/.flag-console-built
 
 passthru ws enable


### PR DESCRIPTION
allows developers to start seeing the full codebase on the host as soon as it's available after build and introduces a new command just to get to that state `ws enable console`