### PR TITLE
Add Spryker 202108.0 support

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -250,7 +250,15 @@ pipeline {
                                 sh './test spryker dynamic'
                             }
                         }
-                        // Deliberately not having an "Install Mutagen" step to test the installer we ship with the harness
+                        // todo: remove this step after the mutagen installer from harness is working again
+                        stage('Install Mutagen') {
+                            steps {
+                                sh 'apk add grep'
+                                sh 'curl --fail --silent --show-error --location --output /tmp/mutagen.tar.gz https://github.com/mutagen-io/mutagen/releases/download/v0.11.8/mutagen_linux_amd64_v0.11.8.tar.gz'
+                                sh 'tar -C /usr/local/bin/ -xf /tmp/mutagen.tar.gz'
+                                sh 'rm -f /tmp/mutagen.tar.gz'
+                            }
+                        }
                         stage('Acceptance Tests') {
                             environment {
                                 REUSE_EXISTING_WORKSPACE = "yes"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -250,15 +250,6 @@ pipeline {
                                 sh './test spryker dynamic'
                             }
                         }
-                        // todo: remove this step after the mutagen installer from harness is working again
-                        stage('Install Mutagen') {
-                            steps {
-                                sh 'apk add grep'
-                                sh 'curl --fail --silent --show-error --location --output /tmp/mutagen.tar.gz https://github.com/mutagen-io/mutagen/releases/download/v0.11.8/mutagen_linux_amd64_v0.11.8.tar.gz'
-                                sh 'tar -C /usr/local/bin/ -xf /tmp/mutagen.tar.gz'
-                                sh 'rm -f /tmp/mutagen.tar.gz'
-                            }
-                        }
                         stage('Acceptance Tests') {
                             environment {
                                 REUSE_EXISTING_WORKSPACE = "yes"

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,16 @@
 
 In addition to the README's [Harness Upgrade Instructions], please note these specific version upgrade instructions.
 
+## Upgrading from 1.2.x to 1.3.x
+
+### Spryker
+With support for Spryker 202108.0 release, we have upgraded the Elasticsearch version to 7.x and also there is a change in
+Zed application's root directory (Spryker now supports different entrypoints for backoffice and Zed gateway applications).
+However, both of these changes are not backward compatible. So, to make sure we do not break projects using old demoshop version,
+we are using `spryker.demoshop-version` attribute to apply these changes conditionally.
+In order to make sure your project uses the right version of Elasticsearch and Zed root directory, make sure you set the 
+right `spryker.demoshop-version` in your workspace.yml
+
 ## Upgrading from 1.1.x to 1.2.x
 
 ### Chrome

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -9,6 +9,7 @@ With support for Spryker 202108.0 release, we have upgraded the Elasticsearch ve
 Zed application's root directory (Spryker now supports different entrypoints for backoffice and Zed gateway applications).
 However, both of these changes are not backward compatible. So, to make sure we do not break projects using old demoshop version,
 we are using `spryker.demoshop-version` attribute to apply these changes conditionally.
+
 In order to make sure your project uses the right version of Elasticsearch and Zed root directory, make sure you set the 
 right `spryker.demoshop-version` in your workspace.yml
 

--- a/src/spryker/.ci/sample-dynamic/workspace.yml
+++ b/src/spryker/.ci/sample-dynamic/workspace.yml
@@ -8,3 +8,5 @@ attribute('aws.access_key_id'): null
 attribute('aws.secret_access_key'): null
 
 attribute('docker.port_forward.enabled'): false
+
+attribute('spryker.demoshop-version'): "202108.0"

--- a/src/spryker/.ci/sample-static/workspace.yml
+++ b/src/spryker/.ci/sample-static/workspace.yml
@@ -9,5 +9,7 @@ attribute('app.repository'): null
 attribute('aws.access_key_id'): null
 attribute('aws.secret_access_key'): null
 
+attribute('spryker.demoshop-version'): "202108.0"
+
 attribute('spryker.oauth_client_secret'): '= decrypt("YTozOntpOjA7czo3OiJkZWZhdWx0IjtpOjE7czoyNDoi/ZxjAtTonBTdHCfPRmh3rlDOOTPZ8oaVIjtpOjI7czo2NDoiXHkN92FXiuuj/PVZKwzJEKtsQzRtAEvdPSYT/6mEA2GVtk+98N4ch+y+MVbg6REiwTAFXOZSb7lEyqZOJMEY+iI7fQ==")'
 attribute('spryker.zed_request_token'): '= decrypt("YTozOntpOjA7czo3OiJkZWZhdWx0IjtpOjE7czoyNDoi5TNpTpnAi3Yjlstw46A63Pvn1nnGoE1VIjtpOjI7czo5NjoiFHj6M4K5I2pUBD5t2nnjzhR6jixzGOtQl/HSBWWyrD9TFmg+Qw82CLZlqBYgQXaCDiOB1GV9tVKAuvvr9ntHZ0KWeZLu5spfhdaqcVsJVm2kxNX6A1YKb5mw/g4V4NvAIjt9")'

--- a/src/spryker/application/overlay/phpstan.neon
+++ b/src/spryker/application/overlay/phpstan.neon
@@ -7,7 +7,8 @@ parameters:
         - %rootDir%/../../../src/Generated/*
         - %rootDir%/../../../src/Orm/*
 
-    bootstrap: %rootDir%/../../../phpstan-bootstrap.php
+    bootstrapFiles:
+        - %rootDir%/../../../phpstan-bootstrap.php
 
     ignoreErrors:
         - '#Call to an undefined method .+Criteria::.+\(\).#'

--- a/src/spryker/application/skeleton/composer-harness.json.twig
+++ b/src/spryker/application/skeleton/composer-harness.json.twig
@@ -65,5 +65,11 @@
     "platform": {
       "php": "7.4.10"
     }
-  }
+  },
+  "repositories": [
+    {
+      "type": "git",
+      "url": "https://github.com/spryker-sdk/lib-innerbrowser.git"
+    }
+  ]
 }

--- a/src/spryker/application/skeleton/composer-harness.json.twig
+++ b/src/spryker/application/skeleton/composer-harness.json.twig
@@ -6,19 +6,19 @@
     "php": ">= 7.4"
   },
   "require-dev": {
-    "behat/behat": "^3.5",
-    "behat/mink": "^1.7",
+    "behat/behat": "^3.10",
+    "behat/mink": "^1.9",
     "behat/mink-extension": "^2.3",
-    "behat/mink-goutte-driver": "^1.2",
+    "behat/mink-goutte-driver": "^2.0",
     "ciaranmcnulty/behat-stepthroughextension": "^1.0",
     "dmore/behat-chrome-extension": "^1.3",
     "dmore/chrome-mink-driver": "^2.6",
     "jakoch/phantomjs-installer": "^3.0",
-    "roave/better-reflection": "~3.5",
+    "roave/better-reflection": "^4.3.0",
     "phpcompatibility/php-compatibility": "dev-master",
     "sensiolabs/behat-page-object-extension": "^2.3",
     "guzzlehttp/guzzle": "^6.3.0",
-    "symfony/browser-kit": "^4.4"
+    "symfony/browser-kit": "^5.1.8"
   },
   "autoload-dev": {
     "psr-4": {

--- a/src/spryker/application/skeleton/config/Shared/config_local.php
+++ b/src/spryker/application/skeleton/config/Shared/config_local.php
@@ -220,4 +220,3 @@ $config[HttpConstants::YVES_TRUSTED_HOSTS]
         $sprykerBackendHost,
         $sprykerBackendApiHost,
     ];
-

--- a/src/spryker/application/skeleton/config/Shared/config_local.php
+++ b/src/spryker/application/skeleton/config/Shared/config_local.php
@@ -2,6 +2,7 @@
 
 use Pyz\Shared\Queue\QueueConstants;
 use Pyz\Shared\Scheduler\SchedulerConfig;
+use Pyz\Zed\Propel\PropelConfig;
 use Spryker\Shared\Application\ApplicationConstants;
 use Spryker\Shared\Collector\CollectorConstants;
 use Spryker\Shared\Customer\CustomerConstants;
@@ -13,12 +14,12 @@ use Spryker\Shared\Mail\MailConstants;
 use Spryker\Shared\Newsletter\NewsletterConstants;
 use Spryker\Shared\ProductManagement\ProductManagementConstants;
 use Spryker\Shared\Propel\PropelConstants;
+use Spryker\Shared\PropelQueryBuilder\PropelQueryBuilderConstants;
 use Spryker\Shared\RabbitMq\RabbitMqEnv;
 use Spryker\Shared\Router\RouterConstants;
 use Spryker\Shared\Scheduler\SchedulerConstants;
 use Spryker\Shared\SchedulerJenkins\SchedulerJenkinsConfig;
 use Spryker\Shared\SchedulerJenkins\SchedulerJenkinsConstants;
-use Spryker\Shared\Search\SearchConstants;
 use Spryker\Shared\SearchElasticsearch\SearchElasticsearchConstants;
 use Spryker\Shared\Session\SessionConstants;
 use Spryker\Shared\SessionRedis\SessionRedisConstants;
@@ -28,64 +29,39 @@ use Spryker\Shared\ZedRequest\ZedRequestConstants;
 use Twig\Cache\FilesystemCache;
 
 $CURRENT_STORE = Store::getInstance()->getStoreName();
+$sprykerFrontendHost = getenv('YVES_HOST_' . $CURRENT_STORE);
+$sprykerBackendHost = getenv('ZED_HOST_' . $CURRENT_STORE);
+$sprykerBackendApiHost = getenv('ZED_API_HOST_' . $CURRENT_STORE);
 
 // ---------- Yves host
-$config[ApplicationConstants::HOST_YVES] = getenv('YVES_HOST_' . $CURRENT_STORE);
-$config[ApplicationConstants::PORT_SSL_YVES] = '';
+$config[ApplicationConstants::HOST_YVES] = $sprykerFrontendHost;
 $config[ApplicationConstants::BASE_URL_YVES] = sprintf(
-    'http://%s%s',
-    $config[ApplicationConstants::HOST_YVES],
-    ''
-);
-$config[ApplicationConstants::BASE_URL_SSL_YVES] = sprintf(
-    'https://%s%s',
-    $config[ApplicationConstants::HOST_YVES],
-    ''
+    'https://%s',
+    $sprykerFrontendHost,
 );
 $config[ProductManagementConstants::BASE_URL_YVES] = $config[ApplicationConstants::BASE_URL_YVES];
 $config[NewsletterConstants::BASE_URL_YVES] = $config[ApplicationConstants::BASE_URL_YVES];
 $config[CustomerConstants::BASE_URL_YVES] = $config[ApplicationConstants::BASE_URL_YVES];
-$config[ApplicationConstants::YVES_TRUSTED_HOSTS]
-    = $config[HttpConstants::YVES_TRUSTED_HOSTS]
-    = [
-    $config[ApplicationConstants::HOST_YVES],
-];
 $config[HttpConstants::YVES_TRUSTED_PROXIES] = ['REMOTE_ADDR'];
-$config[ApplicationConstants::YVES_SSL_ENABLED]
-    = $config[SessionConstants::YVES_SSL_ENABLED]
+$config[SessionConstants::YVES_SSL_ENABLED]
     = $config[RouterConstants::YVES_IS_SSL_ENABLED]
     = true;
 
 // ---------- Zed host
-$config[ApplicationConstants::HOST_ZED] = getenv('ZED_HOST_' . $CURRENT_STORE);
-$config[ApplicationConstants::PORT_SSL_ZED] = '';
 $config[ApplicationConstants::BASE_URL_ZED] = sprintf(
-    'http://%s%s',
-    $config[ApplicationConstants::HOST_ZED],
-    ''
+    'https://%s',
+    $sprykerBackendHost,
 );
-$config[ApplicationConstants::BASE_URL_SSL_ZED] = sprintf(
-    'https://%s%s',
-    $config[ApplicationConstants::HOST_ZED],
-    ''
-);
-$config[ZedRequestConstants::HOST_ZED_API] = getenv('ZED_API_HOST_' . $CURRENT_STORE) ?: $config[ApplicationConstants::HOST_ZED];
+$config[ZedRequestConstants::HOST_ZED_API] = $sprykerBackendApiHost ?: $sprykerBackendHost;
 $config[ZedRequestConstants::BASE_URL_ZED_API] = sprintf(
-    'http://%s%s',
+    'http://%s',
     $config[ZedRequestConstants::HOST_ZED_API],
-    ''
 );
 $config[ZedRequestConstants::BASE_URL_SSL_ZED_API] = sprintf(
-    'https://%s%s',
+    'https://%s',
     $config[ZedRequestConstants::HOST_ZED_API],
-    ''
 );
-$config[ApplicationConstants::ZED_TRUSTED_HOSTS]
-    = $config[HttpConstants::ZED_TRUSTED_HOSTS]
-    = [];
-
-$config[ApplicationConstants::ZED_SSL_ENABLED]
-    = $config[SessionConstants::ZED_SSL_ENABLED]
+$config[SessionConstants::ZED_SSL_ENABLED]
     = $config[RouterConstants::ZED_IS_SSL_ENABLED]
     = $config[ZedRequestConstants::ZED_API_SSL_ENABLED]
     = false;
@@ -95,18 +71,12 @@ $config[GlueApplicationConstants::GLUE_APPLICATION_DOMAIN] = sprintf('http://%s'
 $config[GlueApplicationConstants::GLUE_APPLICATION_CORS_ALLOW_ORIGIN] = sprintf('http://%s', getenv('GLUE_HOST_' . $CURRENT_STORE));
 
 // ---------- Session
-$config[SessionConstants::YVES_SESSION_COOKIE_NAME] = $config[ApplicationConstants::HOST_YVES];
-$config[SessionConstants::YVES_SESSION_COOKIE_DOMAIN] = $config[ApplicationConstants::HOST_YVES];
-
-// ---------- Assets / Media
-$config[ApplicationConstants::BASE_URL_STATIC_ASSETS] = $config[ApplicationConstants::BASE_URL_YVES];
-$config[ApplicationConstants::BASE_URL_STATIC_MEDIA] = $config[ApplicationConstants::BASE_URL_YVES];
-$config[ApplicationConstants::BASE_URL_SSL_STATIC_ASSETS] = $config[ApplicationConstants::BASE_URL_SSL_YVES];
-$config[ApplicationConstants::BASE_URL_SSL_STATIC_MEDIA] = $config[ApplicationConstants::BASE_URL_SSL_YVES];
+$config[SessionConstants::YVES_SESSION_COOKIE_NAME] = $sprykerFrontendHost;
+$config[SessionConstants::YVES_SESSION_COOKIE_DOMAIN] = $sprykerFrontendHost;
 
 // ---------- Session
-$config[SessionConstants::ZED_SESSION_COOKIE_NAME] = $config[ApplicationConstants::HOST_ZED];
-$config[SessionConstants::ZED_SESSION_COOKIE_DOMAIN] = $config[ApplicationConstants::HOST_ZED];
+$config[SessionConstants::ZED_SESSION_COOKIE_NAME] = $sprykerBackendHost;
+$config[SessionConstants::ZED_SESSION_COOKIE_DOMAIN] = $sprykerBackendHost;
 
 // ---------- Database credentials
 $config[PropelConstants::ZED_DB_USERNAME] = getenv('DB_USER');
@@ -115,38 +85,32 @@ $config[PropelConstants::ZED_DB_DATABASE] = getenv('DB_NAME');
 $config[PropelConstants::ZED_DB_HOST] = getenv('DB_HOST');
 $config[PropelConstants::ZED_DB_PORT] = 5432;
 $config[PropelConstants::USE_SUDO_TO_MANAGE_DATABASE] = false;
+$config[PropelConstants::ZED_DB_ENGINE]
+    = $config[PropelQueryBuilderConstants::ZED_DB_ENGINE]
+    = PropelConfig::DB_ENGINE_PGSQL;
 
 // ---------- Elasticsearch
+$config[SearchElasticsearchConstants::HOST] = getenv('ELASTICSEARCH_HOST');
+$config[SearchElasticsearchConstants::TRANSPORT] = getenv('ELASTICSEARCH_SCHEME') ?: 'http';
+$config[SearchElasticsearchConstants::PORT] = getenv('ELASTICSEARCH_PORT');
+if (getenv('ELASTICSEARCH_USERNAME')) {
+    $config[SearchElasticsearchConstants::AUTH_HEADER] = base64_encode(getenv('ELASTICSEARCH_USERNAME') . ':' . getenv('ELASTICSEARCH_PASSWORD'));
+}
 $ELASTICA_INDEX_NAME = strtolower($CURRENT_STORE) . '_search';
-$config[ApplicationConstants::ELASTICA_PARAMETER__TRANSPORT]
-    = $config[SearchElasticsearchConstants::TRANSPORT]
-    = getenv('ELASTICSEARCH_SCHEME') ?: 'http';
-$config[SearchConstants::ELASTICA_PARAMETER__HOST]
-    = $config[SearchElasticsearchConstants::HOST]
-    = getenv('ELASTICSEARCH_HOST');
-$config[SearchConstants::ELASTICA_PARAMETER__PORT]
-    = $config[SearchElasticsearchConstants::PORT]
-    = getenv('ELASTICSEARCH_PORT');
 $config[CollectorConstants::ELASTICA_PARAMETER__INDEX_NAME] = $ELASTICA_INDEX_NAME;
 
-if (getenv('ELASTICSEARCH_USERNAME')) {
-    $config[ApplicationConstants::ELASTICA_PARAMETER__AUTH_HEADER]
-        = $config[SearchElasticsearchConstants::AUTH_HEADER]
-        = base64_encode(getenv('ELASTICSEARCH_USERNAME') . ':' . getenv('ELASTICSEARCH_PASSWORD'));
-}
-
 // ----------- Session and KV storage
-$config[StorageRedisConstants::STORAGE_REDIS_PROTOCOL] = getenv('REDIS_PROTOCOL');
+$config[StorageRedisConstants::STORAGE_REDIS_SCHEME] = getenv('REDIS_PROTOCOL');
 $config[StorageRedisConstants::STORAGE_REDIS_HOST] = getenv('REDIS_HOST');
 $config[StorageRedisConstants::STORAGE_REDIS_PORT] = getenv('REDIS_PORT');
 $config[StorageRedisConstants::STORAGE_REDIS_PASSWORD] = getenv('REDIS_PASSWORD');
 $config[StorageRedisConstants::STORAGE_REDIS_DATABASE] = 0;
-$config[SessionRedisConstants::YVES_SESSION_REDIS_PROTOCOL] = getenv('REDIS_PROTOCOL');
+$config[SessionRedisConstants::YVES_SESSION_REDIS_SCHEME] = getenv('REDIS_PROTOCOL');
 $config[SessionRedisConstants::YVES_SESSION_REDIS_HOST] = getenv('REDIS_HOST');
 $config[SessionRedisConstants::YVES_SESSION_REDIS_PORT] = getenv('REDIS_PORT');
 $config[SessionRedisConstants::YVES_SESSION_REDIS_PASSWORD] = getenv('REDIS_PASSWORD');
 $config[SessionRedisConstants::YVES_SESSION_REDIS_DATABASE] = 1;
-$config[SessionRedisConstants::ZED_SESSION_REDIS_PROTOCOL] = getenv('REDIS_PROTOCOL');
+$config[SessionRedisConstants::ZED_SESSION_REDIS_SCHEME] = getenv('REDIS_PROTOCOL');
 $config[SessionRedisConstants::ZED_SESSION_REDIS_HOST] = getenv('REDIS_HOST');
 $config[SessionRedisConstants::ZED_SESSION_REDIS_PORT] = getenv('REDIS_PORT');
 $config[SessionRedisConstants::ZED_SESSION_REDIS_PASSWORD] = getenv('REDIS_PASSWORD');
@@ -242,4 +206,14 @@ $config[TwigConstants::ZED_TWIG_OPTIONS] = [
         ),
         FilesystemCache::FORCE_BYTECODE_INVALIDATION
     ),
+];
+
+// ---------- Security
+$config[HttpConstants::YVES_TRUSTED_HOSTS]
+    = $config[HttpConstants::ZED_TRUSTED_HOSTS]
+    = $config[KernelConstants::DOMAIN_WHITELIST]
+    = [
+    $sprykerFrontendHost,
+    $sprykerBackendHost,
+    $sprykerBackendApiHost,
 ];

--- a/src/spryker/application/skeleton/config/Shared/config_local.php
+++ b/src/spryker/application/skeleton/config/Shared/config_local.php
@@ -28,6 +28,9 @@ use Spryker\Shared\Twig\TwigConstants;
 use Spryker\Shared\ZedRequest\ZedRequestConstants;
 use Twig\Cache\FilesystemCache;
 
+// todo: this file sets hardcoded auth secrets, remote environments needs to have a different ones supplied via env vars
+require 'common/config_oauth-devvm.php';
+
 $CURRENT_STORE = Store::getInstance()->getStoreName();
 $sprykerFrontendHost = getenv('YVES_HOST_' . $CURRENT_STORE);
 $sprykerBackendHost = getenv('ZED_HOST_' . $CURRENT_STORE);
@@ -213,7 +216,8 @@ $config[HttpConstants::YVES_TRUSTED_HOSTS]
     = $config[HttpConstants::ZED_TRUSTED_HOSTS]
     = $config[KernelConstants::DOMAIN_WHITELIST]
     = [
-    $sprykerFrontendHost,
-    $sprykerBackendHost,
-    $sprykerBackendApiHost,
-];
+        $sprykerFrontendHost,
+        $sprykerBackendHost,
+        $sprykerBackendApiHost,
+    ];
+

--- a/src/spryker/application/skeleton/config/install/docker.yml.twig
+++ b/src/spryker/application/skeleton/config/install/docker.yml.twig
@@ -14,22 +14,22 @@ sections:
     hidden:
         excluded: true
         maintenance-all-on:
-            command: "vendor/bin/console maintenance:enable"
+            command: "if [ \"$APPLICATION_ENV\" = \"development\" ]; then vendor/bin/console maintenance:enable; fi"
 
         maintenance-all-off:
-            command: "vendor/bin/console maintenance:disable"
+            command: "if [ \"$APPLICATION_ENV\" = \"development\" ]; then vendor/bin/console maintenance:disable; fi"
 
         maintenance-zed-on:
-            command: "vendor/bin/console maintenance:enable zed"
+            command: "if [ \"$APPLICATION_ENV\" = \"development\" ]; then vendor/bin/console maintenance:enable zed; fi"
 
         maintenance-zed-off:
-            command: "vendor/bin/console maintenance:disable zed"
+            command: "if [ \"$APPLICATION_ENV\" = \"development\" ]; then vendor/bin/console maintenance:disable zed; fi"
 
         maintenance-yves-on:
-            command: "vendor/bin/console maintenance:enable yves"
+            command: "if [ \"$APPLICATION_ENV\" = \"development\" ]; then vendor/bin/console maintenance:enable yves; fi"
 
         maintenance-yves-off:
-            command: "vendor/bin/console maintenance:disable yves"
+            command: "if [ \"$APPLICATION_ENV\" = \"development\" ]; then vendor/bin/console maintenance:disable yves; fi"
 
     environment:
         console-environment:
@@ -209,7 +209,7 @@ sections:
                 - propel
 
         maintenance-page-enable:
-            command: "vendor/bin/console maintenance:enable"
+            command: "if [ \"$APPLICATION_ENV\" = \"development\" ]; then vendor/bin/console maintenance:enable yves; fi"
             stores: true
             condition:
                 command: "propel-migration-check"
@@ -223,7 +223,7 @@ sections:
                 - propel
 
         maintenance-page-disable:
-            command: "vendor/bin/console maintenance:disable"
+            command: "if [ \"$APPLICATION_ENV\" = \"development\" ]; then vendor/bin/console maintenance:disable yves; fi"
             stores: true
 
         init-database:
@@ -236,6 +236,13 @@ sections:
             stores: true
             groups:
                 - elastic
+
+    performance:
+        composer-autoloader:
+            command: 'composer dumpautoload -a -o --classmap-authoritative'
+
+        class-resolver-build:
+            command: 'vendor/bin/console cache:class-resolver:build'
 
     demodata:
         import:

--- a/src/spryker/application/skeleton/config/install/docker.yml.twig
+++ b/src/spryker/application/skeleton/config/install/docker.yml.twig
@@ -97,7 +97,11 @@ sections:
             stores: true
 
         router-cache-warmup-zed:
-            command: "vendor/bin/console router:cache:warm-up"
+            command: "vendor/bin/console router:cache:warm-up:backend"
+            stores: true
+
+        router-cache-warmup-zed-gateway:
+            command: "vendor/bin/console router:cache:warm-up:backend-gateway"
             stores: true
 
         twig-cache-warmup:

--- a/src/spryker/application/skeleton/src/Inviqa/Yves/Router/Plugin/EventDispatcher/RouterSslRedirectEventDispatcherPlugin.php
+++ b/src/spryker/application/skeleton/src/Inviqa/Yves/Router/Plugin/EventDispatcher/RouterSslRedirectEventDispatcherPlugin.php
@@ -10,7 +10,7 @@ namespace Inviqa\Yves\Router\Plugin\EventDispatcher;
 use Spryker\Shared\EventDispatcher\EventDispatcherInterface;
 use Spryker\Yves\Router\Plugin\EventDispatcher\RouterSslRedirectEventDispatcherPlugin as SprykerRouterSslRedirectEventDispatcherPlugin;
 use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 class RouterSslRedirectEventDispatcherPlugin extends SprykerRouterSslRedirectEventDispatcherPlugin
@@ -26,7 +26,7 @@ class RouterSslRedirectEventDispatcherPlugin extends SprykerRouterSslRedirectEve
      */
     protected function addListener(EventDispatcherInterface $eventDispatcher): EventDispatcherInterface
     {
-        $eventDispatcher->addListener(KernelEvents::REQUEST, function (GetResponseEvent $event): void {
+        $eventDispatcher->addListener(KernelEvents::REQUEST, function (RequestEvent $event): void {
             $request = $event->getRequest();
             if ($this->shouldBeSsl($request)) {
                 $fakeRequest = clone $request;

--- a/src/spryker/docker/image/nginx/root/etc/nginx/conf.d/zed.conf.template.twig
+++ b/src/spryker/docker/image/nginx/root/etc/nginx/conf.d/zed.conf.template.twig
@@ -3,7 +3,7 @@ server {
     listen 80;
     listen 443 ssl http2;
 
-    server_name ${ZED_HOST_{{ store_code }}} ${ZED_API_HOST_{{ store_code }}};
+    server_name ${ZED_HOST_{{ store_code }}}
 
     include snippets/certificate.conf;
     include snippets/ssl-params.conf;
@@ -12,7 +12,7 @@ server {
     {{ name }} {{ value }};
     {% endfor %}
 
-    root {{ @('app.web_directory') }}/Zed;
+    root {{ @('zed.root_dir') }};
 
     # Timeout for ZED requests - 10 minutes
     # (longer requests should be converted to jobs and executed via jenkins)
@@ -33,6 +33,46 @@ server {
     }
 
     # PHP application gets all other requests
+    location / {
+        add_header X-Server $hostname;
+        fastcgi_pass ${FPM_HOST}:{{ @('php-fpm.pools.zed.port') }};
+        fastcgi_index index.php;
+        include /etc/nginx/fastcgi_params;
+        fastcgi_param SCRIPT_NAME /index.php;
+        fastcgi_param SCRIPT_FILENAME  $document_root/index.php;
+
+        # Spryker variables
+        fastcgi_param APPLICATION_STORE {{ store_code }};
+    }
+}
+{% endfor %}
+
+{% for store_code, zed_api_external_host in @('zed_api.external_hosts') %}
+server {
+    listen 80;
+    listen 443 ssl http2;
+
+    server_name ${ZED_API_HOST_{{ store_code }}};
+
+    include snippets/certificate.conf;
+    include snippets/ssl-params.conf;
+
+    {% for name, value in @('nginx.site.conf') %}
+    {{ name }} {{ value }};
+    {% endfor %}
+
+    root {{ @('zed_api.root_dir') }};
+
+    # Timeout for ZED requests - 10 minutes
+    # (longer requests should be converted to jobs and executed via jenkins)
+    proxy_read_timeout 600s;
+    proxy_send_timeout 600s;
+    fastcgi_read_timeout {{ @('php.fpm.ini.max_execution_time') + 1 }}s;
+    client_body_timeout 600s;
+    client_header_timeout 600s;
+    send_timeout 600s;
+
+    # PHP application gets all requests
     location / {
         add_header X-Server $hostname;
         fastcgi_pass ${FPM_HOST}:{{ @('php-fpm.pools.zed.port') }};

--- a/src/spryker/harness.yml
+++ b/src/spryker/harness.yml
@@ -26,13 +26,13 @@ attributes:
   spryker:
     salt: 2tkqCCRKy5rT4wMVz8KTCh8r3sJGkL5v
     demoshop-url: https://github.com/spryker-shop/b2c-demo-shop.git
-    demoshop-version: "202009.0"
+    demoshop-version: "202108.0"
     mode: development
     oauth_client_secret: ~
     zed_request_token: ~
   php:
     composer:
-      major_version: 1
+      major_version: 2
     fpm:
       ini:
         max_execution_time: 600
@@ -89,7 +89,7 @@ attributes:
       php-fpm: "= 'my127/spryker:' ~ @('php.version') ~ '-fpm-' ~ (@('php.version') >= 7.4 ? 'buster' : 'stretch')"
   elasticsearch:
     image: elasticsearch
-    tag: '6.8.12'
+    tag: '7.16.2'
   hostname_aliases: "= replace(flatten([
       @('glue.external_hosts'),
       @('yves.external_hosts'),

--- a/src/spryker/harness.yml
+++ b/src/spryker/harness.yml
@@ -89,7 +89,7 @@ attributes:
       php-fpm: "= 'my127/spryker:' ~ @('php.version') ~ '-fpm-' ~ (@('php.version') >= 7.4 ? 'buster' : 'stretch')"
   elasticsearch:
     image: elasticsearch
-    tag: "= @('spryker.demoshop-version') <= '202009.0'? '6.8.22' : '7.16.2'"
+    tag: "= @('spryker.demoshop-version') <= '202009.0'? '6.8.23' : '7.16.3'"
   hostname_aliases: "= replace(flatten([
       @('glue.external_hosts'),
       @('yves.external_hosts'),

--- a/src/spryker/harness.yml
+++ b/src/spryker/harness.yml
@@ -32,7 +32,7 @@ attributes:
     zed_request_token: ~
   php:
     composer:
-      major_version: 2
+      major_version: 1
     fpm:
       ini:
         max_execution_time: 600

--- a/src/spryker/harness.yml
+++ b/src/spryker/harness.yml
@@ -89,7 +89,7 @@ attributes:
       php-fpm: "= 'my127/spryker:' ~ @('php.version') ~ '-fpm-' ~ (@('php.version') >= 7.4 ? 'buster' : 'stretch')"
   elasticsearch:
     image: elasticsearch
-    tag: "= @('spryker.demoshop-version') <= '202009.0'? '6.8.23' : '7.16.3'"
+    tag: "= version_compare(@('spryker.demoshop-version'), '202009.0', '<=') ? '6.8.23' : '7.16.3'"
   hostname_aliases: "= replace(flatten([
       @('glue.external_hosts'),
       @('yves.external_hosts'),

--- a/src/spryker/harness.yml
+++ b/src/spryker/harness.yml
@@ -32,7 +32,7 @@ attributes:
     zed_request_token: ~
   php:
     composer:
-      major_version: 1
+      major_version: 2
     fpm:
       ini:
         max_execution_time: 600

--- a/src/spryker/harness.yml
+++ b/src/spryker/harness.yml
@@ -89,7 +89,7 @@ attributes:
       php-fpm: "= 'my127/spryker:' ~ @('php.version') ~ '-fpm-' ~ (@('php.version') >= 7.4 ? 'buster' : 'stretch')"
   elasticsearch:
     image: elasticsearch
-    tag: '7.16.2'
+    tag: "= @('spryker.demoshop-version') <= '202009.0'? '6.8.22' : '7.16.2'"
   hostname_aliases: "= replace(flatten([
       @('glue.external_hosts'),
       @('yves.external_hosts'),
@@ -129,7 +129,7 @@ attributes:
       DE: = 'zed-api-de-' ~ @('hostname')
       AT: = 'zed-api-at-' ~ @('hostname')
       US: = 'zed-api-us-' ~ @('hostname')
-    root_dir: = @('app.web_directory') ~ '/BackendGateway'
+    root_dir: "= @('spryker.demoshop-version') >= '202108.0'? @('app.web_directory') ~ '/BackendGateway' : @('app.web_directory') ~ '/Zed'"
   glue:
     external_hosts:
       DE: = 'glue-de-' ~ @('hostname')

--- a/src/spryker/harness.yml
+++ b/src/spryker/harness.yml
@@ -123,11 +123,13 @@ attributes:
       DE: = 'zed-de-' ~ @('hostname')
       AT: = 'zed-at-' ~ @('hostname')
       US: = 'zed-us-' ~ @('hostname')
+    root_dir: = @('app.web_directory') ~ '/Zed'
   zed_api:
     external_hosts:
       DE: = 'zed-api-de-' ~ @('hostname')
       AT: = 'zed-api-at-' ~ @('hostname')
       US: = 'zed-api-us-' ~ @('hostname')
+    root_dir: = @('app.web_directory') ~ '/BackendGateway'
   glue:
     external_hosts:
       DE: = 'glue-de-' ~ @('hostname')


### PR DESCRIPTION
Fixes #654 

- [x] resolve composer dependency issues
- [x] incorporate latest Spryker config changes into config_local.php file
- [x] fix broken yves->zed communication (could be related to config update)
- [x] check if behat sample test is working (as we have updated behat modules to resolve composer deps)
- [x] ~add php8 support~ (will be added later in a separate MR, as they also support PHP 7.4)
- [ ] create separate issue to generate oauth secrets for remote environments