### PR TITLE
Allow limiting chart publish by PR label

### DIFF
--- a/src/_base/application/overlay/Jenkinsfile.twig
+++ b/src/_base/application/overlay/Jenkinsfile.twig
@@ -84,7 +84,12 @@ pipeline {
                     branch '{{ @('pipeline.qa.branch') }}'
 {% endif %}
 {% if bool(@('pipeline.preview.enabled')) %}
-{% for branch in @('pipeline.preview.target_branches') %}
+{% if @('pipeline.preview.pull_request_labels') %}
+                    expression {
+                        return env.CHANGE_ID && {{ @('pipeline.preview.pull_request_labels') | json_encode }}.any { pullRequest.labels.contains(it) }
+                    }
+{% endif %}
+{% for branch in @('pipeline.preview.target_branches') | default([]) %}
                     changeRequest target: '{{ branch }}'
 {% endfor %}
 {% endif %}

--- a/src/_base/harness/attributes/common.yml
+++ b/src/_base/harness/attributes/common.yml
@@ -65,6 +65,10 @@ attributes.default:
       enabled: false
       target_branches:
         - = @('git.default_branch')
+      pull_request_labels: ~
+      # optionally limit by pull request label
+      # A future release will make this default
+      #  - publish-preview
       environment: {}
       cluster:
         name: null


### PR DESCRIPTION
A future release will make this default, and this will be a better way to avoid having a messy cluster repo