### PR TITLE
Do not remove sync container, make more responsive to stop

### DIFF
--- a/src/_base/harness/scripts/mutagen.sh
+++ b/src/_base/harness/scripts/mutagen.sh
@@ -52,7 +52,7 @@ setup_sync_container()
             done < <(echo "${VOLUME_MAPPINGS}" | grep "^${CONTAINER_NAME}" | cut -d ':' -f2- )
 
             # shellcheck disable=SC2046
-            passthru docker run -d --name "${CONTAINER_NAME}" $(printf -- '-v %q ' "${CONTAINER_VOLUME_MAPPINGS[@]}") alpine:latest tail -f /dev/null
+            passthru docker run -d --name "${CONTAINER_NAME}" $(printf -- '-v %q ' "${CONTAINER_VOLUME_MAPPINGS[@]}") alpine:latest /bin/sh -c "'trap : TERM INT; sleep 9999999999d & wait'"
         fi
     done
 }

--- a/src/_base/harness/scripts/mutagen.sh
+++ b/src/_base/harness/scripts/mutagen.sh
@@ -52,7 +52,7 @@ setup_sync_container()
             done < <(echo "${VOLUME_MAPPINGS}" | grep "^${CONTAINER_NAME}" | cut -d ':' -f2- )
 
             # shellcheck disable=SC2046
-            passthru "docker run -d --name '${CONTAINER_NAME}' $(printf -- '-v %q ' '${CONTAINER_VOLUME_MAPPINGS[@]}') alpine:latest /bin/sh -c 'trap : TERM INT; sleep 9999999999d & wait'"
+            passthru docker run -d --init --name "${CONTAINER_NAME}" $(printf -- '-v %q ' "${CONTAINER_VOLUME_MAPPINGS[@]}") alpine:latest tail -f /dev/null
         fi
     done
 }

--- a/src/_base/harness/scripts/mutagen.sh
+++ b/src/_base/harness/scripts/mutagen.sh
@@ -52,7 +52,7 @@ setup_sync_container()
             done < <(echo "${VOLUME_MAPPINGS}" | grep "^${CONTAINER_NAME}" | cut -d ':' -f2- )
 
             # shellcheck disable=SC2046
-            passthru docker run -d --name "${CONTAINER_NAME}" $(printf -- '-v %q ' "${CONTAINER_VOLUME_MAPPINGS[@]}") alpine:latest /bin/sh -c "'trap : TERM INT; sleep 9999999999d & wait'"
+            passthru "docker run -d --name '${CONTAINER_NAME}' $(printf -- '-v %q ' '${CONTAINER_VOLUME_MAPPINGS[@]}') alpine:latest /bin/sh -c 'trap : TERM INT; sleep 9999999999d & wait'"
         fi
     done
 }

--- a/src/_base/harness/scripts/mutagen.sh
+++ b/src/_base/harness/scripts/mutagen.sh
@@ -43,17 +43,17 @@ setup_sync_container()
     local CONTAINER_VOLUME_MAPPINGS
     local line
     for CONTAINER_NAME in "${CONTAINER_NAMES[@]}"; do
-        if [[ "$(docker ps -a -f "name=${CONTAINER_NAME}" --format '{{.Names}}')" == "${CONTAINER_NAME}" ]]; then
-            passthru docker rm -f "${CONTAINER_NAME}"
+        if [[ "$(docker ps --all --filter "name=${CONTAINER_NAME}\$" --format '{{.Names}}')" == "${CONTAINER_NAME}" ]]; then
+            passthru docker start "${CONTAINER_NAME}"
+        else
+            CONTAINER_VOLUME_MAPPINGS=()
+            while IFS= read -r line; do
+                CONTAINER_VOLUME_MAPPINGS+=("$line")
+            done < <(echo "${VOLUME_MAPPINGS}" | grep "^${CONTAINER_NAME}" | cut -d ':' -f2- )
+
+            # shellcheck disable=SC2046
+            passthru docker run -d --name "${CONTAINER_NAME}" $(printf -- '-v %q ' "${CONTAINER_VOLUME_MAPPINGS[@]}") alpine:latest tail -f /dev/null
         fi
-
-        CONTAINER_VOLUME_MAPPINGS=()
-        while IFS= read -r line; do
-            CONTAINER_VOLUME_MAPPINGS+=("$line")
-        done < <(echo "${VOLUME_MAPPINGS}" | grep "^${CONTAINER_NAME}" | cut -d ':' -f2- )
-
-        # shellcheck disable=SC2046
-        passthru docker run -d --name "${CONTAINER_NAME}" $(printf -- '-v %q ' "${CONTAINER_VOLUME_MAPPINGS[@]}") alpine:latest tail -f /dev/null
     done
 }
 


### PR DESCRIPTION
Do not remove the sync container during `ws mutagen start`.

Make `docker stop <syncContainer>` more responsive. The tail command seems to not handle the TERM signal that `docker stop` sends, so ends up waiting for 10 seconds to be KILLed by docker. `sleep` on it's own is also not responsive.