### PR TITLE
Ignore null template key values

### DIFF
--- a/src/_base/_twig/docker-compose.yml/service/nginx.yml.twig
+++ b/src/_base/_twig/docker-compose.yml/service/nginx.yml.twig
@@ -3,7 +3,7 @@
 {% set syncvolume = true %}
 {% endif %}
 {% set hostnames = [@('hostname')] %}
-{% set hostnames = hostnames|merge(@('hostname_aliases')|map(alias => "#{alias}." ~ @('domain'))) %}
+{% set hostnames = hostnames|merge(@('hostname_aliases')| filter(v => v is not empty) | map(alias => "#{alias}." ~ @('domain'))) %}
 
   nginx:
     build: .my127ws/docker/image/nginx

--- a/src/_base/harness/config/functions.yml
+++ b/src/_base/harness/config/functions.yml
@@ -255,6 +255,9 @@ function('template_key_value', [template, key_value]): |
   #!php
   $output = [];
   foreach ($key_value as $key => $value) {
+    if (!$value) {
+      continue;
+    }
     $output[str_replace('{{key}}', $key, $template)] = $value;
   }
   = $output;

--- a/src/_base/harness/config/functions.yml
+++ b/src/_base/harness/config/functions.yml
@@ -255,7 +255,7 @@ function('template_key_value', [template, key_value]): |
   #!php
   $output = [];
   foreach ($key_value as $key => $value) {
-    if (!$value) {
+    if ($value === null) {
       continue;
     }
     $output[str_replace('{{key}}', $key, $template)] = $value;

--- a/src/spryker/docker/image/nginx/root/etc/nginx/conf.d/glue.conf.template.twig
+++ b/src/spryker/docker/image/nginx/root/etc/nginx/conf.d/glue.conf.template.twig
@@ -1,4 +1,5 @@
 {% for store_code, glue_external_host in @('glue.external_hosts') %}
+{% if glue_external_host is not empty %}
 server {
     listen 80;
     listen 443 ssl http2;
@@ -50,4 +51,5 @@ server {
         fastcgi_param APPLICATION_STORE {{ store_code }};
     }
 }
+{% endif %}
 {% endfor %}

--- a/src/spryker/docker/image/nginx/root/etc/nginx/conf.d/yves.conf.template.twig
+++ b/src/spryker/docker/image/nginx/root/etc/nginx/conf.d/yves.conf.template.twig
@@ -1,4 +1,5 @@
 {% for store_code, yves_external_host in @('yves.external_hosts') %}
+{% if yves_external_host is not empty %}
 server {
     listen 80;
     listen 443 ssl http2;
@@ -62,4 +63,5 @@ server {
         fastcgi_param APPLICATION_STORE {{ store_code }};
     }
 }
+{% endif %}
 {% endfor %}

--- a/src/spryker/docker/image/nginx/root/etc/nginx/conf.d/zed.conf.template.twig
+++ b/src/spryker/docker/image/nginx/root/etc/nginx/conf.d/zed.conf.template.twig
@@ -1,4 +1,5 @@
 {% for store_code, zed_external_host in @('zed.external_hosts') %}
+{% if zed_external_host is not empty %}
 server {
     listen 80;
     listen 443 ssl http2;
@@ -85,4 +86,5 @@ server {
         fastcgi_param APPLICATION_STORE {{ store_code }};
     }
 }
+{% endif %}
 {% endfor %}


### PR DESCRIPTION
Currently for values set to `~` that are compiled together using this function, these values are still appended to the output. This ensures that for any null values passed into this function, that they are ignored.