### PR TITLE
Assets need to be included in the console build

### DIFF
--- a/src/_base/harness/scripts/enable.sh.twig
+++ b/src/_base/harness/scripts/enable.sh.twig
@@ -64,6 +64,11 @@ enable_console() {
 
     passthru ws networks external
     passthru ws external-images pull console
+
+    if [ "$HAS_ASSETS" = yes ]; then
+        ws assets download
+    fi
+
     "${APP_BUILD}_console"
 }
 

--- a/src/_base/harness/scripts/enable.sh.twig
+++ b/src/_base/harness/scripts/enable.sh.twig
@@ -64,11 +64,6 @@ enable_console() {
 
     passthru ws networks external
     passthru ws external-images pull console
-
-    if [ "$HAS_ASSETS" = yes ]; then
-        ws assets download
-    fi
-
     "${APP_BUILD}_console"
 }
 
@@ -121,6 +116,9 @@ dynamic()
 
 static_console()
 {
+    if [ "$HAS_ASSETS" = yes ]; then
+        ws assets download
+    fi
     passthru docker-compose up --build -d console
 }
 


### PR DESCRIPTION
To avoid a rebuild of the console image with `ws install`, after `ws enable console` in pipeline mode, we need to have all files in the local directory before the build.