### PR TITLE
Make curl fail helpfully and consistently

### DIFF
--- a/src/_base/docker/image/console/Dockerfile.twig
+++ b/src/_base/docker/image/console/Dockerfile.twig
@@ -9,9 +9,9 @@ COPY --from={{ service.image }} /usr/local/bin/redis-cli /usr/local/bin/redis-cl
 
 COPY .my127ws/docker/image/console/root /
 RUN chown -R build:build /home/build /app \
- && curl --fail --silent --location --output /sbin/tini https://github.com/krallin/tini/releases/download/v0.19.0/tini \
+ && curl --fail --silent --show-error --location --output /sbin/tini https://github.com/krallin/tini/releases/download/v0.19.0/tini \
  && chmod +x /sbin/tini \
- && curl --fail --silent --location --output /usr/local/bin/mhsendmail https://github.com/mailhog/mhsendmail/releases/download/v0.2.0/mhsendmail_linux_amd64 \
+ && curl --fail --silent --show-error --location --output /usr/local/bin/mhsendmail https://github.com/mailhog/mhsendmail/releases/download/v0.2.0/mhsendmail_linux_amd64 \
  && chmod +x /usr/local/bin/mhsendmail \
  && mkdir -p /tmp/php-file-cache \
  && chown -R build:build /tmp/php-file-cache

--- a/src/_base/docker/image/console/root/lib/task/http/wait.sh
+++ b/src/_base/docker/image/console/root/lib/task/http/wait.sh
@@ -6,7 +6,7 @@ function task_http_wait() {
 
     local counter=0
 
-    while ! curl -s -k "$1" -o /dev/null -L --fail; do
+    while ! curl --fail --silent --show-error --location --insecure --output /dev/null "$1"; do
 
         if (( counter > 60 )); then
             (>&2 echo "timeout while waiting on $1 to become available")

--- a/src/_base/docker/image/console/root/lib/task/rabbitmq/vhosts.sh.twig
+++ b/src/_base/docker/image/console/root/lib/task/rabbitmq/vhosts.sh.twig
@@ -7,7 +7,7 @@ function task_rabbitmq_vhosts() {
     task http:wait "$rabbitmq_api_url/index.html"
 
 {% for vhost in @('rabbitmq.vhosts') %}
-    curl -f -I -s -u "$RABBITMQ_USER:$RABBITMQ_PASSWORD" -X PUT "$rabbitmq_api_url/vhosts/{{ vhost }}"
+    curl --fail --silent --show-error --user "$RABBITMQ_USER:$RABBITMQ_PASSWORD" --request PUT "$rabbitmq_api_url/vhosts/{{ vhost }}"
 {% endfor %}
 {% else %}
     :

--- a/src/_base/docker/image/php-fpm/Dockerfile.twig
+++ b/src/_base/docker/image/php-fpm/Dockerfile.twig
@@ -9,9 +9,9 @@ FROM {{ @('docker.image.php-fpm') }}
 WORKDIR /app
 COPY root  /
 
-RUN curl --fail --silent --location --output /sbin/tini https://github.com/krallin/tini/releases/download/v0.19.0/tini \
+RUN curl --fail --silent --show-error --location --output /sbin/tini https://github.com/krallin/tini/releases/download/v0.19.0/tini \
  && chmod +x /sbin/tini \
- && curl --fail --silent --location --output /usr/local/bin/mhsendmail https://github.com/mailhog/mhsendmail/releases/download/v0.2.0/mhsendmail_linux_amd64 \
+ && curl --fail --silent --show-error --location --output /usr/local/bin/mhsendmail https://github.com/mailhog/mhsendmail/releases/download/v0.2.0/mhsendmail_linux_amd64 \
  && chmod +x /usr/local/bin/mhsendmail
 {%- set install_extensions=@('php.install_extensions')|merge(@('php.fpm.install_extensions'))|filter(v => v is not empty) %}
 {%- if install_extensions %} \

--- a/src/_base/harness/scripts/mutagen.sh
+++ b/src/_base/harness/scripts/mutagen.sh
@@ -33,7 +33,7 @@ install_mutagen()
         return 1
     fi
 
-    run curl --fail --silent --show-error --location --disable --output .my127ws/utilities/mutagen/mutagen.tar.gz "$download_url"
+    run curl --fail --silent --show-error --location --output .my127ws/utilities/mutagen/mutagen.tar.gz "$download_url"
     run "cd .my127ws/utilities/mutagen/ && tar -xf mutagen.tar.gz"
 }
 

--- a/src/_base/harness/scripts/mutagen.sh
+++ b/src/_base/harness/scripts/mutagen.sh
@@ -33,7 +33,7 @@ install_mutagen()
         return 1
     fi
 
-    run curl -L -q -sS -f "$download_url" -o .my127ws/utilities/mutagen/mutagen.tar.gz
+    run curl --fail --silent --show-error --location --disable --output .my127ws/utilities/mutagen/mutagen.tar.gz "$download_url"
     run "cd .my127ws/utilities/mutagen/ && tar -xf mutagen.tar.gz"
 }
 

--- a/src/_base/helm/app/templates/application/app-init.yaml
+++ b/src/_base/helm/app/templates/application/app-init.yaml
@@ -42,7 +42,7 @@ spec:
         name: app-init
 {{ if eq $.Values.ingress.type "istio" }}
         command: ["/bin/sh"]
-        args: ["-c", "/entrypoint.sh app init ; code=$? ; curl -vv -XPOST http://127.0.0.1:15020/quitquitquit ; exit $code"]
+        args: ["-c", "/entrypoint.sh app init ; code=$? ; curl -vv --request POST http://127.0.0.1:15020/quitquitquit ; exit $code"]
 {{ else }}
         command: ["/entrypoint.sh"]
         args: ["app", "init"]

--- a/src/_base/helm/app/templates/application/app-migrate.yaml
+++ b/src/_base/helm/app/templates/application/app-migrate.yaml
@@ -40,7 +40,7 @@ spec:
         name: app-migrate
 {{ if eq $.Values.ingress.type "istio" }}
         command: ["/bin/sh"]
-        args: ["-c", "/entrypoint.sh app migrate ; code=$? ; curl -vv -XPOST http://127.0.0.1:15020/quitquitquit ; exit $code"]
+        args: ["-c", "/entrypoint.sh app migrate ; code=$? ; curl -vv -request POST http://127.0.0.1:15020/quitquitquit ; exit $code"]
 {{ else }}
         command: ["/entrypoint.sh"]
         args: ["app", "migrate"]

--- a/src/magento1/docker/image/console/root/lib/task/n98/install.sh
+++ b/src/magento1/docker/image/console/root/lib/task/n98/install.sh
@@ -4,7 +4,7 @@ function task_n98_install()
 {
   if [ ! -f bin/n98-magerun.phar ]; then
     mkdir -p bin
-    curl -o bin/n98-magerun.phar https://files.magerun.net/n98-magerun.phar
+    curl --fail --silent --show-error --location --output bin/n98-magerun.phar https://files.magerun.net/n98-magerun.phar
     chmod +x bin/n98-magerun.phar
   fi
 }

--- a/src/spryker/docker/image/jenkins-runner/root/lib/task/jenkins/setup.sh
+++ b/src/spryker/docker/image/jenkins-runner/root/lib/task/jenkins/setup.sh
@@ -5,8 +5,8 @@ function task_jenkins_setup()
     echo -e "Bootstrapping jenkins runner"
     task http:wait "$JENKINS_URL"
 
-    curl -s "$JENKINS_URL/jnlpJars/jenkins-cli.jar" -o /usr/local/bin/jenkins-cli.jar
-    curl -s "$JENKINS_URL/jnlpJars/slave.jar" -o /usr/local/bin/jenkins-slave.jar
+    curl --fail --silent --show-error --location --output /usr/local/bin/jenkins-cli.jar "$JENKINS_URL/jnlpJars/jenkins-cli.jar"
+    curl --fail --silent --show-error --location --output /usr/local/bin/jenkins-slave.jar "$JENKINS_URL/jnlpJars/slave.jar"
 
     # link php where it is expected by cron.conf
     ln -s /usr/local/bin/php /usr/bin/php

--- a/src/wordpress/docker/image/console/root/lib/task/wp-cli/install.sh
+++ b/src/wordpress/docker/image/console/root/lib/task/wp-cli/install.sh
@@ -4,7 +4,7 @@ function task_wp-cli_install()
 {
   if [ ! -f bin/wp-cli.phar ]; then
     mkdir -p bin
-    curl -o bin/wp-cli.phar https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
+    curl --fail --silent --show-error --location --output bin/wp-cli.phar https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
     chmod +x bin/wp-cli.phar
   fi
 }


### PR DESCRIPTION
Using full option names to make it clear what they do, and use --location except for on unsupported request methods