### PR TITLE
Use elasticsearch user instead of root

### DIFF
--- a/src/_base/helm/app/templates/service/elasticsearch/deployment.yaml
+++ b/src/_base/helm/app/templates/service/elasticsearch/deployment.yaml
@@ -28,6 +28,7 @@ spec:
     spec:
       securityContext:
         fsGroup: 1000
+        runAsUser: 1000
       containers:
       - env:
         - name: ES_JAVA_OPTS


### PR DESCRIPTION
Until elasticsearch v7.9.3 it was working ok with the group being set as `elasticsearch/1000`, but since v7.16.2 it seems like it also requires the user to be set as `elasticsearch/1000`. This would make sure that the volume mount dir would be writeable by elasticsearch user.