### PR TITLE
Fix issue with secrets not being available before app-migrate for Helm

### DIFF
--- a/src/_base/helm/app/templates/_base_helper.tpl
+++ b/src/_base/helm/app/templates/_base_helper.tpl
@@ -51,9 +51,11 @@ metadata:
   name: {{ .root.Values.resourcePrefix }}{{ .service_name }}
   labels:
     {{- include "chart.labels" .root | nindent 4 }}
+    helm
     app.kubernetes.io/component: {{ .component | default .service_name }}
   annotations:
     argocd.argoproj.io/sync-wave: "1"
+    helm.sh/hook: pre-install,pre-upgrade
 {{ if .root.Values.feature.sealed_secrets }}
 {{ if ne .root.Values.sealed_secrets.scope "strict" }}
     sealedsecrets.bitnami.com/{{ .root.Values.sealed_secrets.scope }}: "true"


### PR DESCRIPTION
app-migrate uses a pre-upgrade helm hook, which means a secret has to exist already in the deployment.

This doesn't affect app-init as that is a post-install hook, but a hook is needed in any case. Similar was already implemented with argocd sync-waves.

Due to hook deletion policies, this might remove the secret along with the sealedsecret prior to the new sealedsecret, however that is more ideal anyway, to allow deployments/jobs to require to wait for the secret to be created