### PR TITLE
Add quotes on mysql.tag and other tags to avoid losing x.0 to x

### DIFF
--- a/src/_base/harness/attributes/common.yml
+++ b/src/_base/harness/attributes/common.yml
@@ -311,7 +311,7 @@ attributes.default:
     host: elasticsearch
     image: elasticsearch
     port: 9200
-    tag: 7.14.2
+    tag: '7.14.2'
 
   domain: my127.site
   hostname: = @('namespace') ~ '.' ~ @('domain')
@@ -352,11 +352,11 @@ attributes.default:
   mysql:
     # prefer native platform mysql image. _/mysql doesn't have arm64 images
     image: "= host_architecture() == 'amd64' ? 'mysql' : 'mysql/mysql-server'"
-    tag: 8.0
+    tag: '8.0'
 
   rabbitmq:
     image: rabbitmq
-    tag: 3.8-management-alpine
+    tag: '3.8-management-alpine'
     api_port: 15672
     erlang_cookie: TeTTiwT9y548yIcfw4peaOrqgtLItD6B
     external_host: = 'rabbitmq-' ~ @('hostname')

--- a/src/akeneo/harness.yml
+++ b/src/akeneo/harness.yml
@@ -51,7 +51,7 @@ attributes:
     user: akeneo
     pass: akeneo
     name: akeneo
-    platform_version: 8.0
+    platform_version: '8.0'
     import:
       steps:
         - passthru echo 'Importing database file'
@@ -136,9 +136,9 @@ attributes:
       php-fpm: = 'my127/akeneo:' ~ @('php.version') ~ '-fpm-buster'
   elasticsearch:
     image: elasticsearch
-    tag: 7.10.1
+    tag: '7.10.1'
   mysql:
-    tag: 8.0
+    tag: '8.0'
   nginx:
     # used to limit what is copied into an Nginx static-built image
     # vendor directory needed for vendor/*/*/*/public/ resources (images etc.)

--- a/src/magento1/harness.yml
+++ b/src/magento1/harness.yml
@@ -74,7 +74,7 @@ attributes:
       session:
         save: redis
   mysql:
-    tag: 5.7
+    tag: '5.7'
   backend:
     build:
       steps:

--- a/src/magento2/application/skeleton/src/Acme/HelloWorld.php
+++ b/src/magento2/application/skeleton/src/Acme/HelloWorld.php
@@ -6,5 +6,4 @@ namespace Acme;
 
 class HelloWorld
 {
-
 }

--- a/src/magento2/harness.yml
+++ b/src/magento2/harness.yml
@@ -63,7 +63,7 @@ attributes:
     pass: magento
     name: magento
   elasticsearch:
-    tag: 7.10.1
+    tag: '7.10.1'
   magento:
     edition: enterprise
     config:
@@ -84,7 +84,7 @@ attributes:
     version: 2.4.2
   mysql:
     image: mariadb
-    tag: 10.4
+    tag: '10.4'
   backend:
     build:
       steps:

--- a/src/spryker/harness.yml
+++ b/src/spryker/harness.yml
@@ -85,7 +85,7 @@ attributes:
       php-fpm: "= 'my127/spryker:' ~ @('php.version') ~ '-fpm-' ~ (@('php.version') >= 7.4 ? 'buster' : 'stretch')"
   elasticsearch:
     image: elasticsearch
-    tag: 6.8.12
+    tag: '6.8.12'
   hostname_aliases: "= replace(flatten([
       @('glue.external_hosts'),
       @('yves.external_hosts'),


### PR DESCRIPTION
mysql/mysql-server:8 doesn't exist, though it was coping on mysql:8, at least till 8.1 out