### PR TITLE
Allow specifying k8s context on sealed-secret commands

### DIFF
--- a/src/_base/harness/config/secrets.yml
+++ b/src/_base/harness/config/secrets.yml
@@ -1,17 +1,22 @@
-command('secret image-pull-config [--cert=<cert>] [--scope=<scope>] [--namespace=<namespace>]'):
+command('secret image-pull-config [--cert=<cert>] [--scope=<scope>] [--context=<context>] [--namespace=<namespace>]'):
   env:
     SEALED_SECRETS: "= boolToString(@('helm.feature.sealed_secrets'))"
     DEFAULT_CONFIG: = docker_config(@('docker.registry'))
     SEALED_SECRETS_CONTROLLER_NAME: = @('helm.sealed_secrets.controller_name')
     SEALED_SECRETS_CONTROLLER_NAMESPACE: = @('helm.sealed_secrets.controller_namespace')
     SEALED_SECRETS_CERTIFICATE_FILE: "= input.option('cert') ?: @('helm.sealed_secrets.certificate_file')"
+    K8S_CONTEXT: "= input.option('context') ?: ''"
     SECRET_NAMESPACE: "= input.option('namespace') ?: @('helm.sealed_secrets.namespace')"
     SECRET_SCOPE: "= input.option('scope') ?: @('helm.sealed_secrets.scope')"
   exec: |
     #!bash
-    if [ "$SEALED_SECRETS" == 'yes' ] && ! command -v kubeseal >/dev/null; then
-      echo 'kubeseal is needed in order to use this command' >&2
+    if [ "$SEALED_SECRETS" == 'yes' ] && ! command -v kubeseal kubectl >/dev/null; then
+      echo 'kubeseal and kubectl are needed in order to use this command' >&2
       exit 1
+    fi
+
+    if [ -z "${K8S_CONTEXT:-}" ]; then
+      K8S_CONTEXT="$(kubectl config current-context)"
     fi
 
     if [ -t 0 ] ; then
@@ -28,9 +33,10 @@ command('secret image-pull-config [--cert=<cert>] [--scope=<scope>] [--namespace
     DOCKER_CONFIG="${DOCKER_CONFIG:-${DEFAULT_CONFIG}}"
 
     if [ "$SEALED_SECRETS" == 'yes' ]; then
-      echo 'Encrypting as a sealed-secret value with certificate from current kubectl context' >&2
+      echo "Encrypting as a sealed-secret value with certificate from kubectl context '${K8S_CONTEXT}'" >&2
       DEFAULT_SCOPE=cluster-wide
       KUBESEAL_OPTS=(
+        --context "${K8S_CONTEXT}"
         --name "image-pull-config"
       )
       if [ -n "${SEALED_SECRETS_CONTROLLER_NAME:-}" ]; then
@@ -61,9 +67,10 @@ command('secret image-pull-config [--cert=<cert>] [--scope=<scope>] [--namespace
       echo "${DOCKER_CONFIG}" | base64
     fi
 
-command('sealed-secret encrypt (string|blob) [--cert=<cert>] [--scope=<scope>] [--namespace=<namespace>] <secret-name>'):
+command('sealed-secret encrypt (string|blob) [--cert=<cert>] [--scope=<scope>] [--context=<context>] [--namespace=<namespace>] <secret-name>'):
   env:
     INPUT_TYPE: = input.command(3)
+    K8S_CONTEXT: "= input.option('context') ?: ''"
     SEALED_SECRETS_CONTROLLER_NAME: = @('helm.sealed_secrets.controller_name')
     SEALED_SECRETS_CONTROLLER_NAMESPACE: = @('helm.sealed_secrets.controller_namespace')
     SEALED_SECRETS_CERTIFICATE_FILE: "= input.option('cert') ?: @('helm.sealed_secrets.certificate_file')"
@@ -72,9 +79,13 @@ command('sealed-secret encrypt (string|blob) [--cert=<cert>] [--scope=<scope>] [
     SECRET_SCOPE: "= input.option('scope') ?: @('helm.sealed_secrets.scope')"
   exec: |
     #!bash
-    if ! command -v kubeseal >/dev/null; then
-      echo 'kubeseal is needed in order to use this command' >&2
+    if ! command -v kubeseal kubectl >/dev/null; then
+      echo 'kubeseal and kubectl are needed in order to use this command' >&2
       exit 1
+    fi
+
+    if [ -z "${K8S_CONTEXT:-}" ]; then
+      K8S_CONTEXT="$(kubectl config current-context)"
     fi
 
     echo "Enter the secret ${INPUT_TYPE} to encrypt" >&2
@@ -96,9 +107,10 @@ command('sealed-secret encrypt (string|blob) [--cert=<cert>] [--scope=<scope>] [
         ;;
     esac
 
-    echo 'Encrypting as a sealed-secret value with certificate from current kubectl context' >&2
+    echo "Encrypting as a sealed-secret value with certificate from kubectl context '${K8S_CONTEXT}'" >&2
     DEFAULT_SCOPE=cluster-wide
     KUBESEAL_OPTS=(
+      --context "${K8S_CONTEXT}"
       --name "${SECRET_NAME}"
     )
     if [ -n "${SEALED_SECRETS_CONTROLLER_NAME:-}" ]; then


### PR DESCRIPTION
and print the context on the output (after input due to blob's editor view losing visibility of the first message)