### PR TITLE
Add pathType to Spryker webapp ingress

### DIFF
--- a/src/spryker/helm/app/templates/application/webapp/ingress.yaml
+++ b/src/spryker/helm/app/templates/application/webapp/ingress.yaml
@@ -20,7 +20,9 @@ spec:
   - host: {{ $value | quote }}
     http:
       paths:
-      - backend:
+      - path: /*
+        pathType: Prefix
+        backend:
           service:
             name: {{ $.Values.resourcePrefix }}{{ $.Values.ingress.target_service }}
             port:

--- a/src/spryker/helm/app/templates/application/webapp/ingress.yaml
+++ b/src/spryker/helm/app/templates/application/webapp/ingress.yaml
@@ -20,7 +20,7 @@ spec:
   - host: {{ $value | quote }}
     http:
       paths:
-      - path: /*
+      - path: /
         pathType: Prefix
         backend:
           service:


### PR DESCRIPTION
## Description

While upgrading our project to the latest harness, I faced this error:
``` 
spec.rules[0].http.paths[0].pathType: Required value: pathType must be specified, spec.rules[0].http.paths[1].pathType: Required value: pathType must be specified
```

After some research, I came to this post https://pet2cattle.com/2021/04/ingress-pathtype where it seems to be missing this property:
```yaml
pathType: Prefix
```

The question that I have now is: which of the three possible options would be the optimised for this field?

### We have tree options for selecting the pathType
- ImplementationSpecific: Matching will be handled by the IngressClass. Depending on the implementations can treat this in a different way
- Exact: Matches the URL path exactly with case sensitivity.
- Prefix: Matches based on a URL path prefix split by / (most common) It is also case sensitive on a path element by element basis.
