### PR TITLE
Switch changelog generator docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ When ready to tag a release, make a new branch from the `1.2.x` branch for the c
 2. Export it in your environment: `export CHANGELOG_GITHUB_TOKEN=...`
 3. Run the following docker command to generate the changelog, replacing `1.2.0` with the version number as needed:
   ```bash
-  docker run -e CHANGELOG_GITHUB_TOKEN="$CHANGELOG_GITHUB_TOKEN" -it --rm -v "$(pwd)":/usr/local/src/your-app -v "$(pwd)/github-changelog-http-cache":/tmp/github-changelog-http-cache ferrarimarco/github-changelog-generator --user inviqa --project harness-base-php --exclude-labels "duplicate,question,invalid,wontfix,skip-changelog" --release-branch 1.2.x --future-release 1.2.0
+  docker run -e CHANGELOG_GITHUB_TOKEN="$CHANGELOG_GITHUB_TOKEN" -it --rm -v "$(pwd)":/usr/local/src/your-app -v "$(pwd)/github-changelog-http-cache":/tmp/github-changelog-http-cache githubchangeloggenerator/github-changelog-generator --user inviqa --project harness-base-php --exclude-labels "duplicate,question,invalid,wontfix,skip-changelog" --release-branch 1.2.x --future-release 1.2.0
   ```
 4. Examine the generated CHANGELOG.md. For every entry in the `Merged pull requests` section, examine the Pull Requests
    and assign each pull request either a `enhancement` label for a new feature, `bug` for a bugfix or `deprecated` for


### PR DESCRIPTION
The instructions changed back in April: https://github.com/github-changelog-generator/github-changelog-generator/commit/96e7f2052a43404f8e947965d134a07d94152f0d