### PR TITLE
Use new external network syntax

### DIFF
--- a/src/_base/docker-compose.yml.twig
+++ b/src/_base/docker-compose.yml.twig
@@ -19,8 +19,8 @@ networks:
   private:
     external: false
   shared:
-    external:
-      name: my127ws
+    external: true
+    name: my127ws
 {% if syncvolume or @('services.solr.enabled') %}
 volumes:
 {% if syncvolume %}


### PR DESCRIPTION
See deprecation notice on https://docs.docker.com/compose/compose-file/compose-file-v3/#external-1