### PR TITLE
Use data path for Spryker twig cache

### DIFF
--- a/src/spryker/application/skeleton/config/Shared/config_local.php
+++ b/src/spryker/application/skeleton/config/Shared/config_local.php
@@ -23,7 +23,9 @@ use Spryker\Shared\SearchElasticsearch\SearchElasticsearchConstants;
 use Spryker\Shared\Session\SessionConstants;
 use Spryker\Shared\SessionRedis\SessionRedisConstants;
 use Spryker\Shared\StorageRedis\StorageRedisConstants;
+use Spryker\Shared\Twig\TwigConstants;
 use Spryker\Shared\ZedRequest\ZedRequestConstants;
+use Twig\Cache\FilesystemCache;
 
 $CURRENT_STORE = Store::getInstance()->getStoreName();
 
@@ -209,4 +211,28 @@ $config[KernelConstants::DOMAIN_WHITELIST] = [];
 $config[KernelConstants::PROJECT_NAMESPACES] = [
     'Inviqa',
     'Pyz',
+];
+
+// ---------- Twig
+$config[TwigConstants::YVES_TWIG_OPTIONS] = [
+    'cache' => new FilesystemCache(
+        sprintf(
+            '%s/data/%s/cache/%s/twig',
+            APPLICATION_ROOT_DIR,
+            $CURRENT_STORE,
+            APPLICATION
+        ),
+        FilesystemCache::FORCE_BYTECODE_INVALIDATION
+    ),
+];
+$config[TwigConstants::ZED_TWIG_OPTIONS] = [
+    'cache' => new FilesystemCache(
+        sprintf(
+            '%s/data/%s/cache/%s/twig',
+            APPLICATION_ROOT_DIR,
+            $CURRENT_STORE,
+            APPLICATION
+        ),
+        FilesystemCache::FORCE_BYTECODE_INVALIDATION
+    ),
 ];


### PR DESCRIPTION
Despite being deprecated in the 202009.0 release, we don't want to make src/Generated be web-writable, so re-introduce the configuration from the [202001.0 release](https://github.com/spryker-shop/b2c-demo-shop/blob/202001.0/config/Shared/config_default.php#L232-L254)

Without this we get a 500 response from Yves and Zed out of the box when in static mode, as the twig cache warmer doesn't warm all twig templates.