### PR TITLE
Fix drupal8 build

### DIFF
--- a/src/drupal8/application/skeleton/phpstan.deprecation_check.neon
+++ b/src/drupal8/application/skeleton/phpstan.deprecation_check.neon
@@ -22,4 +22,5 @@ parameters:
         - docroot/core/lib/Drupal/Core/DependencyInjection/ServiceProviderInterface.php
         - docroot/core/tests/Drupal/KernelTests/KernelTestBase.php
         - docroot/core/tests/Drupal/Tests/PhpunitCompatibilityTrait.php
+        - docroot/core/tests/Drupal/Tests/UnitTestCase.php
     tmpDir: /tmp/phpstan_deprecation_check


### PR DESCRIPTION
No idea why this is necessary, as it was in the dumped autoloader files:
```
build@6cdec84719c6:/app$ grep -R UnitTestCase vendor/composer/
vendor/composer/autoload_classmap.php:    'Drupal\\Tests\\UnitTestCase' => $baseDir . '/docroot/core/tests/Drupal/Tests/UnitTestCase.php',
vendor/composer/autoload_classmap.php:    'Drupal\\Tests\\UnitTestCaseDeprecationTest' => $baseDir . '/docroot/core/tests/Drupal/Tests/UnitTestCaseDeprecationTest.php',
vendor/composer/autoload_classmap.php:    'Symfony\\Cmf\\Component\\Routing\\Test\\CmfUnitTestCase' => $vendorDir . '/symfony-cmf/routing/Test/CmfUnitTestCase.php',
vendor/composer/autoload_static.php:        'Drupal\\Tests\\UnitTestCase' => __DIR__ . '/../..' . '/docroot/core/tests/Drupal/Tests/UnitTestCase.php',
vendor/composer/autoload_static.php:        'Drupal\\Tests\\UnitTestCaseDeprecationTest' => __DIR__ . '/../..' . '/docroot/core/tests/Drupal/Tests/UnitTestCaseDeprecationTest.php',
vendor/composer/autoload_static.php:        'Symfony\\Cmf\\Component\\Routing\\Test\\CmfUnitTestCase' => __DIR__ . '/..' . '/symfony-cmf/routing/Test/CmfUnitTestCase.php',
```