### PR TITLE
Deprecate istio sidecar shutdown on Job resources

### DIFF
--- a/src/_base/helm/app/templates/application/app-init.yaml
+++ b/src/_base/helm/app/templates/application/app-init.yaml
@@ -40,6 +40,7 @@ spec:
         image: {{ .image | quote }}
         imagePullPolicy: Always
         name: app-init
+# istio sidecar shutdown deprecated. istio uses sidecar lifecycle in k8s 1.18+
 {{ if eq $.Values.ingress.type "istio" }}
         command: ["/bin/sh"]
         args: ["-c", "/entrypoint.sh app init ; code=$? ; curl -vv -XPOST http://127.0.0.1:15020/quitquitquit ; exit $code"]

--- a/src/_base/helm/app/templates/application/app-migrate.yaml
+++ b/src/_base/helm/app/templates/application/app-migrate.yaml
@@ -38,6 +38,7 @@ spec:
         image: {{ .image }}
         imagePullPolicy: Always
         name: app-migrate
+# istio sidecar shutdown deprecated. istio uses sidecar lifecycle in k8s 1.18+
 {{ if eq $.Values.ingress.type "istio" }}
         command: ["/bin/sh"]
         args: ["-c", "/entrypoint.sh app migrate ; code=$? ; curl -vv -XPOST http://127.0.0.1:15020/quitquitquit ; exit $code"]


### PR DESCRIPTION
istio will use k8s 1.18 sidecar lifecycle to terminate once other containers have finished (also fixes container startup without the proxy being ready as well)