### PR TITLE
Add support for defining affinity and self service antiAffinity

### DIFF
--- a/src/_base/harness/attributes/docker-base.yml
+++ b/src/_base/harness/attributes/docker-base.yml
@@ -198,6 +198,9 @@ attributes:
       enabled: true
   pipeline:
     base:
+      global:
+        affinity:
+          selfAntiAffinityTopologyKey: ~
       prometheus:
         podMonitoring: false
       services:

--- a/src/_base/helm/app/templates/application/console/deployment.yaml
+++ b/src/_base/helm/app/templates/application/console/deployment.yaml
@@ -25,6 +25,7 @@ spec:
         app.kubernetes.io/component: console
         app.service: {{ $.Values.resourcePrefix }}console
     spec:
+      affinity: {{- include "pod.affinity" (dict "root" $ "serviceName" "console" "service" .) | nindent 8 }}
       containers:
       - env:
         {{- range $key, $value := (mergeOverwrite (dict) .environment .environment_dynamic) }}

--- a/src/_base/helm/app/templates/application/cron/deployment.yaml
+++ b/src/_base/helm/app/templates/application/cron/deployment.yaml
@@ -25,6 +25,7 @@ spec:
         app.kubernetes.io/component: cron
         app.service: {{ $.Values.resourcePrefix }}cron
     spec:
+      affinity: {{- include "pod.affinity" (dict "root" $ "serviceName" "cron" "service" .) | nindent 8 }}
       {{- if not (eq "" (include "application.volumes.wwwDataPaths" $)) }}
       initContainers:
       - name: cron-volume-permissions

--- a/src/_base/helm/app/templates/application/webapp/deployment.yaml
+++ b/src/_base/helm/app/templates/application/webapp/deployment.yaml
@@ -25,6 +25,7 @@ spec:
         app.kubernetes.io/component: webapp
         app.service: {{ .Values.resourcePrefix }}webapp
     spec:
+      affinity: {{- include "pod.affinity" (dict "root" $ "serviceName" "webapp" "service" .Values.services.webapp) | nindent 8 }}
       {{- if and $service_php_fpm.enabled (not (eq "" (include "application.volumes.wwwDataPaths" .))) }}
       initContainers:
       - name: webapp-volume-permissions

--- a/src/_base/helm/app/templates/service/solr/statefulset.yaml
+++ b/src/_base/helm/app/templates/service/solr/statefulset.yaml
@@ -27,6 +27,7 @@ spec:
         app.kubernetes.io/component: solr
         app.service: {{ $.Values.resourcePrefix }}solr
     spec:
+      affinity: {{- include "pod.affinity" (dict "root" $ "serviceName" "solr" "service" .) | nindent 8 }}
       securityContext:
         fsGroup: 8983
         runAsUser: 8983

--- a/src/_base/helm/app/templates/service/varnish/statefulset.yaml
+++ b/src/_base/helm/app/templates/service/varnish/statefulset.yaml
@@ -27,6 +27,7 @@ spec:
         app.kubernetes.io/component: varnish
         app.service: {{ $.Values.resourcePrefix }}varnish
     spec:
+      affinity: {{- include "pod.affinity" (dict "root" $ "serviceName" "varnish" "service" .) | nindent 8 }}
       containers:
       - name: varnish
         image: {{ .image | quote }}

--- a/src/_base/helm/app/values-preview.yaml.twig
+++ b/src/_base/helm/app/values-preview.yaml.twig
@@ -1,3 +1,6 @@
+{% if @('pipeline.preview.global') %}
+global: {{ to_nice_yaml(@('pipeline.preview.global'), 2, 2) | raw }}  
+{% endif %}
 {% if @('pipeline.preview.services') %}
 services: {{ to_nice_yaml(@('pipeline.preview.services'), 2, 2) | raw }}  
 {% endif %}

--- a/src/_base/helm/app/values-production.yaml.twig
+++ b/src/_base/helm/app/values-production.yaml.twig
@@ -1,3 +1,6 @@
+{% if @('pipeline.production.global') %}
+global: {{ to_nice_yaml(@('pipeline.production.global'), 2, 2) | raw }}  
+{% endif %}
 {% if @('pipeline.production.services') %}
 services: {{ to_nice_yaml(@('pipeline.production.services'), 2, 2) | raw }}  
 {% endif %}

--- a/src/_base/helm/app/values.yaml.twig
+++ b/src/_base/helm/app/values.yaml.twig
@@ -2,6 +2,8 @@ appVersion: {{ @('app.version') | json_encode | raw }}
 
 feature: {{ to_nice_yaml(@('helm.feature'), 2, 2) | raw }}
 
+global: {{ to_nice_yaml(@('pipeline.base.global'), 2, 2) | raw }}
+
 ingress: {{ to_nice_yaml(@('pipeline.base.ingress'), 2, 2) | raw }}
 
 docker:

--- a/src/akeneo/helm/app/templates/application/job-queue-consumer/deployment.yaml
+++ b/src/akeneo/helm/app/templates/application/job-queue-consumer/deployment.yaml
@@ -25,6 +25,7 @@ spec:
         app.kubernetes.io/component: job-queue-consumer
         app.service: {{ $.Values.resourcePrefix }}job-queue-consumer
     spec:
+      affinity: {{- include "pod.affinity" (dict "root" $ "serviceName" "job-queue-consumer" "service" .) | nindent 8 }}
       {{- if not (eq "" (include "application.volumes.wwwDataPaths" $)) }}
       initContainers:
       - name: job-queue-consumer-volume-permissions

--- a/src/spryker/helm/app/templates/application/jenkins-runner/deployment.yaml
+++ b/src/spryker/helm/app/templates/application/jenkins-runner/deployment.yaml
@@ -25,6 +25,7 @@ spec:
         app.kubernetes.io/component: jenkins-runner
         app.service: {{ $.Values.resourcePrefix }}jenkins-runner
     spec:
+      affinity: {{- include "pod.affinity" (dict "root" $ "serviceName" "jenkins-runner" "service" .) | nindent 8 }}
       containers:
       - env:
         {{- range $key, $value := (mergeOverwrite (dict) .environment .environment_dynamic) }}


### PR DESCRIPTION
Its a common need to space out replicas so they are more guaranteed to be in separate zones or hosts, so a global setting can set the topologyKey across all replicable services.

Also support direct affinity configuration as well, merging the specific setting arrays together