### PR TITLE
Bring up mailhog in Jenkins, for integration tests that send emails

### DIFF
--- a/src/_base/application/overlay/Jenkinsfile.twig
+++ b/src/_base/application/overlay/Jenkinsfile.twig
@@ -46,7 +46,11 @@ pipeline {
 {% if @('jenkins.tests.isolated') %}
         stage('Build') {
             steps {
+{% if @('jenkins.tests.use_global_services') %}
                 sh 'ws install'
+{% else %}
+                sh 'ws enable'
+{% endif %}
                 milestone(30)
             }
         }

--- a/src/_base/application/overlay/Jenkinsfile.twig
+++ b/src/_base/application/overlay/Jenkinsfile.twig
@@ -46,7 +46,7 @@ pipeline {
 {% if @('jenkins.tests.isolated') %}
         stage('Build') {
             steps {
-                sh 'ws enable'
+                sh 'ws install'
                 milestone(30)
             }
         }

--- a/src/_base/harness/attributes/common.yml
+++ b/src/_base/harness/attributes/common.yml
@@ -30,6 +30,7 @@ attributes.default:
         enabled: true
     tests:
       isolated: true
+      use_global_services: false
 
   pipeline:
     base:

--- a/src/drupal8/application/overlay/Jenkinsfile.twig
+++ b/src/drupal8/application/overlay/Jenkinsfile.twig
@@ -45,7 +45,11 @@ pipeline {
 {% if @('jenkins.tests.isolated') %}
         stage('Build') {
             steps {
+{% if @('jenkins.tests.use_global_services') %}
                 sh 'ws install'
+{% else %}
+                sh 'ws enable'
+{% endif %}
                 milestone(30)
             }
         }

--- a/src/drupal8/application/overlay/Jenkinsfile.twig
+++ b/src/drupal8/application/overlay/Jenkinsfile.twig
@@ -45,7 +45,7 @@ pipeline {
 {% if @('jenkins.tests.isolated') %}
         stage('Build') {
             steps {
-                sh 'ws enable'
+                sh 'ws install'
                 milestone(30)
             }
         }


### PR DESCRIPTION
`ws enable` doesn't bring up global services like traefik or mailhog, but `ws install` does.

I've seen a project that tries to send email to mailhog during a run of behat, so this may be needed if we can't fix that behaviour easily.