### PR TITLE
Include the project name in docker-compose project name in CI

### DIFF
--- a/src/_base/harness/attributes/environment/pipeline.yml
+++ b/src/_base/harness/attributes/environment/pipeline.yml
@@ -1,6 +1,6 @@
 
 attributes:
-  namespace: =exec("git log -n 1 --pretty=format:'%H'")
+  namespace: =@('workspace.name') ~ '-' ~ exec("git rev-parse --short HEAD")
   hostname: =@('workspace.name') ~ '.' ~ @('domain')
   app:
     build: static

--- a/src/spryker/harness/attributes/environment/pipeline.yml
+++ b/src/spryker/harness/attributes/environment/pipeline.yml
@@ -2,7 +2,7 @@
 attributes:
   spryker:
     mode: 'production'
-  namespace: =exec("git log -n 1 --pretty=format:'%H'")
+  namespace: =@('workspace.name') ~ '-' ~ exec("git rev-parse --short HEAD")
   hostname: =@('workspace.name') ~ '.' ~ @('domain')
   app:
     build: static


### PR DESCRIPTION
So it's easier to identify the project from the instance shell

Also use a shorter git ref for it so it isn't too long