### PR TITLE
Install build tools for spryker frontend on non-amd64 architectures

### DIFF
--- a/src/_base/docker/image/console/Dockerfile.twig
+++ b/src/_base/docker/image/console/Dockerfile.twig
@@ -20,6 +20,14 @@ RUN chown -R build:build /home/build /app \
     {{ install_extensions|join(" \\\n    ") }}
 {% endif %}
 
+{% if @('frontend.build.distro_packages') or @('backend.build.distro_packages') %}
+RUN apt-get update -qq \
+ && DEBIAN_FRONTEND=noninteractive apt-get -qq -y --no-install-recommends install \
+    {{ @('frontend.build.distro_packages') | default([]) | merge(@('backend.build.distro_packages') | default([])) | join(' ') }} \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+{% endif %}
+
 ENV APP_MODE={{ @('app.mode') }} \
   APP_BUILD={{ @('app.build') }} \
   ASSETS_DIR={{ @('assets.local') }}

--- a/src/_base/docker/image/console/Dockerfile.twig
+++ b/src/_base/docker/image/console/Dockerfile.twig
@@ -20,10 +20,10 @@ RUN chown -R build:build /home/build /app \
     {{ install_extensions|join(" \\\n    ") }}
 {% endif %}
 
-{% if @('frontend.build.distro_packages') or @('backend.build.distro_packages') %}
+{% if @('frontend.build.distribution_packages') or @('backend.build.distribution_packages') %}
 RUN apt-get update -qq \
  && DEBIAN_FRONTEND=noninteractive apt-get -qq -y --no-install-recommends install \
-    {{ @('frontend.build.distro_packages') | default([]) | merge(@('backend.build.distro_packages') | default([])) | join(' ') }} \
+    {{ @('frontend.build.distribution_packages') | default([]) | merge(@('backend.build.distribution_packages') | default([])) | join(' ') }} \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 {% endif %}

--- a/src/spryker/harness.yml
+++ b/src/spryker/harness.yml
@@ -71,10 +71,10 @@ attributes:
     zed:
       watch: npm run zed:watch
     build:
-      x-distro_packages:
+      distribution_packages_non_amd64:
         - build-essential
         - python
-      distro_packages: "= host_architecture() == 'amd64' ? [] : @('frontend.build.x-distro_packages')"
+      distribution_packages: "= host_architecture() == 'amd64' ? [] : @('frontend.build.distribution_packages_non_amd64')"
       when: -f "package.json"
       steps:
         - run vendor/bin/install -r docker -s frontend

--- a/src/spryker/harness.yml
+++ b/src/spryker/harness.yml
@@ -71,6 +71,10 @@ attributes:
     zed:
       watch: npm run zed:watch
     build:
+      x-distro_packages:
+        - build-essential
+        - python
+      distro_packages: "= host_architecture() == 'amd64' ? [] : @('frontend.build.x-distro_packages')"
       when: -f "package.json"
       steps:
         - run vendor/bin/install -r docker -s frontend


### PR DESCRIPTION
e.g. for arm64, as some npm packages don't have prebuilt binaries for them