### PR TITLE
Fix harness.yml to use /Backoffice as root_dir for spryker versions newer 202108.0

### DIFF
--- a/src/spryker/harness.yml
+++ b/src/spryker/harness.yml
@@ -123,7 +123,7 @@ attributes:
       DE: = 'zed-de-' ~ @('hostname')
       AT: = 'zed-at-' ~ @('hostname')
       US: = 'zed-us-' ~ @('hostname')
-    root_dir: = @('app.web_directory') ~ '/Zed'
+    root_dir: "= @('spryker.demoshop-version') >= '202108.0'? @('app.web_directory') ~ '/Backoffice' : @('app.web_directory') ~ '/Zed'"
   zed_api:
     external_hosts:
       DE: = 'zed-api-de-' ~ @('hostname')

--- a/src/spryker/harness.yml
+++ b/src/spryker/harness.yml
@@ -123,13 +123,13 @@ attributes:
       DE: = 'zed-de-' ~ @('hostname')
       AT: = 'zed-at-' ~ @('hostname')
       US: = 'zed-us-' ~ @('hostname')
-    root_dir: "= @('spryker.demoshop-version') >= '202108.0'? @('app.web_directory') ~ '/Backoffice' : @('app.web_directory') ~ '/Zed'"
+    root_dir: "= version_compare(@('spryker.demoshop-version'), '202108.0', '>=') ? '/Backoffice' : '/Zed'"
   zed_api:
     external_hosts:
       DE: = 'zed-api-de-' ~ @('hostname')
       AT: = 'zed-api-at-' ~ @('hostname')
       US: = 'zed-api-us-' ~ @('hostname')
-    root_dir: "= @('spryker.demoshop-version') >= '202108.0'? @('app.web_directory') ~ '/BackendGateway' : @('app.web_directory') ~ '/Zed'"
+    root_dir: "= version_compare(@('spryker.demoshop-version'), '202108.0', '>=') ? '/BackendGateway' : '/Zed'"
   glue:
     external_hosts:
       DE: = 'glue-de-' ~ @('hostname')

--- a/src/spryker/harness.yml
+++ b/src/spryker/harness.yml
@@ -123,13 +123,13 @@ attributes:
       DE: = 'zed-de-' ~ @('hostname')
       AT: = 'zed-at-' ~ @('hostname')
       US: = 'zed-us-' ~ @('hostname')
-    root_dir: "= version_compare(@('spryker.demoshop-version'), '202108.0', '>=') ? '/Backoffice' : '/Zed'"
+    root_dir: "= @('app.web_directory') ~ (version_compare(@('spryker.demoshop-version'), '202108.0', '>=') ? '/Backoffice' : '/Zed')"
   zed_api:
     external_hosts:
       DE: = 'zed-api-de-' ~ @('hostname')
       AT: = 'zed-api-at-' ~ @('hostname')
       US: = 'zed-api-us-' ~ @('hostname')
-    root_dir: "= version_compare(@('spryker.demoshop-version'), '202108.0', '>=') ? '/BackendGateway' : '/Zed'"
+    root_dir: "= @('app.web_directory') ~ (version_compare(@('spryker.demoshop-version'), '202108.0', '>=') ? '/BackendGateway' : '/Zed')"
   glue:
     external_hosts:
       DE: = 'glue-de-' ~ @('hostname')


### PR DESCRIPTION
With Release 202108.0 Spryker has implemented separate application bootstrapping into individual endpoints.
The harness.yml was already updated to use /BackendGateway as the endpoint for the ZED API for Spryker demoshop version >= 202108.0, but the Zed endpoint is still pointing to /Zed. Following Sprykers convention it should be /Backoffice instead.

closes https://github.com/inviqa/harness-base-php/pull/716 (a copy to be able to rebase and CI, as the PR wasn't given us right to edit)