### PR TITLE
Allow defining replicas from attributes for application deployments, …

### DIFF
--- a/src/_base/helm/app/templates/application/console/deployment.yaml
+++ b/src/_base/helm/app/templates/application/console/deployment.yaml
@@ -11,7 +11,9 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "15"
 spec:
-  replicas: 1
+  {{- with (pick . "replicas") }}
+  {{- . | toYaml | nindent 2 }}
+  {{- end }}
   revisionHistoryLimit: 2
   selector:
     matchLabels:

--- a/src/_base/helm/app/templates/application/cron/deployment.yaml
+++ b/src/_base/helm/app/templates/application/cron/deployment.yaml
@@ -11,7 +11,9 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "15"
 spec:
-  replicas: 1
+  {{- with (pick . "replicas") }}
+  {{- . | toYaml | nindent 2 }}
+  {{- end }}
   revisionHistoryLimit: 2
   selector:
     matchLabels:

--- a/src/_base/helm/app/templates/application/webapp/deployment.yaml
+++ b/src/_base/helm/app/templates/application/webapp/deployment.yaml
@@ -11,7 +11,9 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "15"
 spec:
-  replicas: 1
+  {{- with (pick . "replicas") }}
+  {{- . | toYaml | nindent 2 }}
+  {{- end }}
   revisionHistoryLimit: 2
   selector:
     matchLabels:

--- a/src/_base/helm/app/templates/application/webapp/deployment.yaml
+++ b/src/_base/helm/app/templates/application/webapp/deployment.yaml
@@ -11,7 +11,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "15"
 spec:
-  {{- with (pick . "replicas") }}
+  {{- with (pick .Values.services.webapp "replicas") }}
   {{- . | toYaml | nindent 2 }}
   {{- end }}
   revisionHistoryLimit: 2

--- a/src/akeneo/helm/app/templates/application/job-queue-consumer/deployment.yaml
+++ b/src/akeneo/helm/app/templates/application/job-queue-consumer/deployment.yaml
@@ -11,7 +11,9 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "15"
 spec:
-  replicas: 1
+  {{- with (pick . "replicas") }}
+  {{- . | toYaml | nindent 2 }}
+  {{- end }}
   revisionHistoryLimit: 2
   selector:
     matchLabels:

--- a/src/spryker/helm/app/templates/application/jenkins-runner/deployment.yaml
+++ b/src/spryker/helm/app/templates/application/jenkins-runner/deployment.yaml
@@ -11,7 +11,9 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "15"
 spec:
-  replicas: 1
+  {{- with (pick . "replicas") }}
+  {{- . | toYaml | nindent 2 }}
+  {{- end }}
   revisionHistoryLimit: 2
   selector:
     matchLabels:


### PR DESCRIPTION
…removing the existing setting by default

While its not relevant to scale console and cron beyond 1, it may be useful to scale to 0 without "enabled: false" removing the deployment and any related resources