### PR TITLE
Fix executing "ws secret encrypt" when printing help message

### DIFF
--- a/src/_base/harness/config/secrets.yml
+++ b/src/_base/harness/config/secrets.yml
@@ -57,7 +57,7 @@ command('secret image-pull-config [--cert=<cert>] [--scope=<scope>] [--namespace
       echo -n "${DOCKER_CONFIG}" | passthru kubeseal --raw "${KUBESEAL_OPTS[@]}"
     else
       echo 'Note: this has unencrypted credentials in, do not save directly to file' >&2
-      echo "If storing within workspace attributes, use `ws secret encrypt` first" >&2
+      echo "If storing within workspace attributes, use 'ws secret encrypt' first" >&2
       echo "${DOCKER_CONFIG}" | base64
     fi
 


### PR DESCRIPTION
I forgot to set sealed-secrets to true, and presented with the help message for `ws secret encrypt` due to no arguments