### PR TITLE
Add support for defining cpu requests resources for pods

### DIFF
--- a/src/_base/helm/app/templates/application/console/deployment.yaml
+++ b/src/_base/helm/app/templates/application/console/deployment.yaml
@@ -48,6 +48,9 @@ spec:
           limits:
             memory: {{ .resources.memory }}
           requests:
+            {{- with ((.resources.cpu | default (dict)).requests | default nil) }}
+            cpu: {{ . }}
+            {{- end }}
             memory: {{ .resources.memory }}
         readinessProbe:
           exec:

--- a/src/_base/helm/app/templates/application/cron/deployment.yaml
+++ b/src/_base/helm/app/templates/application/cron/deployment.yaml
@@ -64,6 +64,9 @@ spec:
           limits:
             memory: {{ .resources.memory }}
           requests:
+            {{- with ((.resources.cpu | default (dict)).requests | default nil) }}
+            cpu: {{ . }}
+            {{- end }}
             memory: {{ .resources.memory }}
         volumeMounts:
         {{- if not (and (eq "" (include "application.volumeMounts.backend" $)) (eq "" (include "application.volumeMounts.all" $)) ) }}

--- a/src/_base/helm/app/templates/application/webapp/deployment.yaml
+++ b/src/_base/helm/app/templates/application/webapp/deployment.yaml
@@ -68,6 +68,9 @@ spec:
           limits:
             memory: {{ .resources.memory }}
           requests:
+            {{- with ((.resources.cpu | default (dict)).requests | default nil) }}
+            cpu: {{ . }}
+            {{- end }}
             memory: {{ .resources.memory }}
         readinessProbe:
           tcpSocket:
@@ -107,6 +110,9 @@ spec:
           limits:
             memory: {{ .resources.memory }}
           requests:
+            {{- with ((.resources.cpu | default (dict)).requests | default nil) }}
+            cpu: {{ . }}
+            {{- end }}
             memory: {{ .resources.memory }}
         readinessProbe:
           tcpSocket:
@@ -144,6 +150,9 @@ spec:
           limits:
             memory: {{ .resources.memory }}
           requests:
+            {{- with ((.resources.cpu | default (dict)).requests | default nil) }}
+            cpu: {{ . }}
+            {{- end }}
             memory: {{ .resources.memory }}
         readinessProbe:
           tcpSocket:

--- a/src/_base/helm/app/templates/service/elasticsearch/deployment.yaml
+++ b/src/_base/helm/app/templates/service/elasticsearch/deployment.yaml
@@ -44,6 +44,9 @@ spec:
           limits:
             memory: {{ .resources.memory }}
           requests:
+            {{- with ((.resources.cpu | default (dict)).requests | default nil) }}
+            cpu: {{ . }}
+            {{- end }}
             memory: {{ .resources.memory }}
         readinessProbe:
           tcpSocket:

--- a/src/_base/helm/app/templates/service/mongodb/deployment.yaml
+++ b/src/_base/helm/app/templates/service/mongodb/deployment.yaml
@@ -46,6 +46,9 @@ spec:
           limits:
             memory: {{ .resources.memory }}
           requests:
+            {{- with ((.resources.cpu | default (dict)).requests | default nil) }}
+            cpu: {{ . }}
+            {{- end }}
             memory: {{ .resources.memory }}
         readinessProbe:
           tcpSocket:

--- a/src/_base/helm/app/templates/service/mysql/deployment.yaml
+++ b/src/_base/helm/app/templates/service/mysql/deployment.yaml
@@ -54,6 +54,9 @@ spec:
           limits:
             memory: {{ .resources.memory }}
           requests:
+            {{- with ((.resources.cpu | default (dict)).requests | default nil) }}
+            cpu: {{ . }}
+            {{- end }}
             memory: {{ .resources.memory }}
         readinessProbe:
           tcpSocket:

--- a/src/_base/helm/app/templates/service/postgres/deployment.yaml
+++ b/src/_base/helm/app/templates/service/postgres/deployment.yaml
@@ -46,6 +46,9 @@ spec:
           limits:
             memory: {{ .resources.memory }}
           requests:
+            {{- with ((.resources.cpu | default (dict)).requests | default nil) }}
+            cpu: {{ . }}
+            {{- end }}
             memory: {{ .resources.memory }}
         readinessProbe:
           tcpSocket:

--- a/src/_base/helm/app/templates/service/rabbitmq/deployment.yaml
+++ b/src/_base/helm/app/templates/service/rabbitmq/deployment.yaml
@@ -47,6 +47,9 @@ spec:
           limits:
             memory: {{ .resources.memory }}
           requests:
+            {{- with ((.resources.cpu | default (dict)).requests | default nil) }}
+            cpu: {{ . }}
+            {{- end }}
             memory: {{ .resources.memory }}
         readinessProbe:
           tcpSocket:

--- a/src/_base/helm/app/templates/service/redis-session/deployment.yaml
+++ b/src/_base/helm/app/templates/service/redis-session/deployment.yaml
@@ -51,6 +51,9 @@ spec:
           limits:
             memory: {{ .resources.memory }}
           requests:
+            {{- with ((.resources.cpu | default (dict)).requests | default nil) }}
+            cpu: {{ . }}
+            {{- end }}
             memory: {{ .resources.memory }}
         readinessProbe:
           tcpSocket:

--- a/src/_base/helm/app/templates/service/redis/deployment.yaml
+++ b/src/_base/helm/app/templates/service/redis/deployment.yaml
@@ -52,6 +52,9 @@ spec:
           limits:
             memory: {{ .resources.memory }}
           requests:
+            {{- with ((.resources.cpu | default (dict)).requests | default nil) }}
+            cpu: {{ . }}
+            {{- end }}
             memory: {{ .resources.memory }}
         readinessProbe:
           tcpSocket:

--- a/src/_base/helm/app/templates/service/solr/statefulset.yaml
+++ b/src/_base/helm/app/templates/service/solr/statefulset.yaml
@@ -51,6 +51,9 @@ spec:
           limits:
             memory: {{ .resources.memory }}
           requests:
+            {{- with ((.resources.cpu | default (dict)).requests | default nil) }}
+            cpu: {{ . }}
+            {{- end }}
             memory: {{ .resources.memory }}
         readinessProbe:
           tcpSocket:

--- a/src/_base/helm/app/templates/service/tideways/deployment.yaml
+++ b/src/_base/helm/app/templates/service/tideways/deployment.yaml
@@ -43,6 +43,9 @@ spec:
           limits:
             memory: {{ .resources.memory }}
           requests:
+            {{- with ((.resources.cpu | default (dict)).requests | default nil) }}
+            cpu: {{ . }}
+            {{- end }}
             memory: {{ .resources.memory }}
         readinessProbe:
           tcpSocket:

--- a/src/_base/helm/app/templates/service/varnish/statefulset.yaml
+++ b/src/_base/helm/app/templates/service/varnish/statefulset.yaml
@@ -37,6 +37,9 @@ spec:
           limits:
             memory: {{ .resources.memory }}
           requests:
+            {{- with ((.resources.cpu | default (dict)).requests | default nil) }}
+            cpu: {{ . }}
+            {{- end }}
             memory: {{ .resources.memory }}
         readinessProbe:
           tcpSocket:


### PR DESCRIPTION
Just cpu requests, as this is a minimum allocation in addition to scheduling. cpu limits is almost always a bad idea.