### PR TITLE
Switch over Jenkins labels to linux-amd64

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ def isHarnessChange(harnesses) {
 }
 
 pipeline {
-    agent { label 'my127ws' }
+    agent { label 'linux-amd64' }
     environment {
         COMPOSE_DOCKER_CLI_BUILD = 1
         DOCKER_BUILDKIT = 1
@@ -29,7 +29,7 @@ pipeline {
                     // Choose a different agent to our "main" one
                     agent {
                        docker {
-                            label 'my127ws'
+                            label 'linux-amd64'
                             alwaysPull true
                             image 'quay.io/inviqa_images/workspace:latest'
                             args '--group-add docker --entrypoint "" --volume /var/run/docker.sock:/var/run/docker.sock --volume "$HOME/.my127:/root/.my127"'
@@ -149,7 +149,7 @@ pipeline {
                     // Choose a different agent to our "main" one
                     agent {
                         docker {
-                            label 'my127ws'
+                            label 'linux-amd64'
                             alwaysPull true
                             image 'quay.io/inviqa_images/workspace:latest'
                             args '--group-add docker --entrypoint "" --volume /var/run/docker.sock:/var/run/docker.sock --volume "$HOME/.my127:/root/.my127"'
@@ -242,7 +242,7 @@ pipeline {
                         docker {
                             // Reuse the same agent selected at the top of the file
                             reuseNode true
-                            label 'my127ws'
+                            label 'linux-amd64'
                             alwaysPull true
                             image 'quay.io/inviqa_images/workspace:latest'
                             args '--group-add docker --entrypoint "" --volume /var/run/docker.sock:/var/run/docker.sock --volume "$HOME/.my127:/root/.my127"'

--- a/src/_base/application/overlay/Jenkinsfile.twig
+++ b/src/_base/application/overlay/Jenkinsfile.twig
@@ -1,5 +1,5 @@
 pipeline {
-    agent { label "my127ws" }
+    agent { label 'linux-amd64' }
     environment {
         COMPOSE_DOCKER_CLI_BUILD = {{ @('jenkins.docker.buildkit.enabled') ? '1' : '0' }}
         DOCKER_BUILDKIT = {{ @('jenkins.docker.buildkit.enabled') ? '1' : '0' }}

--- a/src/drupal8/application/overlay/Jenkinsfile.twig
+++ b/src/drupal8/application/overlay/Jenkinsfile.twig
@@ -1,5 +1,5 @@
 pipeline {
-    agent { label "my127ws" }
+    agent { label 'linux-amd64' }
     environment {
         COMPOSE_DOCKER_CLI_BUILD = {{ @('jenkins.docker.buildkit.enabled') ? '1' : '0' }}
         DOCKER_BUILDKIT = {{ @('jenkins.docker.buildkit.enabled') ? '1' : '0' }}


### PR DESCRIPTION
This will be the new label we use, and if we have to rollback, we can just move the new label over