### PR TITLE
Add Varnish to Drupal

### DIFF
--- a/src/_base/harness/attributes/common.yml
+++ b/src/_base/harness/attributes/common.yml
@@ -377,6 +377,8 @@ attributes.default:
     port: 1025
 
   varnish:
+    response:
+      s-maxage: ~
     target_service: nginx
 
   replicas:

--- a/src/drupal8/.ci/sample-dynamic/workspace.yml
+++ b/src/drupal8/.ci/sample-dynamic/workspace.yml
@@ -17,5 +17,6 @@ attribute('services.solr.enabled'): true
 attribute('services.solr.major_version'): 4
 
 attribute('services.varnish.enabled'): true
+attribute('varnish.response.s-maxage'): 3600
 
 attribute('composer.auth.github'): = decrypt("YTozOntpOjA7czo3OiJkZWZhdWx0IjtpOjE7czoyNDoiZfbsRN210rxOzGyHhH74tuXtFxak6prxIjtpOjI7czo1Njoi7NjB2oXZJ3/wQsccea2VPeYEjU72koVub89ezkdQzAzOaaFwD2Rm1pbhWXR7aYgpUdXmNmO8g5YiO30=")

--- a/src/drupal8/.ci/sample-dynamic/workspace.yml
+++ b/src/drupal8/.ci/sample-dynamic/workspace.yml
@@ -16,4 +16,6 @@ attribute('hostname_aliases'):
 attribute('services.solr.enabled'): true
 attribute('services.solr.major_version'): 4
 
+attribute('services.varnish.enabled'): true
+
 attribute('composer.auth.github'): = decrypt("YTozOntpOjA7czo3OiJkZWZhdWx0IjtpOjE7czoyNDoiZfbsRN210rxOzGyHhH74tuXtFxak6prxIjtpOjI7czo1Njoi7NjB2oXZJ3/wQsccea2VPeYEjU72koVub89ezkdQzAzOaaFwD2Rm1pbhWXR7aYgpUdXmNmO8g5YiO30=")

--- a/src/drupal8/application/skeleton/composer.json.twig
+++ b/src/drupal8/application/skeleton/composer.json.twig
@@ -110,7 +110,17 @@
       "modules": [
         "docroot/core/modules/",
         "docroot/modules/contrib/",
-        "docroot/modules/custom/"
+        "docroot/modules/custom/",
+        "docroot/modules/contrib/admin_toolbar/",
+        "docroot/modules/contrib/ctools/modules/",
+        "docroot/modules/contrib/devel/",
+        "docroot/modules/contrib/environment_indicator/modules/",
+        "docroot/modules/contrib/field_group/contrib/",
+        "docroot/modules/contrib/hook_event_dispatcher/modules/",
+        "docroot/modules/contrib/metatag/",
+        "docroot/modules/contrib/purge/modules/",
+        "docroot/modules/contrib/redirect/modules/",
+        "docroot/modules/contrib/varnish_purge/modules/"
       ]
     },
     "drupal-scaffold": {

--- a/src/drupal8/application/skeleton/composer.json.twig
+++ b/src/drupal8/application/skeleton/composer.json.twig
@@ -33,6 +33,9 @@
     "drupal/environment_indicator": "^3.0",
     "drupal/field_group": "^3.0@beta",
     "drupal/hook_event_dispatcher": "^1.20",
+{% if @('services.varnish.enabled') %}
+    "drupal/http_cache_control": "^2.0",
+{% endif %}
     "drupal/inline_entity_form": "^1.0-rc1",
     "drupal/linkit": "^4.3.0",
     "drupal/login_emailusername": "1.1",

--- a/src/drupal8/application/skeleton/composer.json.twig
+++ b/src/drupal8/application/skeleton/composer.json.twig
@@ -39,6 +39,7 @@
     "drupal/menu_admin_per_menu": "1.0",
     "drupal/metatag": "1.7",
     "drupal/pathauto": "^1.8",
+    "drupal/purge": "^3.0",
     "drupal/redirect": "1.3",
     "drupal/roleassign": "^1.0@alpha",
     "drupal/seckit": "1.1",
@@ -46,6 +47,9 @@
     "drupal/taxonomy_access_fix": "2.6",
     "drupal/token": "1.5",
     "drupal/ultimate_cron": "2.x-dev",
+{% if @('services.varnish.enabled') %}
+    "drupal/varnish_purge": "^2.0",
+{% endif %}
     "drush/drush": "^8",
     "fenetikm/autoload-drupal": "dev-master#4503484bf2d78e6d739fe13324ab3e6b96d7c244",
     "oomphinc/composer-installers-extender": "^2.0"
@@ -62,6 +66,13 @@
     "phpcompatibility/php-compatibility": "dev-master",
     "phpstan/phpstan": "^0.12",
     "phpstan/phpstan-deprecation-rules": "^0.12"
+  },
+  "autoload": {
+    "psr-4": {
+{% if @('services.varnish.enabled') %}
+      "Drupal\\varnish_purger\\": "docroot/modules/contrib/varnish_purge/src/"
+{% endif %}
+    }
   },
   "autoload-dev": {
     "psr-4": {

--- a/src/drupal8/docker/image/varnish/root/etc/varnish/default.vcl.twig
+++ b/src/drupal8/docker/image/varnish/root/etc/varnish/default.vcl.twig
@@ -9,6 +9,8 @@
 # 4.0 or 4.1 syntax.
 vcl 4.0;
 
+import std;
+
 # Default backend definition. Set this to point to your content server.
 backend default {
     .host = "{% if varnish.target_service is defined %}{{ varnish.target_service }}{% else %}{{ @('varnish.target_service') }}{% endif %}";

--- a/src/drupal8/docker/image/varnish/root/etc/varnish/default.vcl.twig
+++ b/src/drupal8/docker/image/varnish/root/etc/varnish/default.vcl.twig
@@ -1,16 +1,13 @@
 #
-# This is an example VCL file for Varnish.
-#
-# It does not do anything by default, delegating control to the
-# builtin VCL. The builtin VCL is called when there is no explicit
-# return statement.
+# This is a VCL adapted from geerlingguy/drupal-vm
+# https://github.com/geerlingguy/drupal-vm/blob/0c3af7da053d3720e8b93e49a8d573489106c8ba/provisioning/templates/drupalvm.vcl.j2
 #
 # See the VCL chapters in the Users Guide for a comprehensive documentation
 # at https://www.varnish-cache.org/docs/.
 
 # Marker to tell the VCL compiler that this VCL has been written with the
 # 4.0 or 4.1 syntax.
-vcl 4.1;
+vcl 4.0;
 
 # Default backend definition. Set this to point to your content server.
 backend default {
@@ -19,46 +16,162 @@ backend default {
     .first_byte_timeout = {{ @('php.fpm.ini.max_execution_time') + 2 }}s;
 }
 
-# From https://support.acquia.com/hc/en-us/articles/360005540293-Simplified-VCL-for-Varnish
+# Access control list for PURGE requests.
+acl purge {
+    "localhost";
+    "10.0.0.0"/8;
+    "172.16.0.0"/12;
+    "192.168.0.0"/16;
+}
+
 sub vcl_recv {
     # Happens before we check if we have this in cache already.
     #
     # Typically you clean up the request here, removing cookies you don't need,
     # rewriting the request, etc.
 
-    if (req.http.X-Forwarded-For) {
-        set req.http.X-Forwarded-For = req.http.X-Forwarded-For + ", " + client.ip;
-    } else {
-        set req.http.X-Forwarded-For = client.ip;
+    # Add an X-Forwarded-For header with the client IP address.
+    if (req.restarts == 0) {
+        if (req.http.X-Forwarded-For) {
+            set req.http.X-Forwarded-For = req.http.X-Forwarded-For + ", " + client.ip;
+        }
+        else {
+            set req.http.X-Forwarded-For = client.ip;
+        }
     }
-    if (req.request != "GET" && req.request != "HEAD") {
-        return(pass);
+
+    # Only allow PURGE requests from IP addresses in the 'purge' ACL.
+    if (req.method == "PURGE") {
+        if (!client.ip ~ purge) {
+            return (synth(405, "Not allowed."));
+        }
+        return (purge);
     }
-    if(req.url ~ "^/cron.php") {
-        return(pass);
+
+    # Only allow BAN requests from IP addresses in the 'purge' ACL.
+    if (req.method == "BAN") {
+        # Same ACL check as above:
+        if (!client.ip ~ purge) {
+            return (synth(403, "Not allowed."));
+        }
+
+        # Logic for the ban, using the Cache-Tags header. For more info
+        # see https://github.com/geerlingguy/drupal-vm/issues/397.
+        if (req.http.Cache-Tags) {
+            ban("obj.http.Cache-Tags ~ " + req.http.Cache-Tags);
+        }
+        else {
+            return (synth(403, "Cache-Tags header missing."));
+        }
+
+        # Throw a synthetic page so the request won't go to the backend.
+        return (synth(200, "Ban added."));
     }
-    if(req.url ~ "^/xmlrpc.php") {
-        return(pass);
+
+    # Only cache GET and HEAD requests (pass through POST requests).
+    if (req.method != "GET" && req.method != "HEAD") {
+        return (pass);
     }
-    if (req.http.Authorization) {
-        return(pass);
+
+    # Pass through any administrative or AJAX-related paths.
+    if (req.url ~ "^/status\.php$" ||
+        req.url ~ "^/update\.php$" ||
+        req.url ~ "^/admin$" ||
+        req.url ~ "^/admin/.*$" ||
+        req.url ~ "^/flag/.*$" ||
+        req.url ~ "^.*/ajax/.*$" ||
+        req.url ~ "^.*/ahah/.*$") {
+           return (pass);
     }
-    if (req.http.cookie ~ "(^|;\s*)(SESS=)") {
-        return(pass);
+
+    # Removing cookies for static content so Varnish caches these files.
+    if (req.url ~ "(?i)\.(pdf|asc|dat|txt|doc|xls|ppt|tgz|csv|png|gif|jpeg|jpg|ico|swf|css|js)(\?.*)?$") {
+        unset req.http.Cookie;
     }
-    return(lookup);
+
+    # Remove all cookies that Drupal doesn't need to know about. We explicitly
+    # list the ones that Drupal does need, the SESS and NO_CACHE. If, after
+    # running this code we find that either of these two cookies remains, we
+    # will pass as the page cannot be cached.
+    if (req.http.Cookie) {
+        # 1. Append a semi-colon to the front of the cookie string.
+        # 2. Remove all spaces that appear after semi-colons.
+        # 3. Match the cookies we want to keep, adding the space we removed
+        #    previously back. (\1) is first matching group in the regsuball.
+        # 4. Remove all other cookies, identifying them by the fact that they have
+        #    no space after the preceding semi-colon.
+        # 5. Remove all spaces and semi-colons from the beginning and end of the
+        #    cookie string.
+        set req.http.Cookie = ";" + req.http.Cookie;
+        set req.http.Cookie = regsuball(req.http.Cookie, "; +", ";");
+        set req.http.Cookie = regsuball(req.http.Cookie, ";(SESS[a-z0-9]+|SSESS[a-z0-9]+|NO_CACHE)=", "; \1=");
+        set req.http.Cookie = regsuball(req.http.Cookie, ";[^ ][^;]*", "");
+        set req.http.Cookie = regsuball(req.http.Cookie, "^[; ]+|[; ]+$", "");
+
+        if (req.http.Cookie == "") {
+            # If there are no remaining cookies, remove the cookie header. If there
+            # aren't any cookie headers, Varnish's default behavior will be to cache
+            # the page.
+            unset req.http.Cookie;
+        }
+        else {
+            # If there is any cookies left (a session or NO_CACHE cookie), do not
+            # cache the page. Pass it on to Apache directly.
+            return (pass);
+        }
+    }
 }
 
-sub vcl_backend_response {
-    # Happens after we have read the response headers from the backend.
-    #
-    # Here you clean the response headers, removing silly Set-Cookie headers
-    # and other mistakes your backend does.
-}
-
+# Set a header to track a cache HITs and MISSes.
 sub vcl_deliver {
     # Happens when we have all the pieces we need, and are about to send the
     # response to the client.
     #
     # You can do accounting or modifying the final object here.
+
+    # Remove ban-lurker friendly custom headers when delivering to client.
+    unset resp.http.X-Url;
+    unset resp.http.X-Host;
+    unset resp.http.Purge-Cache-Tags;
+
+    if (obj.hits > 0) {
+        set resp.http.X-Varnish-Cache = "HIT";
+    }
+    else {
+        set resp.http.X-Varnish-Cache = "MISS";
+    }
+}
+
+# Instruct Varnish what to do in the case of certain backend responses (beresp).
+sub vcl_backend_response {
+    # Happens after we have read the response headers from the backend.
+    #
+    # Here you clean the response headers, removing silly Set-Cookie headers
+    # and other mistakes your backend does.
+
+    # Set ban-lurker friendly custom headers.
+    set beresp.http.X-Url = bereq.url;
+    set beresp.http.X-Host = bereq.http.host;
+
+    # Cache 404s, 301s, at 500s with a short lifetime to protect the backend.
+    if (beresp.status == 404 || beresp.status == 301 || beresp.status == 500) {
+        set beresp.ttl = 10m;
+    }
+
+    # Enable streaming directly to backend for BigPipe responses.
+    if (beresp.http.Surrogate-Control ~ "BigPipe/1.0") {
+        set beresp.do_stream = true;
+        set beresp.ttl = 0s;
+    }
+
+    # Don't allow static files to set cookies.
+    # (?i) denotes case insensitive in PCRE (perl compatible regular expressions).
+    # This list of extensions appears twice, once here and again in vcl_recv so
+    # make sure you edit both and keep them equal.
+    if (bereq.url ~ "(?i)\.(pdf|asc|dat|txt|doc|xls|ppt|tgz|csv|png|gif|jpeg|jpg|ico|swf|css|js)(\?.*)?$") {
+        unset beresp.http.set-cookie;
+    }
+
+    # Allow items to remain in cache up to 6 hours past their cache expiration.
+    set beresp.grace = 6h;
 }

--- a/src/drupal8/docker/image/varnish/root/etc/varnish/default.vcl.twig
+++ b/src/drupal8/docker/image/varnish/root/etc/varnish/default.vcl.twig
@@ -1,0 +1,64 @@
+#
+# This is an example VCL file for Varnish.
+#
+# It does not do anything by default, delegating control to the
+# builtin VCL. The builtin VCL is called when there is no explicit
+# return statement.
+#
+# See the VCL chapters in the Users Guide for a comprehensive documentation
+# at https://www.varnish-cache.org/docs/.
+
+# Marker to tell the VCL compiler that this VCL has been written with the
+# 4.0 or 4.1 syntax.
+vcl 4.1;
+
+# Default backend definition. Set this to point to your content server.
+backend default {
+    .host = "{% if varnish.target_service is defined %}{{ varnish.target_service }}{% else %}{{ @('varnish.target_service') }}{% endif %}";
+    .port = "80";
+    .first_byte_timeout = {{ @('php.fpm.ini.max_execution_time') + 2 }}s;
+}
+
+# From https://support.acquia.com/hc/en-us/articles/360005540293-Simplified-VCL-for-Varnish
+sub vcl_recv {
+    # Happens before we check if we have this in cache already.
+    #
+    # Typically you clean up the request here, removing cookies you don't need,
+    # rewriting the request, etc.
+
+    if (req.http.X-Forwarded-For) {
+        set req.http.X-Forwarded-For = req.http.X-Forwarded-For + ", " + client.ip;
+    } else {
+        set req.http.X-Forwarded-For = client.ip;
+    }
+    if (req.request != "GET" && req.request != "HEAD") {
+        return(pass);
+    }
+    if(req.url ~ "^/cron.php") {
+        return(pass);
+    }
+    if(req.url ~ "^/xmlrpc.php") {
+        return(pass);
+    }
+    if (req.http.Authorization) {
+        return(pass);
+    }
+    if (req.http.cookie ~ "(^|;\s*)(SESS=)") {
+        return(pass);
+    }
+    return(lookup);
+}
+
+sub vcl_backend_response {
+    # Happens after we have read the response headers from the backend.
+    #
+    # Here you clean the response headers, removing silly Set-Cookie headers
+    # and other mistakes your backend does.
+}
+
+sub vcl_deliver {
+    # Happens when we have all the pieces we need, and are about to send the
+    # response to the client.
+    #
+    # You can do accounting or modifying the final object here.
+}

--- a/src/drupal8/docker/image/varnish/root/etc/varnish/default.vcl.twig
+++ b/src/drupal8/docker/image/varnish/root/etc/varnish/default.vcl.twig
@@ -142,6 +142,15 @@ sub vcl_deliver {
     else {
         set resp.http.X-Varnish-Cache = "MISS";
     }
+
+{% if @('varnish.response.s-maxage') and @('varnish.response.s-maxage') > 0 %}
+    # Respond to upstream proxies with a lower s-maxage
+    if (std.integer(regsub(resp.http.cache-control,
+"(^|.*,)(\s*)s-maxage=([0-9]+)(\s*)(,.*|$)", "\3"), 0) > {{ @('varnish.response.s-maxage') }}) {
+        set resp.http.cache-control = regsub(resp.http.cache-control,
+"(^|.*,)(\s*)s-maxage=([0-9]+)(\s*)(,.*|$)", "\1\2s-maxage={{ @('varnish.response.s-maxage') }}\4\5");
+    }
+{% endif %}
 }
 
 # Instruct Varnish what to do in the case of certain backend responses (beresp).

--- a/src/drupal8/docs/customise/advanced.md
+++ b/src/drupal8/docs/customise/advanced.md
@@ -62,6 +62,123 @@ support newer versions.
 To support v4, we build a custom docker image based on the official v5 image, and overwrite the solr installation with
 the unsupported version.
 
+## Adding Varnish
+
+Opt in to using varnish with the following in your workspace.yml:
+```yaml
+attribute('services.varnish.enabled'): true
+```
+
+To apply changes to your local environment, run `ws harness prepare && docker-compose up -d`.
+
+The harness ships with a version of the [geerlingguy/drupal-vm Varnish VCL], which supports the `purge_varnish` module as well as only allowing certain cookies to impact cachability of requests.
+
+Acquia ships with varnish enabled by default and has a custom Varnish VCL.
+
+The VCL configuration shipped in the harness can be used to try to replicate what is used in Acquia, but you should enable the `acquia_purge` module for Acquia environments.
+
+### Caching Content
+
+To have content cached, we need to tune drupal to allow anonymous requests for pages to be cached.
+
+As an admin, visit `/admin/config/development/performance` to set "Browser and proxy cache maximum age" to a value other than "none", e.g. "1 hour"
+
+Alternatively you can edit `config/sync/system.performance.yml` to specify the number of seconds to cache for, and import the configuration:
+```yaml
+cache:
+  page:
+    max_age: 3600
+```
+
+Note that this also means to cache in browsers for the time specified in addition to varnish (so if you specify one hour, it can take two hours for people to receive updated content).
+
+This time increases further if you have additional proxy caches such as Cloudflare in between the browser and varnish that are set to cache HTML content.
+
+See "Cache in browsers for less time than Varnish and other proxy caches" below for how to avoid this.
+
+#### Testing
+
+Verify with `curl` that pages are now cacheable in varnish and browsers:
+```bash
+curl --silent --head --request GET https://project-name.my127.site/ | grep -iE '^(HTTP/|age|cache-control)'
+```
+If successful, repeated calls to curl should give the following headers, with age increasing based on the time in seconds since cached:
+```
+HTTP/2 200
+age: 118
+cache-control: max-age=3600, public
+```
+
+### Purging Content On Changes
+
+By default, varnish will cache content for your desired time period and not reflect changes for anonymous visits
+until the time period expires.
+
+In the case of short time periods, this may be fine, but Drupal's Cache Tags system allows us to purge varnish when a node (or even a block used in a node) is updated.
+
+To configure this, enable the following modules:
+- purge
+- purge_drush
+- purge_processor_cron
+- purge_processor_lateruntime
+- purge_queuer_coretags
+- purge_ui
+- varnish_purge_tags
+- varnish_purger
+
+A purger will need to be set up at `/admin/config/development/performance/purge`.
+
+Add a "Varnish" purger and configure it:
+* Type "Tag" (the default)
+* Request should be to hostname `varnish`, port `80`, path `/`, request method `BAN`, scheme `http`
+* Headers should be `Cache-Tags` mapped to `[invalidation:expression]`
+
+#### Testing
+
+Test that the purger queue is working by testing with `curl` that a page is still cacheable in varnish and browsers:
+```bash
+curl --silent --head --request GET https://project-name.my127.site/ | grep -iE '^(HTTP/|age|cache-control)'
+HTTP/2 200
+age: 118
+cache-control: max-age=3600, public
+```
+
+You can also verify that varnish receives a `BAN` request with the following varnishlog query:
+```bash
+docker-compose exec varnish varnishlog -q 'ReqMethod ~ BAN'
+```
+
+Now edit the homepage. Once you hit the Save button on the edit page, varnish should receive a ban request through.
+
+Repeating the curl request should show an `age` header that is lower than before.
+
+### Cache in browsers for less time than Varnish and other proxy caches
+
+Enable the `http_cache_control` module, which allows you to configure browser based caching separately from proxy based caching.
+
+Assuming there aren't any further proxy caches (e.g. Cloudflare) in front of varnish, you can increase the s-maxage
+setting to a very high value (even a year!), as with the purge_varnish module working, varnish will be kept up to
+date with changes automatically. Browsers will check in with varnish each time the browser cache (max-age) expires.
+
+s-maxage time periods over a day will need [this issue's patch], but do read the comments.
+
+If you do have other proxy caches in front of varnish, you will either have to purge the upstream proxy cache with
+another purge plugin, or keep the s-maxage setting low as with a s-maxage of 1 month, it can take 2 months for
+visitors to be able to see changes!
+
+With control over the varnish VCL, it should be possible to alter the cache-control header in the response to the upstream proxy to lower the `s-maxage` value, but keeping the high "ttl" in terms of storage in varnish.
+
+#### Testing
+
+Again with curl, check that there's a cache-control header and an age that is increasing, meaning it's in cache.
+The max-age setting should reflect your "browser cache" time in seconds, and `s-maxage` should reflect your "proxy cache" time in seconds.
+```bash
+curl --silent --head --request GET https://project-name.my127.site/ | grep -iE '^(HTTP/|age|cache-control)'
+HTTP/2 200
+age: 12
+cache-control: max-age=300, public, s-maxage=3600, stale-if-error=1800, stale-while-revalidate=60
+```
+
 ## Use twig temples
 When overriding harness files or adding application overlay files using twig templates can be valuable for providing access to Workspace attributes. Not only this but you will have the power of [twig] at your fingertips.
 
@@ -117,3 +234,5 @@ confd('harness:/'):
 [contributing guide]: ../contribute.md
 [twig]: https://twig.symfony.com/doc/3.x/
 [solr's docker hub page]: https://hub.docker.com/_/solr
+[geerlingguy/drupal-vm Varnish VCL]: https://github.com/geerlingguy/drupal-vm/blob/master/provisioning/templates/drupalvm.vcl.j2
+[this issue's patch]: https://www.drupal.org/project/http_cache_control/issues/3173020

--- a/src/drupal8/docs/customise/advanced.md
+++ b/src/drupal8/docs/customise/advanced.md
@@ -176,12 +176,14 @@ import std;
 sub vcl_deliver {
     # Respond to upstream proxies with a lower s-maxage
     if (std.integer(regsub(resp.http.cache-control,
-  "(^\s*|.*,\s*)s-maxage=([0-9]+)(\s*,.*|\s*$)", "\2"), 0) > 100) {
+"(^|.*,)(\s*)s-maxage=([0-9]+)(\s*)(,.*|$)", "\3"), 0) > 100) {
         set resp.http.cache-control = regsub(resp.http.cache-control,
-  "(^\s*|.*,\s*)s-maxage=([0-9]+)(\s*,.*|\s*$)", "\1s-maxage=100\3");
+"(^|.*,)(\s*)s-maxage=([0-9]+)(\s*)(,.*|$)", "\1\2s-maxage=100\4\5");
     }
 }
 ```
+
+This VCL snippet can be activated in the harness by setting `attribute('varnish.response.s-maxage'): 100`.
 
 #### Testing
 


### PR DESCRIPTION
Fixes #570 

Implements the [drupal-vm VCL](https://github.com/geerlingguy/drupal-vm/blob/0c3af7da053d3720e8b93e49a8d573489106c8ba/provisioning/templates/drupalvm.vcl.j2) rather than [Acquia's simplified VCL](https://support.acquia.com/hc/en-us/articles/360005540293-Simplified-VCL-for-Varnish) as specified in #570, as we needed varnish 6 compatibility and support for purging based on cache tags to better match the capabilities of present day Acquia.