### PR TITLE
Use .max_memory instead of raw-value in redis

### DIFF
--- a/src/_base/helm/app/templates/service/redis/deployment.yaml
+++ b/src/_base/helm/app/templates/service/redis/deployment.yaml
@@ -31,7 +31,7 @@ spec:
       - args:
         - redis-server
         - --maxmemory
-        - "1073742000"
+        - {{ .max_memory | quote }}
         - --maxmemory-policy
         - allkeys-lru
         - --save


### PR DESCRIPTION
## 📚 Description

Right now we are using a raw value that define the max memory for redis-server: `"1073742000"`.
We could use the `.max_memory` variable instead.