### PR TITLE
Make topologySpreadConstraints labelSelector overridable by matchLabelKeys

### DIFF
--- a/src/_base/helm/app/templates/_base_helper.tpl
+++ b/src/_base/helm/app/templates/_base_helper.tpl
@@ -117,9 +117,7 @@ preferredDuringSchedulingIgnoredDuringExecution:
 []
 {{- else }}
 {{- range $topologySpreadConstraints }}
-- labelSelector:
-    matchLabels:
-      app.service: {{ $.root.Values.resourcePrefix }}{{ $.serviceName }}
+- 
   {{- with (pick . "maxSkew" "topologyKey" "whenUnsatisfiable") }}
   {{- . | toYaml | nindent 2 }}
   {{- end }}
@@ -128,6 +126,11 @@ preferredDuringSchedulingIgnoredDuringExecution:
   {{- end }}
   {{- if not (hasKey . "whenUnsatisfiable") }}
   whenUnsatisfiable: ScheduleAnyway
+  {{- end }}
+  {{- if not (or (hasKey . "labelSelector") (hasKey . "matchLabelKeys")) }}
+  labelSelector:
+    matchLabels:
+      app.service: {{ $.root.Values.resourcePrefix }}{{ $.serviceName }}
   {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
matchLabelKeys is a better implementation to support pod-template-hash matching as well, but is alpha in 1.25, so can't be switched to yet

However provide it already to ensure it can be used later.

If it doesn't change it can be set later when stable to default to:

```
matchLabelKeys:
  - app.service
  - pod-template-hash
```
to ensure only the replicaset of the pod will be considered in the spread, rather than additionally the previous (or both argo-rollouts preview/stable) replica-sets