### PR TITLE
Allow rabbitmq vhosts as null

### DIFF
--- a/src/_base/docker/image/console/root/lib/task/rabbitmq/vhosts.sh.twig
+++ b/src/_base/docker/image/console/root/lib/task/rabbitmq/vhosts.sh.twig
@@ -6,9 +6,12 @@ function task_rabbitmq_vhosts() {
     local rabbitmq_api_url="http://$RABBITMQ_HOST:$RABBITMQ_API_PORT/api"
     task http:wait "$rabbitmq_api_url/index.html"
 
+{% if @('rabbitmq.vhosts') is not null %}
 {% for vhost in @('rabbitmq.vhosts') %}
     curl --fail --silent --show-error --user "$RABBITMQ_USER:$RABBITMQ_PASSWORD" --request PUT "$rabbitmq_api_url/vhosts/{{ vhost }}"
 {% endfor %}
+{% endif %}
+
 {% else %}
     :
 {% endif %}


### PR DESCRIPTION
Allow removing all rabbitmq vhosts if you only use default vhost "/"

```yaml
attribute('rabbitmq.vhosts'): ~
```