### PR TITLE
Use an integer for varnish tmpfs size for compose cli v2

### DIFF
--- a/src/_base/_twig/docker-compose.yml/service/varnish.yml.twig
+++ b/src/_base/_twig/docker-compose.yml/service/varnish.yml.twig
@@ -20,7 +20,7 @@
       - type: tmpfs
         target: /var/lib/varnish:exec
         tmpfs:
-          size: "100000"
+          size: 100000
     networks:
       private:
         aliases:


### PR DESCRIPTION
Fixes a fatal complaint from compose cli v2 saying it must be an integer

Part of #614 