### PR TITLE
Explicitly configure all composer plugins

### DIFF
--- a/src/akeneo/application/skeleton/composer.json.twig
+++ b/src/akeneo/application/skeleton/composer.json.twig
@@ -104,6 +104,10 @@
   "config": {
     "platform": {
       "php": "{{ (version_compare(@('akeneo.major_version'), '5', '>=')) ? '7.4' : '7.3.22' }}"
+    },
+    "allow-plugins": {
+      "symfony/flex": true,
+      "dealerdirect/phpcodesniffer-composer-installer": true
     }
   },
   "minimum-stability": "stable"

--- a/src/drupal8/application/skeleton/composer.json.twig
+++ b/src/drupal8/application/skeleton/composer.json.twig
@@ -10,6 +10,14 @@
     "sort-packages": true,
     "platform": {
       "php": "7.4.10"
+    },
+    "allow-plugins": {
+      "cweagans/composer-patches": true,
+      "drupal/core-composer-scaffold": true,
+      "composer/installers": true,
+      "dealerdirect/phpcodesniffer-composer-installer": true,
+      "fenetikm/autoload-drupal": true,
+      "oomphinc/composer-installers-extender": true
     }
   },
   "repositories": {

--- a/src/magento1/application/skeleton/_twig/composer.json/default.twig
+++ b/src/magento1/application/skeleton/_twig/composer.json/default.twig
@@ -113,6 +113,10 @@
         "bin-dir": "bin",
         "platform": {
             "php": "7.2.33"
+        },
+        "allow-plugins": {
+            "aydin-hassan/magento-core-composer-installer": true,
+            "magento-hackathon/magento-composer-installer": true
         }
     }
 }

--- a/src/magento1/application/skeleton/_twig/composer.json/php-5.6.twig
+++ b/src/magento1/application/skeleton/_twig/composer.json/php-5.6.twig
@@ -113,6 +113,10 @@
         "bin-dir": "bin",
         "platform": {
             "php": "5.6.40"
+        },
+        "allow-plugins": {
+            "aydin-hassan/magento-core-composer-installer": true,
+            "magento-hackathon/magento-composer-installer": true
         }
     }
 }

--- a/src/magento2/application/skeleton/composer.json.twig
+++ b/src/magento2/application/skeleton/composer.json.twig
@@ -28,6 +28,12 @@
         "sort-packages": true,
         "platform": {
             "php": "7.4.10"
+        },
+        "allow-plugins": {
+            "laminas/laminas-dependency-plugin": true,
+            "magento/inventory-composer-installer": true,
+            "magento/magento-composer-installer": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true
         }
     },
     "extra": {

--- a/src/spryker/application/skeleton/composer-harness.json.twig
+++ b/src/spryker/application/skeleton/composer-harness.json.twig
@@ -66,6 +66,10 @@
     "compatibility": "bin/phpcs -s --standard=vendor/phpcompatibility/php-compatibility/PHPCompatibility/ --runtime-set testVersion 7.4-"
   },
   "config": {
+    "allow-plugins": {
+      "dealerdirect/phpcodesniffer-composer-installer": true,
+      "sllh/composer-versions-check": true
+    },
     "platform": {
       "php": "7.4.10"
     }

--- a/src/symfony/application/skeleton/composer.json.twig
+++ b/src/symfony/application/skeleton/composer.json.twig
@@ -36,7 +36,8 @@
     "config": {
         "allow-plugins": {
             "symfony/flex": true,
-            "symfony/runtime": true
+            "symfony/runtime": true,
+            "dealerdirect/phpcodesniffer-composer-installer": false
         },
         "bin-dir": "bin",
         "optimize-autoloader": true,

--- a/src/wordpress/application/skeleton/composer.json.twig
+++ b/src/wordpress/application/skeleton/composer.json.twig
@@ -61,6 +61,9 @@
         "bin-dir": "bin",
         "platform": {
             "php": "7.4.10"
+        },
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
         }
     }
 }


### PR DESCRIPTION
It seems the behaviour doesn't match the documentation, instead failing install rather than just warning