### PR TITLE
Check for cache control header before using it

### DIFF
--- a/src/drupal8/docker/image/varnish/root/etc/varnish/default.vcl.twig
+++ b/src/drupal8/docker/image/varnish/root/etc/varnish/default.vcl.twig
@@ -145,7 +145,7 @@ sub vcl_deliver {
 
 {% if @('varnish.response.s-maxage') and @('varnish.response.s-maxage') > 0 %}
     # Respond to upstream proxies with a lower s-maxage
-    if (std.integer(regsub(resp.http.cache-control,
+    if (resp.http.cache-control && std.integer(regsub(resp.http.cache-control,
 "(^|.*,)(\s*)s-maxage=([0-9]+)(\s*)(,.*|$)", "\3"), 0) > {{ @('varnish.response.s-maxage') }}) {
         set resp.http.cache-control = regsub(resp.http.cache-control,
 "(^|.*,)(\s*)s-maxage=([0-9]+)(\s*)(,.*|$)", "\1\2s-maxage={{ @('varnish.response.s-maxage') }}\4\5");

--- a/src/drupal8/docs/customise/advanced.md
+++ b/src/drupal8/docs/customise/advanced.md
@@ -175,7 +175,7 @@ Varnish will keep the object in cache for the original s-maxage value, or until 
 import std;
 sub vcl_deliver {
     # Respond to upstream proxies with a lower s-maxage
-    if (std.integer(regsub(resp.http.cache-control,
+    if (resp.http.cache-control && std.integer(regsub(resp.http.cache-control,
 "(^|.*,)(\s*)s-maxage=([0-9]+)(\s*)(,.*|$)", "\3"), 0) > 100) {
         set resp.http.cache-control = regsub(resp.http.cache-control,
 "(^|.*,)(\s*)s-maxage=([0-9]+)(\s*)(,.*|$)", "\1\2s-maxage=100\4\5");


### PR DESCRIPTION
Just in case the response does not contain a Cache-Control header at all.