### PR TITLE
Allow configuring redis options

### DIFF
--- a/src/_base/_twig/docker-compose.yml/service/redis-session.yml.twig
+++ b/src/_base/_twig/docker-compose.yml/service/redis-session.yml.twig
@@ -1,7 +1,10 @@
+{% set command = @('services.redis-session.options')
+  | filter(v => v is not empty)
+  | map((value, var) => '--' ~ var ~ ' ' ~ value|join(' --' ~ var ~ ' '))
+  | reduce((carry, v) => carry|merge([v]), []) %}
   redis-session:
     image: {{ @('services.redis-session.image') }}
-    # 1GB; evict key that would expire soonest
-    command: redis-server --maxmemory 1073742000 --maxmemory-policy volatile-ttl --save 3600 1 --save 300 100 --save 60 10000
+    command: {{ to_nice_yaml(command, 2, 6) }}
     labels:
       # deprecated, a later workspace release will disable by default
       - traefik.enable=false

--- a/src/_base/_twig/docker-compose.yml/service/redis.yml.twig
+++ b/src/_base/_twig/docker-compose.yml/service/redis.yml.twig
@@ -1,7 +1,10 @@
+{% set command = @('services.redis.options')
+  | filter(v => v is not empty)
+  | map((value, var) => '--' ~ var ~ ' ' ~ value|join(' --' ~ var ~ ' '))
+  | reduce((carry, v) => carry|merge([v]), []) %}
   redis:
     image: {{ @('services.redis.image')  }}
-    # 1GB; evict any least recently used key even if they don't have a TTL
-    command: redis-server --maxmemory 1073742000 --maxmemory-policy allkeys-lru --save 3600 1 --save 300 100 --save 60 10000
+    command: {{ to_nice_yaml(command, 2, 6) }}
     labels:
       # deprecated, a later workspace release will disable by default
       - traefik.enable=false

--- a/src/_base/harness/attributes/docker-base.yml
+++ b/src/_base/harness/attributes/docker-base.yml
@@ -152,10 +152,13 @@ attributes:
     redis:
       image: redis:6-alpine
       options:
+        # Handle many smaller keys
         activedefrag: 'yes'
-        # 1Gi - 1024*1024*1024 bytes; evict any least recently used key even if they don't have a TTL
+        # 1Gi - 1024*1024*1024 bytes
         maxmemory: '1073741824'
+        # Evict any least recently used key even if they don't have a TTL
         maxmemory-policy: allkeys-lru
+        # Save snapshots every X changes have happened within Y seconds (these are the defaults in redis.conf)
         save:
           - 3600 1
           - 300 100
@@ -166,10 +169,13 @@ attributes:
     redis-session:
       image: redis:6-alpine
       options:
+        # Handle many smaller keys
         activedefrag: 'yes'
-        # 1Gi - 1024*1024*1024 bytes; evict key that would expire soonest
+        # 1Gi - 1024*1024*1024 bytes
         maxmemory: '1073741824'
+        # Evict key that would expire soonest
         maxmemory-policy: volatile-ttl
+        # Save snapshots every X changes have happened within Y seconds (these are the defaults in redis.conf)
         save:
           - 3600 1
           - 300 100

--- a/src/_base/harness/attributes/docker-base.yml
+++ b/src/_base/harness/attributes/docker-base.yml
@@ -150,15 +150,33 @@ attributes:
       resources:
         memory: "1024Mi"
     redis:
-      enabled: "= 'redis' in @('app.services')"
-      image: redis:5-alpine
+      image: redis:6-alpine
+      options:
+        activedefrag: 'yes'
+        # 1Gi - 1024*1024*1024 bytes; evict any least recently used key even if they don't have a TTL
+        maxmemory: '1073741824'
+        maxmemory-policy: allkeys-lru
+        save:
+          - 3600 1
+          - 300 100
+          - 60 10000
       resources:
-        memory: "256Mi"
+        # 1.5 * maxmemory to allow copy on write snapshots
+        memory: "1.5Gi"
     redis-session:
-      enabled: "= 'redis-session' in @('app.services')"
-      image: redis:5-alpine
+      image: redis:6-alpine
+      options:
+        activedefrag: 'yes'
+        # 1Gi - 1024*1024*1024 bytes; evict key that would expire soonest
+        maxmemory: '1073741824'
+        maxmemory-policy: volatile-ttl
+        save:
+          - 3600 1
+          - 300 100
+          - 60 10000
       resources:
-        memory: "1024Mi"
+        # 1.5 * maxmemory to allow copy on write snapshots
+        memory: "1.5Gi"
     relay:
       enabled: true
       publish: false
@@ -293,9 +311,3 @@ attributes:
         php-fpm-exporter:
           resources:
             memory: "32Mi"
-        redis:
-          resources:
-            memory: "64Mi"
-        redis-session:
-          resources:
-            memory: "64Mi"

--- a/src/_base/harness/attributes/docker-base.yml
+++ b/src/_base/harness/attributes/docker-base.yml
@@ -245,6 +245,10 @@ attributes:
             VARNISH_HOSTNAME_TEMPLATE: "{{ .Values.resourcePrefix }}varnish-%d.{{ .Values.resourcePrefix }}varnish-headless"
         mysql:
           options: = @('services.mysql.options')
+        redis:
+          options: = @('services.redis.options')
+        redis-session:
+          options: = @('services.redis-session.options')
         console:
           environment:
             TIDEWAYS_ENABLED: "= @('php.ext-tideways.cli.enable') ? '{{ .Values.services.tideways.enabled }}' : 'false'"

--- a/src/_base/helm/app/templates/service/redis-session/deployment.yaml
+++ b/src/_base/helm/app/templates/service/redis-session/deployment.yaml
@@ -30,7 +30,10 @@ spec:
       - {{- if .options }}
         args:
         {{- range $var, $value := .options }}
-        {{- if $value }}
+        {{- if kindIs "slice" $value }}
+        {{- range $arrayValue := $value }}
+        - {{ print "--" $var " " $arrayValue | quote }}
+        {{- else }}
         - {{ print "--" $var " " $value | quote }}
         {{- end }}
         {{- end }}

--- a/src/_base/helm/app/templates/service/redis-session/deployment.yaml
+++ b/src/_base/helm/app/templates/service/redis-session/deployment.yaml
@@ -30,10 +30,11 @@ spec:
       - {{- if .options }}
         args:
         {{- range $var, $value := .options }}
-        {{- if kindIs "slice" $value }}
+        {{- if and $value (kindIs "slice" $value) }}
         {{- range $arrayValue := $value }}
         - {{ print "--" $var " " $arrayValue | quote }}
-        {{- else }}
+        {{- end }}
+        {{- else if $value }}
         - {{ print "--" $var " " $value | quote }}
         {{- end }}
         {{- end }}

--- a/src/_base/helm/app/templates/service/redis-session/deployment.yaml
+++ b/src/_base/helm/app/templates/service/redis-session/deployment.yaml
@@ -27,21 +27,14 @@ spec:
         app.service: {{ $.Values.resourcePrefix }}redis-session
     spec:
       containers:
-      - args:
-        - redis-server
-        - --maxmemory
-        - "1073742000"
-        - --maxmemory-policy
-        - volatile-ttl
-        - --save
-        - "3600"
-        - "1"
-        - --save
-        - "300"
-        - "100"
-        - --save
-        - "60"
-        - "10000"
+      - {{- if .options }}
+        args:
+        {{- range $var, $value := .options }}
+        {{- if $value }}
+        - {{ print "--" $var " " $value | quote }}
+        {{- end }}
+        {{- end }}
+        {{- end }}
         image: {{ .image | quote }}
         imagePullPolicy: Always
         name: redis-session

--- a/src/_base/helm/app/templates/service/redis/deployment.yaml
+++ b/src/_base/helm/app/templates/service/redis/deployment.yaml
@@ -28,21 +28,14 @@ spec:
         app.service: {{ $.Values.resourcePrefix }}redis
     spec:
       containers:
-      - args:
-        - redis-server
-        - --maxmemory
-        - "1073742000"
-        - --maxmemory-policy
-        - allkeys-lru
-        - --save
-        - "3600"
-        - "1"
-        - --save
-        - "300"
-        - "100"
-        - --save
-        - "60"
-        - "10000"
+      - {{- if .options }}
+        args:
+        {{- range $var, $value := .options }}
+        {{- if $value }}
+        - {{ print "--" $var " " $value | quote }}
+        {{- end }}
+        {{- end }}
+        {{- end }}
         image: {{ .image | quote }}
         imagePullPolicy: Always
         name: redis

--- a/src/_base/helm/app/templates/service/redis/deployment.yaml
+++ b/src/_base/helm/app/templates/service/redis/deployment.yaml
@@ -32,7 +32,12 @@ spec:
         args:
         {{- range $var, $value := .options }}
         {{- if $value }}
+        {{- if kindIs "slice" $value }}
+        {{- range $arrayValue := $value }}
+        - {{ print "--" $var " " $arrayValue | quote }}
+        {{- else }}
         - {{ print "--" $var " " $value | quote }}
+        {{- end }}
         {{- end }}
         {{- end }}
         {{- end }}

--- a/src/_base/helm/app/templates/service/redis/deployment.yaml
+++ b/src/_base/helm/app/templates/service/redis/deployment.yaml
@@ -31,13 +31,12 @@ spec:
       - {{- if .options }}
         args:
         {{- range $var, $value := .options }}
-        {{- if $value }}
-        {{- if kindIs "slice" $value }}
+        {{- if and $value (kindIs "slice" $value) }}
         {{- range $arrayValue := $value }}
         - {{ print "--" $var " " $arrayValue | quote }}
-        {{- else }}
-        - {{ print "--" $var " " $value | quote }}
         {{- end }}
+        {{- else if $value }}
+        - {{ print "--" $var " " $value | quote }}
         {{- end }}
         {{- end }}
         {{- end }}


### PR DESCRIPTION
* Upgrade to Redis 6.2+
* Match memory request in kubernetes to one that will work out of the box (the alternative is decreasing maxmemory to fit in the memory request, which will require action to be taken to delete keys)
* Remove the "preview" environment override for memory request as if the service is enabled with a 1Gi maxmemory, it won't fit in 64Mi
* Turn on activedefrag to better handle small keys