### PR TITLE
Avoid syntax checking tests for drupal8

### DIFF
--- a/src/drupal8/application/skeleton/composer.json.twig
+++ b/src/drupal8/application/skeleton/composer.json.twig
@@ -78,7 +78,7 @@
       "@test-acceptance"
     ],
     "test-production-quality": [
-      "bash -e -o pipefail -c \"find docroot/ -type f ! -path 'docroot/core/lib/Drupal/Component/Assertion/global_namespace_php5.php' \\( -name '*.inc' -o -name '*.install' -o -name '*.module' -o -name '*.php' -o -name '*.profile' -o -name '*.test' -o -name '*.theme' \\)  -print0 | xargs -0 --no-run-if-empty -n 1 -P 8 -i php -l {} | (grep -v 'No syntax errors detected' || echo OK)\"",
+      "bash -e -o pipefail -c \"find docroot -type f ! -iregex 'docroot/core/.*?/?tests?/.*' ! -iregex 'docroot/modules/contrib/.*/tests?/.*' ! -path 'docroot/core/lib/Drupal/Component/Assertion/global_namespace_php5.php' \\( -name '*.inc' -o -name '*.install' -o -name '*.module' -o -name '*.php' -o -name '*.profile' -o -name '*.test' -o -name '*.theme' \\)  -print0 | xargs -0 --no-run-if-empty -n 1 -P 8 -i php -l {} | (grep -v 'No syntax errors detected' || echo OK)\"",
       "composer validate --no-check-publish"
     ],
     "test-quality": [


### PR DESCRIPTION
Reduces the amount of files to syntax check from 11721 to 5841, for example.

We could potentially avoid scanning docroot/core/ and docroot/modules/contrib/, but we've seen some modules being used in the past that contain php files with invalid syntax (due to php version upgrade).