### PR TITLE
Switch to msmtp to avoid DNS issues with mhsendmail

### DIFF
--- a/src/_base/docker/image/console/Dockerfile.twig
+++ b/src/_base/docker/image/console/Dockerfile.twig
@@ -7,8 +7,16 @@ RUN chown -R build:build /home/build /app \
  # installing tools in the image is deprecated
  && ([ -e /sbin/tini ] || curl --fail --silent --show-error --location --output /sbin/tini https://github.com/krallin/tini/releases/download/v0.19.0/tini) \
  && chmod +x /sbin/tini \
- && ([ -e /usr/local/bin/mhsendmail ] || curl --fail --silent --show-error --location --output /usr/local/bin/mhsendmail https://github.com/mailhog/mhsendmail/releases/download/v0.2.0/mhsendmail_linux_amd64) \
- && chmod +x /usr/local/bin/mhsendmail \
+ && [ -e /usr/bin/msmtp ] || ( \
+    apt-get update -qq \
+    && DEBIAN_FRONTEND=noninteractive apt-get -qq -y --no-install-recommends install \
+    # package dependencies \
+      msmtp \
+    # clean \
+    && apt-get auto-remove -qq -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+ ) \
  && mkdir -p /tmp/php-file-cache \
  && chown -R build:build /tmp/php-file-cache
 {%- if @('php.composer.major_version') != '1' %} \

--- a/src/_base/docker/image/console/Dockerfile.twig
+++ b/src/_base/docker/image/console/Dockerfile.twig
@@ -7,16 +7,6 @@ RUN chown -R build:build /home/build /app \
  # installing tools in the image is deprecated
  && ([ -e /sbin/tini ] || curl --fail --silent --show-error --location --output /sbin/tini https://github.com/krallin/tini/releases/download/v0.19.0/tini) \
  && chmod +x /sbin/tini \
- && [ -e /usr/bin/msmtp ] || ( \
-    apt-get update -qq \
-    && DEBIAN_FRONTEND=noninteractive apt-get -qq -y --no-install-recommends install \
-    # package dependencies \
-      msmtp \
-    # clean \
-    && apt-get auto-remove -qq -y \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* \
- ) \
  && mkdir -p /tmp/php-file-cache \
  && chown -R build:build /tmp/php-file-cache
 {%- if @('php.composer.major_version') != '1' %} \

--- a/src/_base/docker/image/console/root/usr/local/bin/send_mail
+++ b/src/_base/docker/image/console/root/usr/local/bin/send_mail
@@ -2,4 +2,4 @@
 
 set -e
 
-/usr/local/bin/mhsendmail --smtp-addr="$SMTP_HOST:$SMTP_PORT" "$@"
+/usr/bin/msmtp --host="$SMTP_HOST" --port="$SMTP_PORT" --read-recipients --read-envelope-from -- "$@"

--- a/src/_base/docker/image/console/root/usr/local/bin/send_mail
+++ b/src/_base/docker/image/console/root/usr/local/bin/send_mail
@@ -2,4 +2,4 @@
 
 set -e
 
-/usr/bin/msmtp --host="$SMTP_HOST" --port="$SMTP_PORT" --read-recipients --read-envelope-from -- "$@"
+/usr/bin/msmtp --host="$SMTP_HOST" --port="$SMTP_PORT" --remove-bcc-headers=off --read-recipients --read-envelope-from --auto-from=on --maildomain="$APP_HOST" -- "$@"

--- a/src/_base/docker/image/php-fpm/Dockerfile.twig
+++ b/src/_base/docker/image/php-fpm/Dockerfile.twig
@@ -12,8 +12,16 @@ COPY root  /
 # installing tools in the image is deprecated
 RUN ([ -e /sbin/tini ] || curl --fail --silent --show-error --location --output /sbin/tini https://github.com/krallin/tini/releases/download/v0.19.0/tini) \
  && chmod +x /sbin/tini \
- && ([ -e /usr/local/bin/mhsendmail ] || curl --fail --silent --show-error --location --output /usr/local/bin/mhsendmail https://github.com/mailhog/mhsendmail/releases/download/v0.2.0/mhsendmail_linux_amd64) \
- && chmod +x /usr/local/bin/mhsendmail
+ && [ -e /usr/bin/msmtp ] || ( \
+    apt-get update -qq \
+    && DEBIAN_FRONTEND=noninteractive apt-get -qq -y --no-install-recommends install \
+    # package dependencies \
+      msmtp \
+    # clean \
+    && apt-get auto-remove -qq -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+ )
 
 {% set install_extensions=@('php.install_extensions')|merge(@('php.fpm.install_extensions'))|filter(v => v is not empty) %}
 {% if install_extensions %}

--- a/src/_base/docker/image/php-fpm/Dockerfile.twig
+++ b/src/_base/docker/image/php-fpm/Dockerfile.twig
@@ -11,17 +11,7 @@ COPY root  /
 
 # installing tools in the image is deprecated
 RUN ([ -e /sbin/tini ] || curl --fail --silent --show-error --location --output /sbin/tini https://github.com/krallin/tini/releases/download/v0.19.0/tini) \
- && chmod +x /sbin/tini \
- && [ -e /usr/bin/msmtp ] || ( \
-    apt-get update -qq \
-    && DEBIAN_FRONTEND=noninteractive apt-get -qq -y --no-install-recommends install \
-    # package dependencies \
-      msmtp \
-    # clean \
-    && apt-get auto-remove -qq -y \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* \
- )
+ && chmod +x /sbin/tini
 
 {% set install_extensions=@('php.install_extensions')|merge(@('php.fpm.install_extensions'))|filter(v => v is not empty) %}
 {% if install_extensions %}

--- a/src/_base/docker/image/php-fpm/root/usr/local/bin/send_mail
+++ b/src/_base/docker/image/php-fpm/root/usr/local/bin/send_mail
@@ -2,4 +2,4 @@
 
 set -e
 
-/usr/local/bin/mhsendmail --smtp-addr="$SMTP_HOST:$SMTP_PORT" "$@"
+/usr/bin/msmtp --host="$SMTP_HOST" --port="$SMTP_PORT" --read-recipients --read-envelope-from -- "$@"

--- a/src/_base/docker/image/php-fpm/root/usr/local/bin/send_mail
+++ b/src/_base/docker/image/php-fpm/root/usr/local/bin/send_mail
@@ -2,4 +2,4 @@
 
 set -e
 
-/usr/bin/msmtp --host="$SMTP_HOST" --port="$SMTP_PORT" --read-recipients --read-envelope-from -- "$@"
+/usr/bin/msmtp --host="$SMTP_HOST" --port="$SMTP_PORT" --remove-bcc-headers=off --read-recipients --read-envelope-from --auto-from=on --maildomain="$APP_HOST" -- "$@"


### PR DESCRIPTION
@elvetemedve is having issues with mhsendmail resolving `mailhog-relay` incorrectly due to being compiled with an older go version and not picking up on docker's `options nodots:0` in resolv.conf

Using msmtp allows us to bypass this issue.