### PR TITLE
Fix dockerfile path with compose cli v2

### DIFF
--- a/src/_base/harness/config/functions.yml
+++ b/src/_base/harness/config/functions.yml
@@ -123,10 +123,12 @@ function('docker_service_images', [filterService]): |
     }
 
     if (isset($service['build'])) {
-      $context = rtrim($service['build']['context'], '/');
-      $dockerfile = $service['build']['dockerfile'] ?? 'Dockerfile';
+      $dockerfilePath = $service['build']['dockerfile'] ?? 'Dockerfile';
+      if (substr($dockerfilePath, 0, 1) !== '/') {
+        $dockerfilePath = rtrim($service['build']['context'], '/') . '/' . $dockerfilePath;
+      }
 
-      if (preg_match_all('/^FROM\s+([^\s]*)/m', file_get_contents($context.'/'.$dockerfile), $matches) === false) {
+      if (preg_match_all('/^FROM\s+([^\s]*)/m', file_get_contents($dockerfilePath), $matches) === false) {
         continue;
       }
 


### PR DESCRIPTION
`docker compose config` gives path a full path to a Dockerfile, rather than a context-relative path.

We can detect this and use the dockerfile path directly.

Part of #614