### PR TITLE
Add pod topologySpreadConstraints to replace selfAntiAffinityTopologyKey

### DIFF
--- a/src/_base/harness/attributes/docker-base.yml
+++ b/src/_base/harness/attributes/docker-base.yml
@@ -198,18 +198,18 @@ attributes:
       enabled: true
   pipeline:
     base:
-    global:
-      affinity:
-        # deprecated and should move to using topologySpreadConstraints
-        selfAntiAffinityTopologyKey: ~
-      topologySpreadConstraints: []
-        # - topologyKey: topology.kubernetes.io/zone
-        #   # defaults:
-        #   # maxSkew: 1
-        #   # whenUnsatisfiable: ScheduleAnyway
-        # - topologyKey: kubernetes.io/hostname
-        #   maxSkew: 2
-        #   whenUnsatisfiable: DoNotSchedule
+      global:
+        affinity:
+          # deprecated and should move to using topologySpreadConstraints
+          selfAntiAffinityTopologyKey: ~
+        topologySpreadConstraints: []
+          # - topologyKey: topology.kubernetes.io/zone
+          #   # defaults:
+          #   # maxSkew: 1
+          #   # whenUnsatisfiable: ScheduleAnyway
+          # - topologyKey: kubernetes.io/hostname
+          #   maxSkew: 2
+          #   whenUnsatisfiable: DoNotSchedule
       prometheus:
         podMonitoring: false
       services:

--- a/src/_base/harness/attributes/docker-base.yml
+++ b/src/_base/harness/attributes/docker-base.yml
@@ -198,9 +198,18 @@ attributes:
       enabled: true
   pipeline:
     base:
-      global:
-        affinity:
-          selfAntiAffinityTopologyKey: ~
+    global:
+      affinity:
+        # deprecated and should move to using topologySpreadConstraints
+        selfAntiAffinityTopologyKey: ~
+      topologySpreadConstraints: []
+        # - topologyKey: topology.kubernetes.io/zone
+        #   # defaults:
+        #   # maxSkew: 1
+        #   # whenUnsatisfiable: ScheduleAnyway
+        # - topologyKey: kubernetes.io/hostname
+        #   maxSkew: 2
+        #   whenUnsatisfiable: DoNotSchedule
       prometheus:
         podMonitoring: false
       services:

--- a/src/_base/helm/app/templates/_base_helper.tpl
+++ b/src/_base/helm/app/templates/_base_helper.tpl
@@ -110,3 +110,25 @@ preferredDuringSchedulingIgnoredDuringExecution:
 {{- end -}}
 {{ $affinity | toYaml }}
 {{- end -}}
+
+{{- define "pod.topologySpreadConstraints" }}
+{{- $topologySpreadConstraints := $.service.topologySpreadConstraints | default $.root.Values.global.topologySpreadConstraints }}
+{{- if eq (len $topologySpreadConstraints) 0 -}}
+{}
+{{- else }}
+{{- range $topologySpreadConstraints }}
+- labelSelector:
+    matchLabels:
+      app.service: {{ $.root.Values.resourcePrefix }}{{ $.serviceName }}
+  {{- with (pick . "maxSkew" "topologyKey" "whenUnsatisfiable") }}
+  {{- . | toYaml | nindent 2 }}
+  {{- end }}
+  {{- if not (hasKey . "maxSkew") }}
+  maxSkew: 1
+  {{- end }}
+  {{- if not (hasKey . "whenUnsatisfiable") }}
+  whenUnsatisfiable: ScheduleAnyway
+  {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/src/_base/helm/app/templates/_base_helper.tpl
+++ b/src/_base/helm/app/templates/_base_helper.tpl
@@ -114,7 +114,7 @@ preferredDuringSchedulingIgnoredDuringExecution:
 {{- define "pod.topologySpreadConstraints" }}
 {{- $topologySpreadConstraints := $.service.topologySpreadConstraints | default $.root.Values.global.topologySpreadConstraints }}
 {{- if eq (len $topologySpreadConstraints) 0 -}}
-{}
+[]
 {{- else }}
 {{- range $topologySpreadConstraints }}
 - labelSelector:

--- a/src/_base/helm/app/templates/application/console/deployment.yaml
+++ b/src/_base/helm/app/templates/application/console/deployment.yaml
@@ -76,6 +76,7 @@ spec:
       {{- include "application.volumes.console" $ | indent 6 }}
       {{- else }} []
       {{- end }}
+      topologySpreadConstraints: {{- (include "pod.topologySpreadConstraints" (dict "root" $ "serviceName" "console" "service" .)) | nindent 8 }}
 status: {}
 {{- end }}
 {{- end }}

--- a/src/_base/helm/app/templates/application/cron/deployment.yaml
+++ b/src/_base/helm/app/templates/application/cron/deployment.yaml
@@ -87,6 +87,7 @@ spec:
       {{- include "application.volumes.all" $ | indent 6 }}
       {{- else }} []
       {{- end }}
+      topologySpreadConstraints: {{- (include "pod.topologySpreadConstraints" (dict "root" $ "serviceName" "console" "service" .)) | nindent 8 }}
 status: {}
 {{- end }}
 {{- end }}

--- a/src/_base/helm/app/templates/application/cron/deployment.yaml
+++ b/src/_base/helm/app/templates/application/cron/deployment.yaml
@@ -87,7 +87,7 @@ spec:
       {{- include "application.volumes.all" $ | indent 6 }}
       {{- else }} []
       {{- end }}
-      topologySpreadConstraints: {{- (include "pod.topologySpreadConstraints" (dict "root" $ "serviceName" "console" "service" .)) | nindent 8 }}
+      topologySpreadConstraints: {{- (include "pod.topologySpreadConstraints" (dict "root" $ "serviceName" "cron" "service" .)) | nindent 8 }}
 status: {}
 {{- end }}
 {{- end }}

--- a/src/_base/helm/app/templates/application/webapp/deployment.yaml
+++ b/src/_base/helm/app/templates/application/webapp/deployment.yaml
@@ -174,6 +174,6 @@ spec:
       {{- include "application.volumes.all" . | indent 6 }}
       {{- else }} []
       {{- end }}
-      topologySpreadConstraints: {{- (include "pod.topologySpreadConstraints" (dict "root" $ "serviceName" "console" "service" .)) | nindent 8 }}
+      topologySpreadConstraints: {{- (include "pod.topologySpreadConstraints" (dict "root" $ "serviceName" "webapp" "service" .)) | nindent 8 }}
 status: {}
 {{- end }}

--- a/src/_base/helm/app/templates/application/webapp/deployment.yaml
+++ b/src/_base/helm/app/templates/application/webapp/deployment.yaml
@@ -174,5 +174,6 @@ spec:
       {{- include "application.volumes.all" . | indent 6 }}
       {{- else }} []
       {{- end }}
+      topologySpreadConstraints: {{- (include "pod.topologySpreadConstraints" (dict "root" $ "serviceName" "console" "service" .)) | nindent 8 }}
 status: {}
 {{- end }}

--- a/src/_base/helm/app/templates/service/solr/statefulset.yaml
+++ b/src/_base/helm/app/templates/service/solr/statefulset.yaml
@@ -74,7 +74,7 @@ spec:
       - name: {{ $.Values.resourcePrefix }}solr-data
         emptyDir:
           medium: Memory
-      topologySpreadConstraints: {{- (include "pod.topologySpreadConstraints" (dict "root" $ "serviceName" "console" "service" .)) | nindent 8 }}
+      topologySpreadConstraints: {{- (include "pod.topologySpreadConstraints" (dict "root" $ "serviceName" "solr" "service" .)) | nindent 8 }}
 {{- with $.Values.persistence.solr -}}
 {{- if .enabled }}
   volumeClaimTemplates:

--- a/src/_base/helm/app/templates/service/solr/statefulset.yaml
+++ b/src/_base/helm/app/templates/service/solr/statefulset.yaml
@@ -74,6 +74,7 @@ spec:
       - name: {{ $.Values.resourcePrefix }}solr-data
         emptyDir:
           medium: Memory
+      topologySpreadConstraints: {{- (include "pod.topologySpreadConstraints" (dict "root" $ "serviceName" "console" "service" .)) | nindent 8 }}
 {{- with $.Values.persistence.solr -}}
 {{- if .enabled }}
   volumeClaimTemplates:

--- a/src/_base/helm/app/templates/service/varnish/statefulset.yaml
+++ b/src/_base/helm/app/templates/service/varnish/statefulset.yaml
@@ -60,5 +60,6 @@ spec:
       - name: {{ $.Values.resourcePrefix }}varnish-cache
         emptyDir:
           medium: Memory
+      topologySpreadConstraints: {{- (include "pod.topologySpreadConstraints" (dict "root" $ "serviceName" "console" "service" .)) | nindent 8 }}
 {{- end }}
 {{- end }}

--- a/src/_base/helm/app/templates/service/varnish/statefulset.yaml
+++ b/src/_base/helm/app/templates/service/varnish/statefulset.yaml
@@ -60,6 +60,6 @@ spec:
       - name: {{ $.Values.resourcePrefix }}varnish-cache
         emptyDir:
           medium: Memory
-      topologySpreadConstraints: {{- (include "pod.topologySpreadConstraints" (dict "root" $ "serviceName" "console" "service" .)) | nindent 8 }}
+      topologySpreadConstraints: {{- (include "pod.topologySpreadConstraints" (dict "root" $ "serviceName" "varnish" "service" .)) | nindent 8 }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
topologySpreadConstraints is specifically for this use-case, and spreads pods where possible equally between the topology

New configuration exposes support for setting multiple constraints, such as:

```yaml
global:
  topologySpreadConstraints:
   - topologyKey: topology.kubernetes.io/zone
   - topologyKey: kubernetes.io/hostname
     whenUnsatisfiable: DoNotSchedule
```

Spread across zones and hosts, but don't allow scheduling on nodes that have 1 more of the app than other nodes (sort of like podAntiAffinity requiredDuringSchedulingIgnoredDuringExecution but allows overlapping and a higher skew).