### PR TITLE
Pass through tideways hostname and env variable

### DIFF
--- a/src/_base/helm/app/templates/service/tideways/deployment.yaml
+++ b/src/_base/helm/app/templates/service/tideways/deployment.yaml
@@ -24,7 +24,17 @@ spec:
         app.service: {{ $.Values.resourcePrefix }}tideways
     spec:
       containers:
-      - image: {{ .image | quote }}
+      - env:
+        {{- range $key, $value := (mergeOverwrite (dict) .environment .environment_dynamic) }}
+        - name: {{ $key | quote }}
+          value: {{ $value | quote }}
+        {{- end }}
+        {{- if .environment_secrets }}
+        envFrom:
+          - secretRef:
+              name: {{ $.Values.resourcePrefix }}tideways
+        {{- end }}
+        image: {{ .image | quote }}
         imagePullPolicy: Always
         name: tideways
         ports:


### PR DESCRIPTION
Passes through these env vars to the tideways daemon: https://github.com/inviqa/harness-base-php/blob/1.2.x/src/_base/harness/attributes/docker-base.yml#L167-L174