### PR TITLE
Deprecate database.var attribute for newer services.mysql.options

### DIFF
--- a/src/_base/harness/attributes/common.yml
+++ b/src/_base/harness/attributes/common.yml
@@ -299,6 +299,7 @@ attributes.default:
     name: app
     root_pass: DV6RdNY3QcFsBk7V
     port_forward: ~
+    # deprecated: database.var will move to services.mysql.options in a future release
     var:
       default_authentication_plugin: "= (@('database.platform') == 'mysql' && @('database.platform_version') >= 8.0 && @('database.platform_version') < 10.0 ? 'mysql_native_password' : '')"
       ignore-db-dir: "= (@('database.platform') == 'mysql' && @('database.platform_version') < 8.0 ? 'lost+found' : '')"


### PR DESCRIPTION
It's specific to the docker image, and is more consistent this way. The database.platform condition will be able to be removed