### PR TITLE
Fix issue with php service sub dicts copying into php-base

### DIFF
--- a/src/_base/harness/attributes/docker-base.yml
+++ b/src/_base/harness/attributes/docker-base.yml
@@ -43,6 +43,8 @@ attributes:
         memory: "100Mi"
     console:
       enabled: true
+      extends:
+        - php-base
       image: = @('docker.repository') ~ ':' ~ @('app.version') ~ '-console'
       publish: true
       build:
@@ -58,12 +60,16 @@ attributes:
         init_memory: "1024Mi"
         migrate_memory: "1024Mi"
     cron:
+      extends:
+        - php-base
       enabled: "= 'cron' in @('app.services')"
       image: = @('docker.repository') ~ ':' ~ @('app.version') ~ '-cron'
       publish: "= @('services.cron.enabled')"
       resources:
         memory: "1024Mi"
     php-fpm:
+      extends:
+        - php-base
       enabled: true
       image: = @('docker.repository') ~ ':' ~ @('app.version') ~ '-php-fpm'
       publish: true

--- a/src/_base/harness/config/functions.yml
+++ b/src/_base/harness/config/functions.yml
@@ -76,6 +76,7 @@ function('filter_local_services', [services]): |
         case 'enabled':
         case 'environment':
         case 'environment_dynamic':
+        case 'extends':
         case 'image':
         case 'resources':
           $filteredService[$key] = $value;

--- a/src/_base/helm/app/templates/_base_helper.tpl
+++ b/src/_base/helm/app/templates/_base_helper.tpl
@@ -73,9 +73,15 @@ stringData:
 {{ end }}
 {{- end }}
 
-{{- define "service.php.resolved" -}}
+{{/*
+A template to fully resolve services that extend template services
+*/}}
+{{- define "service.resolved" -}}
 {{- $service := index $.root.Values.services $.service_name -}}
-{{- $extended := index $.root.Values.services "php-base" -}}
-{{- $merged := mergeOverwrite (deepCopy $extended) (deepCopy $service) -}}
-{{ $merged | toYaml }}
+{{- $extended := (dict) -}}
+{{- range $service.extends -}}
+{{ $_ := mergeOverwrite $extended (include "service.resolved" (dict "root" $.root "service_name" .) | fromYaml) }}
+{{- end -}}
+{{- $_ := mergeOverwrite $extended $service -}}
+{{ $extended | toYaml }}
 {{- end -}}

--- a/src/_base/helm/app/templates/_base_helper.tpl
+++ b/src/_base/helm/app/templates/_base_helper.tpl
@@ -72,3 +72,10 @@ stringData:
 {{ end }}
 {{ end }}
 {{- end }}
+
+{{- define "service.php.resolved" -}}
+{{- $service := index $.root.Values.services $.service_name -}}
+{{- $extended := index $.root.Values.services "php-base" -}}
+{{- $merged := mergeOverwrite (deepCopy $extended) (deepCopy $service) -}}
+{{ $merged | toYaml }}
+{{- end -}}

--- a/src/_base/helm/app/templates/application/app-init.yaml
+++ b/src/_base/helm/app/templates/application/app-init.yaml
@@ -1,4 +1,4 @@
-{{- with (include "service.php.resolved" (dict "root" $ "service_name" "console") | fromYaml) -}}
+{{- with (include "service.resolved" (dict "root" $ "service_name" "console") | fromYaml) -}}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/src/_base/helm/app/templates/application/app-init.yaml
+++ b/src/_base/helm/app/templates/application/app-init.yaml
@@ -1,4 +1,4 @@
-{{- with mergeOverwrite (dict) (index .Values.services "php-base") (index .Values.services "console") -}}
+{{- with (include "service.php.resolved" (dict "root" $ "service_name" "console") | fromYaml) -}}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/src/_base/helm/app/templates/application/app-migrate.yaml
+++ b/src/_base/helm/app/templates/application/app-migrate.yaml
@@ -1,4 +1,4 @@
-{{- with (include "service.php.resolved" (dict "root" $ "service_name" "console") | fromYaml) -}}
+{{- with (include "service.resolved" (dict "root" $ "service_name" "console") | fromYaml) -}}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/src/_base/helm/app/templates/application/app-migrate.yaml
+++ b/src/_base/helm/app/templates/application/app-migrate.yaml
@@ -1,4 +1,4 @@
-{{- with mergeOverwrite (dict) (index .Values.services "php-base") (index .Values.services "console") -}}
+{{- with (include "service.php.resolved" (dict "root" $ "service_name" "console") | fromYaml) -}}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/src/_base/helm/app/templates/application/console/deployment.yaml
+++ b/src/_base/helm/app/templates/application/console/deployment.yaml
@@ -1,4 +1,4 @@
-{{- with mergeOverwrite (dict) (index .Values.services "php-base") (index .Values.services "console") -}}
+{{- with (include "service.php.resolved" (dict "root" $ "service_name" "console") | fromYaml) -}}
 {{- if .enabled -}}
 apiVersion: apps/v1
 kind: Deployment

--- a/src/_base/helm/app/templates/application/console/deployment.yaml
+++ b/src/_base/helm/app/templates/application/console/deployment.yaml
@@ -1,4 +1,4 @@
-{{- with (include "service.php.resolved" (dict "root" $ "service_name" "console") | fromYaml) -}}
+{{- with (include "service.resolved" (dict "root" $ "service_name" "console") | fromYaml) -}}
 {{- if .enabled -}}
 apiVersion: apps/v1
 kind: Deployment

--- a/src/_base/helm/app/templates/application/console/secret.yaml
+++ b/src/_base/helm/app/templates/application/console/secret.yaml
@@ -1,2 +1,2 @@
-{{- $service := include "service.php.resolved" (dict "root" $ "service_name" "console") | fromYaml -}}
+{{- $service := include "service.resolved" (dict "root" $ "service_name" "console") | fromYaml -}}
 {{ template "service.environment.secret" (dict "service_name" "console" "service" $service "root" $) }}

--- a/src/_base/helm/app/templates/application/console/secret.yaml
+++ b/src/_base/helm/app/templates/application/console/secret.yaml
@@ -1,2 +1,2 @@
-{{- $service := mergeOverwrite (dict) (index .Values.services "php-base") (index .Values.services "console") -}}
+{{- $service := include "service.php.resolved" (dict "root" $ "service_name" "console") | fromYaml -}}
 {{ template "service.environment.secret" (dict "service_name" "console" "service" $service "root" $) }}

--- a/src/_base/helm/app/templates/application/cron/deployment.yaml
+++ b/src/_base/helm/app/templates/application/cron/deployment.yaml
@@ -1,4 +1,4 @@
-{{- with (include "service.php.resolved" (dict "root" $ "service_name" "cron") | fromYaml) -}}
+{{- with (include "service.resolved" (dict "root" $ "service_name" "cron") | fromYaml) -}}
 {{- if .enabled -}}
 apiVersion: apps/v1
 kind: Deployment

--- a/src/_base/helm/app/templates/application/cron/deployment.yaml
+++ b/src/_base/helm/app/templates/application/cron/deployment.yaml
@@ -1,4 +1,4 @@
-{{- with mergeOverwrite (dict) (index .Values.services "php-base") (index .Values.services "cron") -}}
+{{- with (include "service.php.resolved" (dict "root" $ "service_name" "cron") | fromYaml) -}}
 {{- if .enabled -}}
 apiVersion: apps/v1
 kind: Deployment

--- a/src/_base/helm/app/templates/application/cron/secret.yaml
+++ b/src/_base/helm/app/templates/application/cron/secret.yaml
@@ -1,2 +1,2 @@
-{{- $service := mergeOverwrite (dict) (index .Values.services "php-base") (index .Values.services "cron") -}}
+{{- $service := include "service.php.resolved" (dict "root" $ "service_name" "cron") | fromYaml -}}
 {{ template "service.environment.secret" (dict "service_name" "cron" "service" $service "root" $) }}

--- a/src/_base/helm/app/templates/application/cron/secret.yaml
+++ b/src/_base/helm/app/templates/application/cron/secret.yaml
@@ -1,2 +1,2 @@
-{{- $service := include "service.php.resolved" (dict "root" $ "service_name" "cron") | fromYaml -}}
+{{- $service := include "service.resolved" (dict "root" $ "service_name" "cron") | fromYaml -}}
 {{ template "service.environment.secret" (dict "service_name" "cron" "service" $service "root" $) }}

--- a/src/_base/helm/app/templates/application/webapp/deployment.yaml
+++ b/src/_base/helm/app/templates/application/webapp/deployment.yaml
@@ -1,4 +1,4 @@
-{{- $service_php_fpm := include "service.php.resolved" (dict "root" $ "service_name" "php-fpm") | fromYaml -}}
+{{- $service_php_fpm := include "service.resolved" (dict "root" $ "service_name" "php-fpm") | fromYaml -}}
 {{- if .Values.services.webapp.enabled -}}
 apiVersion: apps/v1
 kind: Deployment

--- a/src/_base/helm/app/templates/application/webapp/deployment.yaml
+++ b/src/_base/helm/app/templates/application/webapp/deployment.yaml
@@ -1,4 +1,4 @@
-{{- $service_php_fpm := mergeOverwrite (dict) (index .Values.services "php-base") (index .Values.services "php-fpm") -}}
+{{- $service_php_fpm := include "service.php.resolved" (dict "root" $ "service_name" "php-fpm") | fromYaml -}}
 {{- if .Values.services.webapp.enabled -}}
 apiVersion: apps/v1
 kind: Deployment

--- a/src/_base/helm/app/templates/application/webapp/secret-php-fpm.yaml
+++ b/src/_base/helm/app/templates/application/webapp/secret-php-fpm.yaml
@@ -1,2 +1,2 @@
-{{- $service := mergeOverwrite (dict) (index .Values.services "php-base") (index .Values.services "php-fpm") -}}
+{{- $service := include "service.php.resolved" (dict "root" $ "service_name" "php-fpm") | fromYaml -}}
 {{ template "service.environment.secret" (dict "component" "webapp" "service_name" "php-fpm" "service" $service "root" $) }}

--- a/src/_base/helm/app/templates/application/webapp/secret-php-fpm.yaml
+++ b/src/_base/helm/app/templates/application/webapp/secret-php-fpm.yaml
@@ -1,2 +1,2 @@
-{{- $service := include "service.php.resolved" (dict "root" $ "service_name" "php-fpm") | fromYaml -}}
+{{- $service := include "service.resolved" (dict "root" $ "service_name" "php-fpm") | fromYaml -}}
 {{ template "service.environment.secret" (dict "component" "webapp" "service_name" "php-fpm" "service" $service "root" $) }}

--- a/src/akeneo/harness/attributes/docker.yml
+++ b/src/akeneo/harness/attributes/docker.yml
@@ -28,6 +28,8 @@ attributes:
         APP_DATABASE_PASSWORD: = @('database.pass')
         APP_SECRET: = @('akeneo.secret')
     job-queue-consumer:
+      extends:
+        - php-base
       enabled: "= 'job-queue-consumer' in @('app.services')"
       image: = @('docker.repository') ~ ':' ~ @('app.version') ~ '-job-queue-consumer'
       publish: = @('services.job-queue-consumer.enabled')

--- a/src/akeneo/helm/app/templates/application/job-queue-consumer/deployment.yaml
+++ b/src/akeneo/helm/app/templates/application/job-queue-consumer/deployment.yaml
@@ -1,4 +1,4 @@
-{{- with mergeOverwrite (dict) (index .Values.services "php-base") (index .Values.services "job-queue-consumer") -}}
+{{- with (include "service.php.resolved" (dict "root" $ "service_name" "job-queue-consumer") | fromYaml) -}}
 {{- if .enabled }}
 apiVersion: apps/v1
 kind: Deployment

--- a/src/akeneo/helm/app/templates/application/job-queue-consumer/deployment.yaml
+++ b/src/akeneo/helm/app/templates/application/job-queue-consumer/deployment.yaml
@@ -1,4 +1,4 @@
-{{- with (include "service.php.resolved" (dict "root" $ "service_name" "job-queue-consumer") | fromYaml) -}}
+{{- with (include "service.resolved" (dict "root" $ "service_name" "job-queue-consumer") | fromYaml) -}}
 {{- if .enabled }}
 apiVersion: apps/v1
 kind: Deployment

--- a/src/akeneo/helm/app/templates/application/job-queue-consumer/secret.yaml
+++ b/src/akeneo/helm/app/templates/application/job-queue-consumer/secret.yaml
@@ -1,2 +1,2 @@
-{{- $service := include "service.php.resolved" (dict "root" $ "service_name" "job-queue-consumer") | fromYaml -}}
+{{- $service := include "service.resolved" (dict "root" $ "service_name" "job-queue-consumer") | fromYaml -}}
 {{ template "service.environment.secret" (dict "service_name" "job-queue-consumer" "service" $service "root" $) }}

--- a/src/akeneo/helm/app/templates/application/job-queue-consumer/secret.yaml
+++ b/src/akeneo/helm/app/templates/application/job-queue-consumer/secret.yaml
@@ -1,2 +1,2 @@
-{{- $service := mergeOverwrite (dict) (index .Values.services "php-base") (index .Values.services "job-queue-consumer") -}}
+{{- $service := include "service.php.resolved" (dict "root" $ "service_name" "job-queue-consumer") | fromYaml -}}
 {{ template "service.environment.secret" (dict "service_name" "job-queue-consumer" "service" $service "root" $) }}

--- a/src/spryker/harness/attributes/docker.yml
+++ b/src/spryker/harness/attributes/docker.yml
@@ -35,6 +35,8 @@ attributes:
       resources:
         memory: "1536Mi"
     jenkins-runner:
+      extends:
+        - php-base
       enabled: "= 'jenkins-runner' in @('app.services')"
       image: = @('docker.repository') ~ ':' ~ @('app.version') ~ '-jenkins-runner'
       publish: = @('services.jenkins-runner.enabled')

--- a/src/spryker/helm/app/templates/application/jenkins-runner/deployment.yaml
+++ b/src/spryker/helm/app/templates/application/jenkins-runner/deployment.yaml
@@ -1,4 +1,4 @@
-{{- with (include "service.php.resolved" (dict "root" $ "service_name" "jenkins-runner") | fromYaml) -}}
+{{- with (include "service.resolved" (dict "root" $ "service_name" "jenkins-runner") | fromYaml) -}}
 {{- if .enabled -}}
 apiVersion: apps/v1
 kind: Deployment

--- a/src/spryker/helm/app/templates/application/jenkins-runner/deployment.yaml
+++ b/src/spryker/helm/app/templates/application/jenkins-runner/deployment.yaml
@@ -1,4 +1,4 @@
-{{- with mergeOverwrite (dict) (index .Values.services "php-base") (index .Values.services "jenkins-runner") -}}
+{{- with (include "service.php.resolved" (dict "root" $ "service_name" "jenkins-runner") | fromYaml) -}}
 {{- if .enabled -}}
 apiVersion: apps/v1
 kind: Deployment

--- a/src/spryker/helm/app/templates/application/jenkins-runner/secret.yaml
+++ b/src/spryker/helm/app/templates/application/jenkins-runner/secret.yaml
@@ -1,2 +1,2 @@
-{{- $service := mergeOverwrite (dict) (index .Values.services "php-base") (index .Values.services "jenkins-runner") -}}
+{{- $service := include "service.php.resolved" (dict "root" $ "service_name" "jenkins-runner") | fromYaml -}}
 {{ template "service.environment.secret" (dict "service_name" "jenkins-runner" "service" $service "root" $) }}

--- a/src/spryker/helm/app/templates/application/jenkins-runner/secret.yaml
+++ b/src/spryker/helm/app/templates/application/jenkins-runner/secret.yaml
@@ -1,2 +1,2 @@
-{{- $service := include "service.php.resolved" (dict "root" $ "service_name" "jenkins-runner") | fromYaml -}}
+{{- $service := include "service.resolved" (dict "root" $ "service_name" "jenkins-runner") | fromYaml -}}
 {{ template "service.environment.secret" (dict "service_name" "jenkins-runner" "service" $service "root" $) }}


### PR DESCRIPTION
 for all services

An example of an issue with this is AUTOSTART_PHP_FPM in php-fpm environment occasionally appearing in other pods depending on the non-deterministic order of resource rendering