### PR TITLE
Update k8s Ingress to v1 and add optional ingressClassName

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,6 +4,13 @@ In addition to the README's [Harness Upgrade Instructions], please note these sp
 
 ## Upgrading from 1.2.x to 1.3.x
 
+### Kubernetes Ingress v1
+Cloud Kubernetes providers such as Digitial Ocean will be forcing upgrades of Kubernetes to 1.22 in a few months, and will obsolete, amongst other things, Ingress extensions/v1beta1 and networking.k8s.io/v1beta1 apiVersions.
+
+This release includes an upgrade from networking.k8s.io/v1beta1 to networking.k8s.io/v1 apiVersion of Ingress resources to handle that.
+
+Care is needed to ensure GitOps cluster deploy tools can handle this, which includes ArgoCD needing to be at least version 1.8, due to a bug in applying networking.k8s.io/v1 Ingresses failing.
+
 ### MySQL
 
 We are switching back to Docker Inc's official mysql for arm64 computers, as it now supports arm64 on 8.0-oracle tag. This was also done because Oracle's mysql-server repository changed it's image publishing structure to no longer be multi-platform images.

--- a/src/_base/helm/app/templates/application/webapp/ingress.yaml
+++ b/src/_base/helm/app/templates/application/webapp/ingress.yaml
@@ -13,6 +13,9 @@ metadata:
     app.service: {{ .Values.resourcePrefix }}webapp
   name: {{ .Values.resourcePrefix }}webapp
 spec:
+  {{- with (pick .Values.ingress "ingressClassName" "tls") }}
+  {{- . | toYaml | nindent 2 }}
+  {{- end }}
   rules:
   - host: {{ index .Values.services "php-base" "environment" "APP_HOST" }}
     http:
@@ -22,10 +25,6 @@ spec:
             name: {{ .Values.resourcePrefix }}{{ .Values.ingress.target_service }}
             port:
               number: 80
-  {{- if .Values.ingress.tls }}
-  tls:
-  {{- toYaml .Values.ingress.tls | nindent 4 }}
-  {{- end }}
 status:
   loadBalancer: {}
 {{- end }}

--- a/src/_base/helm/app/templates/application/webapp/ingress.yaml
+++ b/src/_base/helm/app/templates/application/webapp/ingress.yaml
@@ -20,7 +20,9 @@ spec:
   - host: {{ index .Values.services "php-base" "environment" "APP_HOST" }}
     http:
       paths:
-      - backend:
+      - path: /
+        pathType: Prefix
+        backend:
           service:
             name: {{ .Values.resourcePrefix }}{{ .Values.ingress.target_service }}
             port:

--- a/src/_base/helm/app/templates/application/webapp/ingress.yaml
+++ b/src/_base/helm/app/templates/application/webapp/ingress.yaml
@@ -1,5 +1,5 @@
 {{ if and (index .Values.services .Values.ingress.target_service "enabled") (eq .Values.ingress.type "standard") }}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
 {{- with .Values.ingress.annotations }}
@@ -18,8 +18,10 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: {{ .Values.resourcePrefix }}{{ .Values.ingress.target_service }}
-          servicePort: 80
+          service:
+            name: {{ .Values.resourcePrefix }}{{ .Values.ingress.target_service }}
+            port:
+              number: 80
   {{- if .Values.ingress.tls }}
   tls:
   {{- toYaml .Values.ingress.tls | nindent 4 }}

--- a/src/spryker/helm/app/templates/application/webapp/ingress.yaml
+++ b/src/spryker/helm/app/templates/application/webapp/ingress.yaml
@@ -1,5 +1,5 @@
 {{ if and (index .Values.services .Values.ingress.target_service "enabled") (eq .Values.ingress.type "standard") }}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
 {{- with .Values.ingress.annotations }}
@@ -21,8 +21,10 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: {{ $.Values.resourcePrefix }}{{ $.Values.ingress.target_service }}
-          servicePort: 80
+          service:
+            name: {{ $.Values.resourcePrefix }}{{ $.Values.ingress.target_service }}
+            port:
+              number: 80
   {{- end }}
   {{- end }}
   {{- end }}


### PR DESCRIPTION
Needed for k8s 1.22, supported since 1.19, and requires ArgoCD > 1.8