### PR TITLE
Fetch the correct architecture mutagen binary for the host

### DIFF
--- a/src/_base/harness/scripts/latest-mutagen-release.php
+++ b/src/_base/harness/scripts/latest-mutagen-release.php
@@ -22,9 +22,19 @@ if (!$latestStableRelease) {
     throw new Exception('Could not find latest stable release.');
 }
 
+$goArchMap = [
+    'i386' => '386',
+    'x86_64' => 'amd64',
+    'aarch64' => 'arm64',
+    'armv7l' => 'arm',
+    'armv6l' => 'arm',
+];
+
 $osFamily = strtolower(PHP_OS_FAMILY);
-$releaseAssets = array_filter($latestStableRelease['assets'], function ($asset) use ($osFamily) {
-    return preg_match("/^mutagen_.*${osFamily}.*amd64.*/", $asset['name']) > 0;
+$hostArch = php_uname('m');
+$goArch = $goArchMap[php_uname('m')] ?? $hostArch;
+$releaseAssets = array_filter($latestStableRelease['assets'], function ($asset) use ($osFamily, $goArch) {
+    return preg_match("/^mutagen_.*${osFamily}.*${goArch}.*/", $asset['name']) > 0;
 });
 $releaseAsset = reset($releaseAssets);
 if (!$releaseAsset) {


### PR DESCRIPTION
In MacOS M1's case though arm64 is the host architecture, but support linux aarch64 still (MacOS intel is x86_64)