### PR TITLE
#608: Use NGINX 1.21

### DIFF
--- a/src/_base/docker/image/nginx/Dockerfile.twig
+++ b/src/_base/docker/image/nginx/Dockerfile.twig
@@ -2,7 +2,7 @@
 FROM {{ @('docker.repository') ~ ':' ~ @('app.version') }}-console as console
 {% endif %}
 
-FROM nginx:1.19-alpine
+FROM nginx:1.21-alpine
 COPY root /
 
 {% if @('app.build') == 'static' %}

--- a/src/_base/docker/image/relay/Dockerfile
+++ b/src/_base/docker/image/relay/Dockerfile
@@ -1,2 +1,2 @@
-FROM nginx:1.19-alpine
+FROM nginx:1.21-alpine
 COPY root /

--- a/src/_base/docker/image/tls-offload/Dockerfile
+++ b/src/_base/docker/image/tls-offload/Dockerfile
@@ -1,2 +1,2 @@
-FROM nginx:1.19-alpine
+FROM nginx:1.21-alpine
 COPY root /


### PR DESCRIPTION
Fixes #608 to be within the supported tags for NGINX on docker hub.