### PR TITLE
Introduce a ws rebuild command

### DIFF
--- a/src/_base/harness/config/commands.yml
+++ b/src/_base/harness/config/commands.yml
@@ -22,15 +22,21 @@ command('disable'):
 
 command('destroy'):
   env:
-    NAMESPACE:            = @('namespace')
-    APP_BUILD:            = @('app.build')
-    APP_VERSION:          = @('app.version')
-    DOCKER_REPOSITORY:    = @('docker.repository')
     USE_MUTAGEN:          = @('host.os') == 'darwin' and @('mutagen') == 'yes' ? 'yes':'no'
+    NAMESPACE:            = @('namespace')
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
     source .my127ws/harness/scripts/destroy.sh
+
+command('rebuild'):
+  env:
+    USE_MUTAGEN:          = @('host.os') == 'darwin' and @('mutagen') == 'yes' ? 'yes':'no'
+    NAMESPACE:            = @('namespace')
+    COMPOSE_PROJECT_NAME: = @('namespace')
+  exec: |
+    #!bash(workspace:/)|@
+    source .my127ws/harness/scripts/rebuild.sh
 
 command('networks external'):
   env:

--- a/src/_base/harness/scripts/rebuild.sh
+++ b/src/_base/harness/scripts/rebuild.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+run docker-compose down --rmi local --volumes --remove-orphans --timeout 120
+
+passthru ws cleanup built-images
+
+run rm -f .my127ws/.flag-built
+
+passthru ws enable


### PR DESCRIPTION
While `ws destroy; ws enable` can rebuild, it destroys the mutagen volume as well, which adds a lot of unnecessary time if the volume isn't 100% different to the project folder

This is in conjunction with #557, as ws enable will still destroy the mutagen volume without that