### PR TITLE
Fix spryker build failure

### DIFF
--- a/src/spryker/application/skeleton/composer-harness.json.twig
+++ b/src/spryker/application/skeleton/composer-harness.json.twig
@@ -16,6 +16,7 @@
     "dmore/chrome-mink-driver": "^2.6",
     "jakoch/phantomjs-installer": "^3.0",
     "roave/better-reflection": "^4.3.0",
+    "phpstan/phpstan": "~1.6.9",
     "phpcompatibility/php-compatibility": "dev-master",
     "sensiolabs/behat-page-object-extension": "^2.3",
     "guzzlehttp/guzzle": "^6.3.0",

--- a/src/spryker/application/skeleton/phpstan-baseline.neon
+++ b/src/spryker/application/skeleton/phpstan-baseline.neon
@@ -1,51 +1,31 @@
 parameters:
-    ignoreErrors:
-        -
-            message: "#^Parameter \\#2 \\$value of method Elastica\\\\Query\\\\Term\\:\\:setTerm\\(\\) expects array|string, int given\\.$#"
-            count: 1
-            path: src/Pyz/Client/ExampleProductSalePage/Plugin/Elasticsearch/Query/SaleSearchQueryPlugin.php
+	ignoreErrors:
+		-
+			message: "#^Parameter \\#1 \\$rawCatalogSearchResultFormatterPlugin of class Spryker\\\\Client\\\\CatalogPriceProductConnector\\\\Plugin\\\\CurrencyAwareSuggestionByTypeResultFormatter constructor expects Spryker\\\\Client\\\\Search\\\\Dependency\\\\Plugin\\\\ResultFormatterPluginInterface, Spryker\\\\Client\\\\SearchElasticsearch\\\\Plugin\\\\ResultFormatter\\\\SuggestionByTypeResultFormatterPlugin given\\.$#"
+			count: 1
+			path: src/Pyz/Client/Catalog/CatalogDependencyProvider.php
 
-        -
-            message: "#^Parameter \\#2 \\$default of method Symfony\\\\Component\\\\HttpFoundation\\\\InputBag\\:\\:get\\(\\) expects string|null, array given\\.$#"
-            count: 1
-            path: src/Pyz/Yves/ProductSetWidget/Widget/ProductSetIdsWidget.php
+		-
+			message: "#^Parameter \\#1 \\$input of function array_filter expects array, string given\\.$#"
+			count: 1
+			path: src/Pyz/Yves/ProductSetWidget/Widget/ProductSetIdsWidget.php
 
-        -
-            message: "#^Parameter \\#1 \\$input of function array_filter expects array, string given\\.$#"
-            count: 1
-            path: src/Pyz/Yves/ProductSetWidget/Widget/ProductSetIdsWidget.php
+		-
+			message: "#^Parameter \\#2 \\$default of method Symfony\\\\Component\\\\HttpFoundation\\\\InputBag\\:\\:get\\(\\) expects bool\\|float\\|int\\|string\\|null, array given\\.$#"
+			count: 1
+			path: src/Pyz/Yves/ProductSetWidget/Widget/ProductSetIdsWidget.php
 
-        -
-            message: "#^Parameter \\#1 \\$exampleStateMachineItems of method Pyz\\\\Zed\\\\ExampleStateMachine\\\\Business\\\\Model\\\\ExampleStateMachineItemReader\\:\\:hydrateTransferFromPersistence\\(\\) expects#"
-            count: 2
-            path: src/Pyz/Zed/ExampleStateMachine/Business/Model/ExampleStateMachineItemReader.php
+		-
+			message: "#^Parameter \\#2 \\$serverUniqueId of method Spryker\\\\Zed\\\\Queue\\\\Business\\\\Process\\\\ProcessManager\\:\\:__construct\\(\\) expects string, int given\\.$#"
+			count: 1
+			path: src/Pyz/Zed/Queue/Business/Process/ProcessManager.php
 
-        -
-            message: "#^Parameter \\#1 \\$command of class Symfony\\\\Component\\\\Process\\\\Process constructor expects array, string given\\.$#"
-            count: 2
-            path: src/Pyz/Zed/Log/Communication/Plugin/FilebeatLogListenerPlugin.php
+		-
+			message: "#^Parameter \\#2 \\$serverUniqueId of class Pyz\\\\Zed\\\\Queue\\\\Business\\\\Process\\\\ProcessManager constructor expects int, string given\\.$#"
+			count: 1
+			path: src/Pyz/Zed/Queue/Business/QueueBusinessFactory.php
 
-        -
-            message: "#^Parameter \\#1 \\$productFacade of class Pyz\\\\Zed\\\\ProductUrlCartConnector\\\\Business\\\\Expander\\\\ProductUrlExpander constructor expects Spryker\\\\Zed\\\\Product\\\\Business\\\\ProductFacadeInterface, Spryker\\\\Zed\\\\ProductRelation\\\\Business\\\\ProductRelationFacadeInterface given\\.$#"
-            count: 1
-            path: src/Pyz/Zed/ProductUrlCartConnector/Business/ProductUrlCartConnectorBusinessFactory.php
-
-        -
-            message: "#^Parameter \\#2 \\$serverUniqueId of method Spryker\\\\Zed\\\\Queue\\\\Business\\\\Process\\\\ProcessManager\\:\\:__construct\\(\\) expects string, int given\\.$#"
-            count: 1
-            path: src/Pyz/Zed/Queue/Business/Process/ProcessManager.php
-
-        -
-            message: "#^Parameter \\#2 \\$serverUniqueId of class Pyz\\\\Zed\\\\Queue\\\\Business\\\\Process\\\\ProcessManager constructor expects int, string given\\.$#"
-            count: 1
-            path: src/Pyz/Zed/Queue/Business/QueueBusinessFactory.php
-
-        -
-            message: "#^Parameter \\#3 \\$queueConfig of class Pyz\\\\Zed\\\\Queue\\\\Business\\\\Process\\\\ProcessManager constructor expects Pyz\\\\Zed\\\\Queue\\\\QueueConfig, Spryker\\\\Zed\\\\Queue\\\\QueueConfig given\\.$#"
-            count: 1
-            path: src/Pyz/Zed/Queue/Business/QueueBusinessFactory.php
-
-        -
-            message: "#^Parameter \\#2 \\$entityId of method Spryker\\\\Zed\\\\DataImport\\\\Business\\\\Model\\\\DataImportStep\\\\PublishAwareStep\\:\\:addPublishEvents\\(\\) expects int, Orm\\\\Zed\\\\Product\\\\Persistence\\\\SpyProductAbstract given\\.$#"
-            count: 1
-            path: src/Pyz/Zed/DataImport/Business/Model/ProductOption/ProductOptionWriterStep.php
+		-
+			message: "#^Parameter \\#3 \\$queueConfig of class Pyz\\\\Zed\\\\Queue\\\\Business\\\\Process\\\\ProcessManager constructor expects Pyz\\\\Zed\\\\Queue\\\\QueueConfig, Spryker\\\\Zed\\\\Queue\\\\QueueConfig given\\.$#"
+			count: 1
+			path: src/Pyz/Zed/Queue/Business/QueueBusinessFactory.php

--- a/src/spryker/application/skeleton/phpstan-baseline.neon
+++ b/src/spryker/application/skeleton/phpstan-baseline.neon
@@ -1,31 +1,51 @@
 parameters:
-	ignoreErrors:
-		-
-			message: "#^Parameter \\#1 \\$rawCatalogSearchResultFormatterPlugin of class Spryker\\\\Client\\\\CatalogPriceProductConnector\\\\Plugin\\\\CurrencyAwareSuggestionByTypeResultFormatter constructor expects Spryker\\\\Client\\\\Search\\\\Dependency\\\\Plugin\\\\ResultFormatterPluginInterface, Spryker\\\\Client\\\\SearchElasticsearch\\\\Plugin\\\\ResultFormatter\\\\SuggestionByTypeResultFormatterPlugin given\\.$#"
-			count: 1
-			path: src/Pyz/Client/Catalog/CatalogDependencyProvider.php
+    ignoreErrors:
+        -
+            message: "#^Parameter \\#2 \\$value of method Elastica\\\\Query\\\\Term\\:\\:setTerm\\(\\) expects array|string, int given\\.$#"
+            count: 1
+            path: src/Pyz/Client/ExampleProductSalePage/Plugin/Elasticsearch/Query/SaleSearchQueryPlugin.php
 
-		-
-			message: "#^Parameter \\#1 \\$input of function array_filter expects array, string given\\.$#"
-			count: 1
-			path: src/Pyz/Yves/ProductSetWidget/Widget/ProductSetIdsWidget.php
+        -
+            message: "#^Parameter \\#2 \\$default of method Symfony\\\\Component\\\\HttpFoundation\\\\InputBag\\:\\:get\\(\\) expects string|null, array given\\.$#"
+            count: 1
+            path: src/Pyz/Yves/ProductSetWidget/Widget/ProductSetIdsWidget.php
 
-		-
-			message: "#^Parameter \\#2 \\$default of method Symfony\\\\Component\\\\HttpFoundation\\\\InputBag\\:\\:get\\(\\) expects bool\\|float\\|int\\|string\\|null, array given\\.$#"
-			count: 1
-			path: src/Pyz/Yves/ProductSetWidget/Widget/ProductSetIdsWidget.php
+        -
+            message: "#^Parameter \\#1 \\$input of function array_filter expects array, string given\\.$#"
+            count: 1
+            path: src/Pyz/Yves/ProductSetWidget/Widget/ProductSetIdsWidget.php
 
-		-
-			message: "#^Parameter \\#2 \\$serverUniqueId of method Spryker\\\\Zed\\\\Queue\\\\Business\\\\Process\\\\ProcessManager\\:\\:__construct\\(\\) expects string, int given\\.$#"
-			count: 1
-			path: src/Pyz/Zed/Queue/Business/Process/ProcessManager.php
+        -
+            message: "#^Parameter \\#1 \\$exampleStateMachineItems of method Pyz\\\\Zed\\\\ExampleStateMachine\\\\Business\\\\Model\\\\ExampleStateMachineItemReader\\:\\:hydrateTransferFromPersistence\\(\\) expects#"
+            count: 2
+            path: src/Pyz/Zed/ExampleStateMachine/Business/Model/ExampleStateMachineItemReader.php
 
-		-
-			message: "#^Parameter \\#2 \\$serverUniqueId of class Pyz\\\\Zed\\\\Queue\\\\Business\\\\Process\\\\ProcessManager constructor expects int, string given\\.$#"
-			count: 1
-			path: src/Pyz/Zed/Queue/Business/QueueBusinessFactory.php
+        -
+            message: "#^Parameter \\#1 \\$command of class Symfony\\\\Component\\\\Process\\\\Process constructor expects array, string given\\.$#"
+            count: 2
+            path: src/Pyz/Zed/Log/Communication/Plugin/FilebeatLogListenerPlugin.php
 
-		-
-			message: "#^Parameter \\#3 \\$queueConfig of class Pyz\\\\Zed\\\\Queue\\\\Business\\\\Process\\\\ProcessManager constructor expects Pyz\\\\Zed\\\\Queue\\\\QueueConfig, Spryker\\\\Zed\\\\Queue\\\\QueueConfig given\\.$#"
-			count: 1
-			path: src/Pyz/Zed/Queue/Business/QueueBusinessFactory.php
+        -
+            message: "#^Parameter \\#1 \\$productFacade of class Pyz\\\\Zed\\\\ProductUrlCartConnector\\\\Business\\\\Expander\\\\ProductUrlExpander constructor expects Spryker\\\\Zed\\\\Product\\\\Business\\\\ProductFacadeInterface, Spryker\\\\Zed\\\\ProductRelation\\\\Business\\\\ProductRelationFacadeInterface given\\.$#"
+            count: 1
+            path: src/Pyz/Zed/ProductUrlCartConnector/Business/ProductUrlCartConnectorBusinessFactory.php
+
+        -
+            message: "#^Parameter \\#2 \\$serverUniqueId of method Spryker\\\\Zed\\\\Queue\\\\Business\\\\Process\\\\ProcessManager\\:\\:__construct\\(\\) expects string, int given\\.$#"
+            count: 1
+            path: src/Pyz/Zed/Queue/Business/Process/ProcessManager.php
+
+        -
+            message: "#^Parameter \\#2 \\$serverUniqueId of class Pyz\\\\Zed\\\\Queue\\\\Business\\\\Process\\\\ProcessManager constructor expects int, string given\\.$#"
+            count: 1
+            path: src/Pyz/Zed/Queue/Business/QueueBusinessFactory.php
+
+        -
+            message: "#^Parameter \\#3 \\$queueConfig of class Pyz\\\\Zed\\\\Queue\\\\Business\\\\Process\\\\ProcessManager constructor expects Pyz\\\\Zed\\\\Queue\\\\QueueConfig, Spryker\\\\Zed\\\\Queue\\\\QueueConfig given\\.$#"
+            count: 1
+            path: src/Pyz/Zed/Queue/Business/QueueBusinessFactory.php
+
+        -
+            message: "#^Parameter \\#2 \\$entityId of method Spryker\\\\Zed\\\\DataImport\\\\Business\\\\Model\\\\DataImportStep\\\\PublishAwareStep\\:\\:addPublishEvents\\(\\) expects int, Orm\\\\Zed\\\\Product\\\\Persistence\\\\SpyProductAbstract given\\.$#"
+            count: 1
+            path: src/Pyz/Zed/DataImport/Business/Model/ProductOption/ProductOptionWriterStep.php


### PR DESCRIPTION
Fixes this build failure:
```
 ------ -----------------------------------------------------------------------
  Line   Pyz/Client/Catalog/CatalogDependencyProvider.php
 ------ -----------------------------------------------------------------------
  147    Parameter #1 $rawCatalogSearchResultFormatterPlugin of class
         Spryker\Client\CatalogPriceProductConnector\Plugin\CurrencyAwareSugge
         stionByTypeResultFormatter constructor expects
         Spryker\Client\Search\Dependency\Plugin\ResultFormatterPluginInterfac
         e,
         Spryker\Client\SearchElasticsearch\Plugin\ResultFormatter\SuggestionB
         yTypeResultFormatterPlugin given.
 ------ -----------------------------------------------------------------------
```
The file https://github.com/spryker/search/blob/master/src/Spryker/Client/Search/Dependency/Plugin/ResultFormatterPluginInterface.php is included and has a class_alias() to the new implementation.

phpstan 1.7.2 is having issues loading this, tried adding `vendor/spryker/search/src/Spryker/Client/Search/Dependency/Plugin/ResultFormatterPluginInterface.php` as a bootstrap file but it didn't help.