### PR TITLE
Fix lighthouse result forwarding

### DIFF
--- a/src/_base/_twig/docker-compose.yml/service/lighthouse.yml.twig
+++ b/src/_base/_twig/docker-compose.yml/service/lighthouse.yml.twig
@@ -4,6 +4,7 @@
     command: "/bin/true"
     environment:
       TARGET_URL: "{{ @('lighthouse.target.url') | raw }}"
+      OUTPUT_RESULTS: "${OUTPUT_RESULTS:-}"
 {% if @('app.build') == 'dynamic' %}
     volumes:
       - .my127ws/docker/image/lighthouse/root/app:/app

--- a/src/_base/harness/config/commands.yml
+++ b/src/_base/harness/config/commands.yml
@@ -314,4 +314,4 @@ command('lighthouse [--with-results]'):
     OUTPUT_RESULTS:       = boolToString(input.option('with-results'))
   exec: |
     #!bash(workspace:/)|@
-    passthru docker-compose run --rm lighthouse bash -i /app/run.sh
+    passthru docker-compose run -T --rm lighthouse bash -i /app/run.sh


### PR DESCRIPTION
There were two issues:
- It wasn't allowing `ws lighthouse --with-results` command to pass `OUTPUT_RESULTS` env var correctly
- This ws command was executing docker-compose run with TTY, which was causing it to combine stdout and stderr, which was making it impossible to forward the result json output to a file on host machine (eg. `ws lighthouse --with-results > result.json`