### PR TITLE
Filter out the empty hosts from yves/zed on nginx conf.template

### DIFF
--- a/src/spryker/docker/image/nginx/root/etc/nginx/conf.d/yves.conf.template.twig
+++ b/src/spryker/docker/image/nginx/root/etc/nginx/conf.d/yves.conf.template.twig
@@ -1,4 +1,4 @@
-{% for store_code, yves_external_host in @('yves.external_hosts') %}
+{% for store_code, yves_external_host in @('yves.external_hosts') | filter(v => v is not empty) %}
 server {
     listen 80;
     listen 443 ssl http2;

--- a/src/spryker/docker/image/nginx/root/etc/nginx/conf.d/zed.conf.template.twig
+++ b/src/spryker/docker/image/nginx/root/etc/nginx/conf.d/zed.conf.template.twig
@@ -1,4 +1,4 @@
-{% for store_code, zed_external_host in @('zed.external_hosts') %}
+{% for store_code, zed_external_host in @('zed.external_hosts')|merge(@('zed_api.external_hosts')) | filter(v => v is not empty) %}
 server {
     listen 80;
     listen 443 ssl http2;

--- a/src/spryker/docker/image/nginx/root/etc/nginx/conf.d/zed.conf.template.twig
+++ b/src/spryker/docker/image/nginx/root/etc/nginx/conf.d/zed.conf.template.twig
@@ -1,4 +1,4 @@
-{% for store_code, zed_external_host in @('zed.external_hosts')|merge(@('zed_api.external_hosts')) | filter(v => v is not empty) %}
+{% for store_code, zed_external_host in @('zed.external_hosts') | filter(v => v is not empty) %}
 server {
     listen 80;
     listen 443 ssl http2;
@@ -47,7 +47,7 @@ server {
 }
 {% endfor %}
 
-{% for store_code, zed_api_external_host in @('zed_api.external_hosts') %}
+{% for store_code, zed_api_external_host in @('zed_api.external_hosts') | filter(v => v is not empty) %}
 server {
     listen 80;
     listen 443 ssl http2;


### PR DESCRIPTION
## Description

Allow defining null/empty external_hosts and filter them out from the conf.d yves|zed template.