### PR TITLE
Ignore null values from template_key_value func

### DIFF
--- a/src/_base/harness/config/functions.yml
+++ b/src/_base/harness/config/functions.yml
@@ -253,8 +253,8 @@ function('replace', [haystack, needle, replacement]): |
 
 function('template_key_value', [template, key_value]): |
   #!php
-  if ($key_value === null) {
-    return null;
+  if (empty($key_value)) {
+    return [];
   }
   $output = [];
   foreach ($key_value as $key => $value) {

--- a/src/_base/harness/config/functions.yml
+++ b/src/_base/harness/config/functions.yml
@@ -253,8 +253,14 @@ function('replace', [haystack, needle, replacement]): |
 
 function('template_key_value', [template, key_value]): |
   #!php
+  if ($key_value === null) {
+    return null;
+  }
   $output = [];
   foreach ($key_value as $key => $value) {
+    if ($value === null) {
+      continue;
+    }
     $output[str_replace('{{key}}', $key, $template)] = $value;
   }
   = $output;


### PR DESCRIPTION
## Description

Ignore all null values from the `key=>values`. 
Also add an early return `[]` if the `$key_value` is already empty anyhow.