### PR TITLE
Fix wrong platform mysql image on arm64 with new mysql:8.0-oracle image

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,6 +4,19 @@ In addition to the README's [Harness Upgrade Instructions], please note these sp
 
 ## Upgrading from 1.2.x to 1.3.x
 
+### MySQL
+
+We are switching back to Docker Inc's official mysql for arm64 computers, as it now supports arm64 on 8.0-oracle tag. This was also done because Oracle's mysql-server repository changed it's image publishing structure to no longer be multi-platform images.
+
+You can switch to any of the previous settings setting:
+
+e.g. to Docker Inc's official mysql 5.7 (with no arm64 support)
+```
+attribute('mysql.tag'): 5.7
+# since it's a multi-platform image of only one platform
+attribute('services.mysql.platform'): linux/amd64 
+```
+
 ### Spryker
 With support for Spryker 202108.0 release, we have upgraded the Elasticsearch version to 7.x and also there is a change in
 Zed application's root directory (Spryker now supports different entrypoints for backoffice and Zed gateway applications).

--- a/src/_base/harness/attributes/common.yml
+++ b/src/_base/harness/attributes/common.yml
@@ -352,9 +352,9 @@ attributes.default:
       steps: []
 
   mysql:
-    # prefer native platform mysql image. _/mysql doesn't have arm64 images
-    image: "= host_architecture() == 'amd64' ? 'mysql' : 'mysql/mysql-server'"
-    tag: '8.0'
+    image: mysql
+    # arm64 support is currently in a different tag
+    tag: "= host_architecture() == 'amd64' ? '8.0' : '8.0-oracle'"
 
   rabbitmq:
     image: rabbitmq


### PR DESCRIPTION
mysql/mysql-server:8.0 stopped being a multi-platform image sometime after it was implemented here