### PR TITLE
Fix spryker docker hosts having CI namespace issues

### DIFF
--- a/src/spryker/harness.yml
+++ b/src/spryker/harness.yml
@@ -91,7 +91,7 @@ attributes:
       @('yves.external_hosts'),
       @('zed.external_hosts'),
       @('zed_api.external_hosts')
-    ]), @('hostname'), @('namespace'))"
+    ]), '.' ~ @('domain'), '')"
   redis:
     protocol: redis
   rabbitmq:


### PR DESCRIPTION
Currently we rely on the hosts still matching the domain the same way as in dev