### PR TITLE
Fix Drupal 8 using only stable/beta/alpha and not dev stabilty

### DIFF
--- a/src/drupal8/application/skeleton/composer.json.twig
+++ b/src/drupal8/application/skeleton/composer.json.twig
@@ -3,7 +3,7 @@
   "description": "Drupal site for {{ @('workspace.name')|lower }}",
   "type": "project",
   "license": "GPL-2.0+",
-  "minimum-stability": "dev",
+  "minimum-stability": "stable",
   "prefer-stable": true,
   "config": {
     "bin-dir": "bin/",
@@ -57,7 +57,7 @@
     "drupal/stage_file_proxy": "^1.0@alpha",
     "drupal/taxonomy_access_fix": "2.6",
     "drupal/token": "1.5",
-    "drupal/ultimate_cron": "2.x-dev",
+    "drupal/ultimate_cron": "~2.0.0@alpha",
 {% if @('services.varnish.enabled') %}
     "drupal/varnish_purge": "^2.0",
 {% endif %}


### PR DESCRIPTION
dev stability is almost never a good idea, and absolutely a bad idea as a global minimum for projects

ultimate_cron's 2.0-dev stopped supporting drupal 8. The newest alphas may do in the future though