### PR TITLE
Fix harness.yml to use /Backoffice as root_dir for spryker versions newer 202108.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ A developer for a project can follow these steps to upgrade their harness versio
 ```bash
 git clone git@github.com:inviqa/harness-<framework>.git
 cd harness-<framework>
-git checkout 1.4.0
+git checkout 1.5.0
 pwd # Use this path for the diff in step 3
 ```
 4. Update the `workspace.yml` harness version (usually line 2 or 3) to the new tagged version.
@@ -161,7 +161,7 @@ The [deploy script](./deploy) does a similar thing but the end result is output 
 committed as a publish commit to a temporary build branch.
 
 A "subtree-split" is then performed which outputs a directory for each folder into a "publish" folder, where it is then
-force pushed to the individual harness repositories' `1.4.x` branch.
+force pushed to the individual harness repositories' `1.5.x` branch.
 
 ## Release
 
@@ -169,19 +169,19 @@ force pushed to the individual harness repositories' `1.4.x` branch.
 
 We are keeping a changelog, powered by [GitHub Changelog Generator].
 
-When ready to tag a release, make a new branch from the `1.4.x` branch for the changelog entries:
+When ready to tag a release, make a new branch from the `1.5.x` branch for the changelog entries:
 1. Generate a `repo` scope token for use with the changelog generator: https://github.com/settings/tokens/new?description=GitHub%20Changelog%20Generator%20token
 2. Export it in your environment: `export CHANGELOG_GITHUB_TOKEN=...`
-3. Run the following docker command to generate the changelog, replacing `1.4.0` with the version number as needed:
+3. Run the following docker command to generate the changelog, replacing `1.5.0` with the version number as needed:
   ```bash
-  docker run -e CHANGELOG_GITHUB_TOKEN="$CHANGELOG_GITHUB_TOKEN" -it --rm -v "$(pwd)":/usr/local/src/your-app -v "$(pwd)/github-changelog-http-cache":/tmp/github-changelog-http-cache githubchangeloggenerator/github-changelog-generator --user inviqa --project harness-base-php --exclude-labels "duplicate,question,invalid,wontfix,skip-changelog" --release-branch 1.4.x --future-release 1.4.0
+  docker run -e CHANGELOG_GITHUB_TOKEN="$CHANGELOG_GITHUB_TOKEN" -it --rm -v "$(pwd)":/usr/local/src/your-app -v "$(pwd)/github-changelog-http-cache":/tmp/github-changelog-http-cache githubchangeloggenerator/github-changelog-generator --user inviqa --project harness-base-php --exclude-labels "duplicate,question,invalid,wontfix,skip-changelog" --release-branch 1.5.x --future-release 1.5.0
   ```
 4. Examine the generated CHANGELOG.md. For every entry in the `Merged pull requests` section, examine the Pull Requests
    and assign each pull request either a `enhancement` label for a new feature, `bug` for a bugfix or `deprecated` for
    a deprecation.
 5. For each Pull Request in the release, assign an appropriate `harness-*` label.
 6. Re-generate the changelog using step 3 as needed.
-7. Adjust the version for each framework's README.md: `sed -i '' s/1\.1\.2/1.4.0/ README.md src/*/README.md src/*/docs/*.md  src/*/docs/*/*.md`
+7. Adjust the version for each framework's README.md: `sed -i '' s/1\.1\.2/1.5.0/ README.md src/*/README.md src/*/docs/*.md  src/*/docs/*/*.md`
 8. Commit the resulting changes, push and raise a pull request.
 9. Once merged, continue with the release process below.
 
@@ -189,41 +189,41 @@ When ready to tag a release, make a new branch from the `1.4.x` branch for the c
 
 Once the CHANGELOG.markdown is in the branch you wish to release:
 
-1. Tag the release version with `git tag 1.4.0 -m "v1.4.0"`
-2. Push the tag to the repository: `git push origin 1.4.0`
+1. Tag the release version with `git tag 1.5.0 -m "v1.5.0"`
+2. Push the tag to the repository: `git push origin 1.5.0`
 3. Verify you don't have any ignored files in `src/`, and clean up if you do: `git status --ignored`
 4. Run the deploy script: `./deploy`
 5. Submit a pull request to [my127/my127.io] which adds the new release version and asset download URL for the
    php-based harnesses to `harnesses.json`
 6. Create a "Github Release" for this repository and downstream repositories, pasting in the changelog for the release:
-   - https://github.com/inviqa/harness-base-php/releases/new?tag=1.4.0&title=1.4.0&target=1.4.x
-   - https://github.com/inviqa/harness-php/releases/new?tag=1.4.0&title=1.4.0&target=1.4.x
-   - https://github.com/inviqa/harness-akeneo/releases/new?tag=1.4.0&title=1.4.0&target=1.4.x
-   - https://github.com/inviqa/harness-drupal8/releases/new?tag=1.4.0&title=1.4.0&target=1.4.x
-   - https://github.com/inviqa/harness-magento1/releases/new?tag=1.4.0&title=1.4.0&target=1.4.x
-   - https://github.com/inviqa/harness-magento2/releases/new?tag=1.4.0&title=1.4.0&target=1.4.x
-   - https://github.com/inviqa/harness-spryker/releases/new?tag=1.4.0&title=1.4.0&target=1.4.x
-   - https://github.com/inviqa/harness-symfony/releases/new?tag=1.4.0&title=1.4.0&target=1.4.x
-   - https://github.com/inviqa/harness-wordpress/releases/new?tag=1.4.0&title=1.4.0&target=1.4.x
+   - https://github.com/inviqa/harness-base-php/releases/new?tag=1.5.0&title=1.5.0&target=1.5.x
+   - https://github.com/inviqa/harness-php/releases/new?tag=1.5.0&title=1.5.0&target=1.5.x
+   - https://github.com/inviqa/harness-akeneo/releases/new?tag=1.5.0&title=1.5.0&target=1.5.x
+   - https://github.com/inviqa/harness-drupal8/releases/new?tag=1.5.0&title=1.5.0&target=1.5.x
+   - https://github.com/inviqa/harness-magento1/releases/new?tag=1.5.0&title=1.5.0&target=1.5.x
+   - https://github.com/inviqa/harness-magento2/releases/new?tag=1.5.0&title=1.5.0&target=1.5.x
+   - https://github.com/inviqa/harness-spryker/releases/new?tag=1.5.0&title=1.5.0&target=1.5.x
+   - https://github.com/inviqa/harness-symfony/releases/new?tag=1.5.0&title=1.5.0&target=1.5.x
+   - https://github.com/inviqa/harness-wordpress/releases/new?tag=1.5.0&title=1.5.0&target=1.5.x
 
 ### Post-release actions
 
-If the next release does not make sense to be in the current 1.4.x branch:
+If the next release does not make sense to be in the current 1.5.x branch:
 
 1. Create a new branch:
   ```bash
   git checkout -b 1.5.x
   ```
-2. Adjust references from 1.4.x to 1..x:
+2. Adjust references from 1.5.x to 1.6.x:
   ```bash
-  grep -FR '1.4.x' . | grep -v dist/
-  grep -FR '1.4.x' . | grep -v dist/
+  grep -FR '1.5.x' . | grep -v dist/
+  grep -FR '1.5.x' . | grep -v dist/
   # Edit resulting files
   ```
-3. Adjust references in this file from 1.4.0 to 1.5.0:
+3. Adjust references in this file from 1.5.0 to 1.5.0:
   ```bash
   grep -FR '1.5.0' README.md
-  grep -FR '1.4.0' README.md
+  grep -FR '1.5.0' README.md
   # Edit resulting files
   ```
 4. Commit the resulting files and push:
@@ -233,7 +233,7 @@ If the next release does not make sense to be in the current 1.4.x branch:
   git push origin -u HEAD
   ```
 5. Change the default branch in GitHub settings and re-target any open PRs against the new default branch.
-6. Run a deployment of the 1.4.x branch so the branches now exist in the downstream repositories:
+6. Run a deployment of the 1.5.x branch so the branches now exist in the downstream repositories:
   ```bash
   ./deploy
   ```
@@ -250,4 +250,4 @@ If the next release does not make sense to be in the current 1.4.x branch:
 [inviqa/harness-symfony]: https://github.com/inviqa/harness-symfony
 [inviqa/harness-wordpress]: https://github.com/inviqa/harness-wordpress
 [my127/my127.io]: https://github.com/my127/my127.io
-[version specific upgrade instructions]: https://github.com/inviqa/harness-base-php/blob/1.4.x/UPGRADE.md
+[version specific upgrade instructions]: https://github.com/inviqa/harness-base-php/blob/1.5.x/UPGRADE.md

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,7 +2,7 @@
 
 In addition to the README's [Harness Upgrade Instructions], please note these specific version upgrade instructions.
 
-## Upgrading from 1.3.x to 1.4.x
+## Upgrading from 1.3.x to 1.5.x
 
 ### Debian Bullseye for PHP 8+
 

--- a/deploy
+++ b/deploy
@@ -18,16 +18,16 @@ function main()
 
     set_remote "base" "git@github.com:inviqa/harness-php.git"
     splitsh-lite --prefix="src/_base" --target="publish/harness-php"
-    git push -q -f "base" "publish/harness-php:refs/heads/1.4.x"
+    git push -q -f "base" "publish/harness-php:refs/heads/1.5.x"
 
     for harness in "${HARNESSES[@]}"
     do
         set_remote "$harness" "git@github.com:inviqa/harness-${harness}.git"
         splitsh-lite --prefix="src/${harness}" --target="publish/harness-${harness}"
-        git push -q -f "$harness" "publish/harness-${harness}:refs/heads/1.4.x"
+        git push -q -f "$harness" "publish/harness-${harness}:refs/heads/1.5.x"
     done
 
-    git checkout 1.4.x
+    git checkout 1.5.x
     git branch -D _build
 }
 

--- a/src/drupal8/docs/customise/advanced.md
+++ b/src/drupal8/docs/customise/advanced.md
@@ -7,7 +7,7 @@ There may be times when you need to customise the Workspace environment beyond w
 
 ## Adding a new service
 
-If you need a service that isn't already provided (see [available base services](https://github.com/inviqa/harness-base-php/blob/1.4.x/src/_base/_twig/docker-compose.yml/service)) then you can register a new service following the [docker-compose](https://docs.docker.com/compose/compose-file/) notation.
+If you need a service that isn't already provided (see [available base services](https://github.com/inviqa/harness-base-php/blob/1.5.x/src/_base/_twig/docker-compose.yml/service)) then you can register a new service following the [docker-compose](https://docs.docker.com/compose/compose-file/) notation.
 
 Create your new service file in the `tools/workspace/_twig/docker-compose.yml/service/` directory.  
 

--- a/src/drupal8/docs/customise/commands.md
+++ b/src/drupal8/docs/customise/commands.md
@@ -3,7 +3,7 @@
 Adding commands can help with productivity and to standardise tasks.  
 Information on writing commands can be found [here](https://github.com/my127/workspace/blob/0.1.x/docs/types/command.md)
 
-There are also a number of [default commands](https://github.com/inviqa/harness-base-php/blob/1.4.x/src/_base/harness/config/commands.yml) available that may already provide the functionality you require.
+There are also a number of [default commands](https://github.com/inviqa/harness-base-php/blob/1.5.x/src/_base/harness/config/commands.yml) available that may already provide the functionality you require.
 
 If not, here are some example that might be a good starting point.
 

--- a/src/drupal8/docs/customise/overrides.md
+++ b/src/drupal8/docs/customise/overrides.md
@@ -62,7 +62,7 @@ You can find even more in [common.yml], e.g. `frontend.build.steps`.
 
 When you see `steps`, there will more than likely be a `task` that defines how and when these steps are executed.
 
-To understand more, take a look at the tasks in the `console` docker image [here](https://github.com/inviqa/harness-base-php/blob/1.4.x/src/_base/docker/image/console/root/lib/task)
+To understand more, take a look at the tasks in the `console` docker image [here](https://github.com/inviqa/harness-base-php/blob/1.5.x/src/_base/docker/image/console/root/lib/task)
 
 [harness.yml]: ../../harness.yml
-[common.yml]: https://github.com/inviqa/harness-base-php/blob/1.4.x/src/_base/harness/attributes/common.yml
+[common.yml]: https://github.com/inviqa/harness-base-php/blob/1.5.x/src/_base/harness/attributes/common.yml

--- a/src/spryker/application/skeleton/composer-harness.json.twig
+++ b/src/spryker/application/skeleton/composer-harness.json.twig
@@ -16,6 +16,7 @@
     "dmore/chrome-mink-driver": "^2.6",
     "jakoch/phantomjs-installer": "^3.0",
     "roave/better-reflection": "^4.3.0",
+    "phpstan/phpstan": "~1.6.9",
     "phpcompatibility/php-compatibility": "dev-master",
     "sensiolabs/behat-page-object-extension": "^2.3",
     "guzzlehttp/guzzle": "^6.3.0",

--- a/src/spryker/harness.yml
+++ b/src/spryker/harness.yml
@@ -123,7 +123,7 @@ attributes:
       DE: = 'zed-de-' ~ @('hostname')
       AT: = 'zed-at-' ~ @('hostname')
       US: = 'zed-us-' ~ @('hostname')
-    root_dir: = @('app.web_directory') ~ '/Zed'
+    root_dir: "= @('spryker.demoshop-version') >= '202108.0'? @('app.web_directory') ~ '/Backoffice' : @('app.web_directory') ~ '/Zed'"
   zed_api:
     external_hosts:
       DE: = 'zed-api-de-' ~ @('hostname')

--- a/src/spryker/harness.yml
+++ b/src/spryker/harness.yml
@@ -123,13 +123,13 @@ attributes:
       DE: = 'zed-de-' ~ @('hostname')
       AT: = 'zed-at-' ~ @('hostname')
       US: = 'zed-us-' ~ @('hostname')
-    root_dir: "= @('spryker.demoshop-version') >= '202108.0'? @('app.web_directory') ~ '/Backoffice' : @('app.web_directory') ~ '/Zed'"
+    root_dir: "= version_compare(@('spryker.demoshop-version'), '202108.0', '>=') ? '/Backoffice' : '/Zed'"
   zed_api:
     external_hosts:
       DE: = 'zed-api-de-' ~ @('hostname')
       AT: = 'zed-api-at-' ~ @('hostname')
       US: = 'zed-api-us-' ~ @('hostname')
-    root_dir: "= @('spryker.demoshop-version') >= '202108.0'? @('app.web_directory') ~ '/BackendGateway' : @('app.web_directory') ~ '/Zed'"
+    root_dir: "= version_compare(@('spryker.demoshop-version'), '202108.0', '>=') ? '/BackendGateway' : '/Zed'"
   glue:
     external_hosts:
       DE: = 'glue-de-' ~ @('hostname')


### PR DESCRIPTION
With Release 202108.0 Spryker has implemented separate application bootstrapping into individual endpoints.
The harness.yml was already updated to use /BackendGateway as the endpoint for the ZED API for Spryker demoshop version >= 202108.0, but the Zed endpoint is still pointing to /Zed. Following Sprykers convention it should be /Backoffice instead.