### PR TITLE
Upgrade all elasticsearch versions to latest versions

### DIFF
--- a/src/_base/harness/attributes/common.yml
+++ b/src/_base/harness/attributes/common.yml
@@ -311,7 +311,7 @@ attributes.default:
     host: elasticsearch
     image: elasticsearch
     port: 9200
-    tag: '7.16.1'
+    tag: '7.16.2'
 
   domain: my127.site
   hostname: = @('namespace') ~ '.' ~ @('domain')

--- a/src/_base/harness/attributes/common.yml
+++ b/src/_base/harness/attributes/common.yml
@@ -311,7 +311,7 @@ attributes.default:
     host: elasticsearch
     image: elasticsearch
     port: 9200
-    tag: '7.14.2'
+    tag: '7.16.1'
 
   domain: my127.site
   hostname: = @('namespace') ~ '.' ~ @('domain')

--- a/src/akeneo/harness.yml
+++ b/src/akeneo/harness.yml
@@ -134,11 +134,6 @@ attributes:
     image:
       console: = 'my127/akeneo:' ~ @('php.version') ~ '-fpm-buster-console'
       php-fpm: = 'my127/akeneo:' ~ @('php.version') ~ '-fpm-buster'
-  elasticsearch:
-    image: elasticsearch
-    tag: '7.10.1'
-  mysql:
-    tag: '8.0'
   nginx:
     # used to limit what is copied into an Nginx static-built image
     # vendor directory needed for vendor/*/*/*/public/ resources (images etc.)

--- a/src/magento2/harness.yml
+++ b/src/magento2/harness.yml
@@ -62,8 +62,6 @@ attributes:
     user: magento
     pass: magento
     name: magento
-  elasticsearch:
-    tag: '7.10.1'
   magento:
     edition: enterprise
     config:

--- a/src/spryker/harness.yml
+++ b/src/spryker/harness.yml
@@ -83,6 +83,9 @@ attributes:
     image:
       console: "= 'my127/spryker:' ~ @('php.version') ~ '-fpm-' ~ (@('php.version') >= 7.4 ? 'buster' : 'stretch') ~ '-console'"
       php-fpm: "= 'my127/spryker:' ~ @('php.version') ~ '-fpm-' ~ (@('php.version') >= 7.4 ? 'buster' : 'stretch')"
+  elasticsearch:
+    image: elasticsearch
+    tag: '6.8.22'
   hostname_aliases: "= replace(flatten([
       @('glue.external_hosts'),
       @('yves.external_hosts'),

--- a/src/spryker/harness.yml
+++ b/src/spryker/harness.yml
@@ -83,9 +83,6 @@ attributes:
     image:
       console: "= 'my127/spryker:' ~ @('php.version') ~ '-fpm-' ~ (@('php.version') >= 7.4 ? 'buster' : 'stretch') ~ '-console'"
       php-fpm: "= 'my127/spryker:' ~ @('php.version') ~ '-fpm-' ~ (@('php.version') >= 7.4 ? 'buster' : 'stretch')"
-  elasticsearch:
-    image: elasticsearch
-    tag: '6.8.12'
   hostname_aliases: "= replace(flatten([
       @('glue.external_hosts'),
       @('yves.external_hosts'),


### PR DESCRIPTION
Even if a platform doesn't explicitly say it supports beyond 7.10, it will need upgrading

Spryker's elasticsearch 6 can use 6.8.22