### PR TITLE
Fix asking for shutdown

### DIFF
--- a/src/_base/harness/scripts/enable.sh.twig
+++ b/src/_base/harness/scripts/enable.sh.twig
@@ -32,7 +32,7 @@ enable_all()
         if [ "$HAS_FLAG" = no ]; then
             # remove all services, keeping console if considered built
             if console_enabled; then
-                passthru "docker-compose ps --services | grep -v -Fxe console | xargs docker-compose rm --stop --"
+                passthru "docker-compose ps --services | grep -v -Fxe console | xargs docker-compose rm --force --stop --"
             else
                 passthru docker-compose down
             fi


### PR DESCRIPTION
`docker-compose rm` needs `--force` to avoid asking if containers should be destroyed (`ws install` doesn't wait for your response)