### PR TITLE
Enable bash history under spryker console

### DIFF
--- a/src/_base/harness/config/events.yml
+++ b/src/_base/harness/config/events.yml
@@ -2,6 +2,7 @@
 after('harness.install'): |
   #!bash
   ws enable
+  touch ./.my127ws/.bash_history
 
 after('harness.refresh'):
   env:

--- a/src/spryker/_twig/docker-compose.yml/service/console.yml.twig
+++ b/src/spryker/_twig/docker-compose.yml/service/console.yml.twig
@@ -16,6 +16,7 @@
       - ./.my127ws/application:/home/build/application
       - ./.my127ws/docker/image/console/root/lib/task:/lib/task
       - ./.my127ws:/.my127ws
+      - ./.my127ws/.bash_history:/home/build/.bash_history
 {% else %}
     image: {{ @('services.console.image') }}
 {% endif %}


### PR DESCRIPTION
Original idea by @alexandrajulius 🙌

## 🛠 Manual steps
```
$ ws install
```
This will create an empty file .bash_history in `/.my127ws` and it will mount your local bash history to that file. 
Therefore, after exiting and entering the console container again, you will still have your bash history available.

## 🤔 Open questions

Maybe does it make sense to add this mounting to the _base console template? Or all other as well?
- `src/_base/_twig/docker-compose.yml/service/console.yml.twig` 

Answer: https://github.com/inviqa/harness-base-php/pull/635 ☝️ 