### PR TITLE
Remove symfony flex post-update workaround now flex fixed

### DIFF
--- a/src/symfony/application/skeleton/composer.json.twig
+++ b/src/symfony/application/skeleton/composer.json.twig
@@ -9,7 +9,7 @@
         "ext-iconv": "*",
         "symfony/console": "~5.4",
         "symfony/dotenv": "~5.4",
-        "symfony/flex": "^2.1",
+        "symfony/flex": "^2.1.8",
         "symfony/framework-bundle": "~5.4",
         "symfony/runtime": "~5.4",
         "symfony/translation": "~5.4",
@@ -77,7 +77,6 @@
             "@auto-scripts"
         ],
         "post-update-cmd": [
-            "[ -e symfony.lock ] || composer sync-recipes",
             "@auto-scripts"
         ],
         "test": [


### PR DESCRIPTION
`https://github.com/symfony/flex/pull/907` released in 2.1.8 fixed the original issue this was solving.