### PR TITLE
Conditionally upgrade HPA/PDB for k8s 1.25 and 1.26 support

### DIFF
--- a/src/_base/harness/config/pipeline.yml
+++ b/src/_base/harness/config/pipeline.yml
@@ -97,6 +97,7 @@ command('app deploy <environment>'):
 command('helm template <chart-path>'):
   env:
     CHART_PATH:  = input.argument('chart-path')
+    K8S_VERSION: = @('helm.kubernetes_version')
     NAMESPACE:   = @('pipeline.' ~ input.argument('environment') ~ '.namespace')
   exec: |
     #!bash(harness:/helm)|=
@@ -106,7 +107,7 @@ command('helm template <chart-path>'):
       passthru helm init --client-only
     fi
     passthru helm dependency build
-    passthru helm template .
+    passthru helm template --kube-version "${K8S_VERSION}" .
 
 command('helm kubeval [--cleanup] <chart-path>'):
   env:

--- a/src/_base/helm/app/templates/horizontal-pod-autoscaler.yaml
+++ b/src/_base/helm/app/templates/horizontal-pod-autoscaler.yaml
@@ -3,7 +3,11 @@
 {{- $autoscaling := .autoscaling | default (dict) -}}
 {{- if and (not (hasPrefix "." $serviceName)) .enabled $autoscaling.enabled }}
 ---
+{{- if semverCompare ">=1.23-0" $.Capabilities.KubeVersion.Version }}
+apiVersion: autoscaling/v2
+{{- else }}
 apiVersion: autoscaling/v2beta2
+{{- end }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ print $.Values.resourcePrefix $serviceName }}

--- a/src/_base/helm/app/templates/pod-disruption-budgets.yaml
+++ b/src/_base/helm/app/templates/pod-disruption-budgets.yaml
@@ -4,7 +4,11 @@
 {{- $autoscaling := .autoscaling | default (dict "minReplicas" 0) -}}
 {{- if or (gt (.replicas | default 1 | int) 1) (and $autoscaling.enabled (gt ($autoscaling.minReplicas | int) 1)) }}
 ---
+{{- if semverCompare ">=1.21-0" $.Capabilities.KubeVersion.Version }}
+apiVersion: policy/v1
+{{- else }}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ print $.Values.resourcePrefix $serviceName }}


### PR DESCRIPTION
Since not all clusters are required to be on k8s 1.21+ yet, use helm's capabilities to conditionally upgrade it.

ArgoCD also passes the cluster's version to its helm template render