### PR TITLE
Clean up old mutagen sync sessions

### DIFF
--- a/src/_base/harness/config/mutagen.yml
+++ b/src/_base/harness/config/mutagen.yml
@@ -31,6 +31,23 @@ function('get_mutagen_volume_containers'): |
   }
   = join("\n", array_unique($volumeContainers));
 
+function('get_mutagen_volume_mappings'): |
+  #!php
+  $volumeMappings = [];
+
+  if (file_exists('mutagen.yml')) {
+    $configRaw = file_get_contents('mutagen.yml');
+    $config = \Symfony\Component\Yaml\Yaml::parse($configRaw);
+
+    if (isset($config['sync']))  {
+      foreach ($config['sync'] as $syncName => $syncConfig) {
+        $parts = parse_url($syncConfig['beta']);
+        $volumeMappings[] = $parts['host'] . ':' . $syncName . '-sync:' . $parts['path'];
+      }
+    }
+  }
+  = join("\n", $volumeMappings);
+
 function('get_mutagen_forward_names'): |
   #!php
   $forwardNames = [];
@@ -58,23 +75,6 @@ function('get_mutagen_sync_names'): |
     }
   }
   = join("\n", array_unique($syncNames));
-
-function('get_mutagen_volume_mappings'): |
-  #!php
-  $volumeMappings = [];
-
-  if (file_exists('mutagen.yml')) {
-    $configRaw = file_get_contents('mutagen.yml');
-    $config = \Symfony\Component\Yaml\Yaml::parse($configRaw);
-
-    if (isset($config['sync']))  {
-      foreach ($config['sync'] as $syncName => $syncConfig) {
-        $parts = parse_url($syncConfig['beta']);
-        $volumeMappings[] = $parts['host'] . ':' . $syncName . '-sync:' . $parts['path'];
-      }
-    }
-  }
-  = join("\n", $volumeMappings);
 
 command('mutagen (start|stop|pause|resume)'):
   env:

--- a/src/_base/harness/config/mutagen.yml
+++ b/src/_base/harness/config/mutagen.yml
@@ -31,6 +31,20 @@ function('get_mutagen_volume_containers'): |
   }
   = join("\n", array_unique($volumeContainers));
 
+function('get_mutagen_forward_names'): |
+  #!php
+  $forwardNames = [];
+
+  if (file_exists('mutagen.yml')) {
+    $configRaw = file_get_contents('mutagen.yml');
+    $config = \Symfony\Component\Yaml\Yaml::parse($configRaw);
+
+    if (isset($config['forward']))  {
+      $forwardNames = array_keys($config['forward']);
+    }
+  }
+  = join("\n", array_unique($forwardNames));
+
 function('get_mutagen_sync_names'): |
   #!php
   $syncNames = [];
@@ -66,6 +80,7 @@ command('mutagen (start|stop|pause|resume)'):
   env:
     COMMAND: = input.command(2)
     CONTAINER_NAMES: = get_mutagen_volume_containers()
+    FORWARD_NAMES: = get_mutagen_forward_names()
     SYNC_NAMES: = get_mutagen_sync_names()
     VOLUME_MAPPINGS: = get_mutagen_volume_mappings()
   exec: |
@@ -75,6 +90,7 @@ command('mutagen (start|stop|pause|resume)'):
 command('mutagen rm'):
   env:
     CONTAINER_NAMES: = get_mutagen_volume_containers()
+    FORWARD_NAMES: = get_mutagen_forward_names()
     SYNC_NAMES: = get_mutagen_sync_names()
   exec: |
      #!bash(workspace:/)

--- a/src/_base/harness/config/mutagen.yml
+++ b/src/_base/harness/config/mutagen.yml
@@ -31,6 +31,20 @@ function('get_mutagen_volume_containers'): |
   }
   = join("\n", array_unique($volumeContainers));
 
+function('get_mutagen_sync_names'): |
+  #!php
+  $syncNames = [];
+
+  if (file_exists('mutagen.yml')) {
+    $configRaw = file_get_contents('mutagen.yml');
+    $config = \Symfony\Component\Yaml\Yaml::parse($configRaw);
+
+    if (isset($config['sync']))  {
+      $syncNames = array_keys($config['sync']);
+    }
+  }
+  = join("\n", array_unique($syncNames));
+
 function('get_mutagen_volume_mappings'): |
   #!php
   $volumeMappings = [];
@@ -52,6 +66,7 @@ command('mutagen (start|stop|pause|resume)'):
   env:
     COMMAND: = input.command(2)
     CONTAINER_NAMES: = get_mutagen_volume_containers()
+    SYNC_NAMES: = get_mutagen_sync_names()
     VOLUME_MAPPINGS: = get_mutagen_volume_mappings()
   exec: |
     #!bash(workspace:/)
@@ -60,6 +75,7 @@ command('mutagen (start|stop|pause|resume)'):
 command('mutagen rm'):
   env:
     CONTAINER_NAMES: = get_mutagen_volume_containers()
+    SYNC_NAMES: = get_mutagen_sync_names()
   exec: |
      #!bash(workspace:/)
      CONTAINER_NAMES=($CONTAINER_NAMES)

--- a/src/_base/harness/scripts/mutagen.sh
+++ b/src/_base/harness/scripts/mutagen.sh
@@ -98,7 +98,6 @@ clean_existing_projects()
     local FORWARD_LIST
     local CONTAINER_NAMES_REGEX
     CONTAINER_NAMES_REGEX="$(join_by_character "\|" "${CONTAINER_NAMES[@]}")"
-    echo $CONTAINER_NAMES_REGEX; exit
     for FORWARD_NAME in ${FORWARD_NAMES[*]}; do
         # List forwards based on name
         FORWARD_LIST="$(mutagen forward list "$FORWARD_NAME" 2> /dev/null || true)"

--- a/src/_base/harness/scripts/mutagen.sh
+++ b/src/_base/harness/scripts/mutagen.sh
@@ -78,7 +78,7 @@ clean_existing_projects()
         # List syncs based on name
         SYNC_LIST="$(mutagen sync list "$SYNC_NAME" 2> /dev/null || true)"
         # Check if there are entries left
-        if [ "$(echo "$SYNC_LIST" | grep "URL: $(pwd)" | wc -l | awk '{ print $1 }')" -gt 0 ]; then
+        if [ "$(echo "$SYNC_LIST" | grep --count "URL: $(pwd)" | awk '{ print $1 }')" -gt 0 ]; then
             # Build an array of sync session IDs to clean up
             while IFS='' read -r line; do EXISTING_SYNC_IDS+=("$line"); done < <(echo "$SYNC_LIST" | grep --before-context=6 "URL: $(pwd)" | grep Identifier: | cut -d" " -f2)
         fi

--- a/src/_base/harness/scripts/mutagen.sh
+++ b/src/_base/harness/scripts/mutagen.sh
@@ -76,7 +76,7 @@ clean_existing_projects()
     local SYNC_LIST=""
     for SYNC_NAME in ${SYNC_NAMES[*]}; do
         # List syncs based on name
-        SYNC_LIST="$(mutagen sync list "$SYNC_NAME")"
+        SYNC_LIST="$(mutagen sync list "$SYNC_NAME" 2> /dev/null || true)"
         # Check if there are entries left
         if [ "$(echo "$SYNC_LIST" | grep "URL: $(pwd)" | wc -l | awk '{ print $1 }')" -gt 0 ]; then
             # Build an array of sync session IDs to clean up
@@ -89,7 +89,7 @@ clean_existing_projects()
         echo "This can lead to increased CPU usage."
         local REPLY=""
         if [ -t 0 ] ; then
-          read -p 'Do you want to remove the other sync sessions? [Yes]/no: ' REPLY
+          read -r -p 'Do you want to remove the other sync sessions? [Yes]/no: ' REPLY
         fi
         REPLY="${REPLY:-Yes}"
         if ! [[ "$REPLY" =~ ^(Y|Yes|y|yes)$ ]]; then


### PR DESCRIPTION
We've seen a load average of 48 on a developer's machine due to multiple sync sessions. This reduced to less than 5 after cleaning up the old sync sessions.

This situation can arise if `mutagen.yml.lock` is removed (e.g. a clean checkout) and `ws mutagen start` or `ws install` is called on macOS.

`mutagen.yml.lock` contains a project ID that `mutagen project` uses to link to the sync and forward sessions.