### PR TITLE
Use ARM-compatible tag of official varnish docker image

### DIFF
--- a/src/_base/harness/attributes/docker-base.yml
+++ b/src/_base/harness/attributes/docker-base.yml
@@ -173,7 +173,7 @@ attributes:
         SOLR_CORE_NAME: collection1
         SOLR_VOLUME_DIR: "=@('services.solr.major_version') == 4 ? '/opt/solr/example/solr' : (@('services.solr.major_version') < 8 ? '/opt/solr/server/solr/mycores' : '/var/solr')"
       environment_secrets: {}
-      host: solr      
+      host: solr
       major_version: 8
       port: 8983
       resources:
@@ -188,7 +188,7 @@ attributes:
         memory: "256Mi"
     varnish:
       enabled: "= 'varnish' in @('app.services')"
-      image: varnish:6
+      image: 'varnish:6.6'
       environment:
         VARNISH_SIZE: "1024M"
       resources:

--- a/src/_base/harness/attributes/docker-base.yml
+++ b/src/_base/harness/attributes/docker-base.yml
@@ -188,7 +188,7 @@ attributes:
         memory: "256Mi"
     varnish:
       enabled: "= 'varnish' in @('app.services')"
-      image: 'varnish:6.6'
+      image: 'varnish:6.0'
       environment:
         VARNISH_SIZE: "1024M"
       resources:


### PR DESCRIPTION
`varnish:6` doesn't seem to have been published in a while on https://hub.docker.com/_/varnish?tab=tags

6.6 exists but last published 2 months ago, and not referenced as a supported tag in the description