### PR TITLE
Add apiVersion to helm charts for lint error

### DIFF
--- a/src/_base/helm/app/Chart.yaml.twig
+++ b/src/_base/helm/app/Chart.yaml.twig
@@ -1,3 +1,4 @@
+apiVersion: v1
 name: {{ @('workspace.name') }}
 description: Base helm chart for {{ @('workspace.name') }}
 version: 0.0.1

--- a/src/_base/helm/qa/Chart.yaml.twig
+++ b/src/_base/helm/qa/Chart.yaml.twig
@@ -1,3 +1,4 @@
+apiVersion: v1
 name: {{ @('workspace.name') }}-qa
 description: Base helm chart for the {{ @('workspace.name') }}-qa environment
 version: 0.0.1

--- a/src/spryker/helm/preview/Chart.yaml
+++ b/src/spryker/helm/preview/Chart.yaml
@@ -1,3 +1,4 @@
+apiVersion: v1
 name: app-preview
 description: Base helm chart for the app-preview environment
 version: 0.0.1


### PR DESCRIPTION
While we still don't use `helm lint`, this solves the errors using it in helm 3.8.2