### PR TITLE
Allow configuring the Akeneo v6+ messenger consumers

### DIFF
--- a/src/akeneo/docker/image/job-queue-consumer/root/etc/supervisor/conf.d/container-cmd.conf.twig
+++ b/src/akeneo/docker/image/job-queue-consumer/root/etc/supervisor/conf.d/container-cmd.conf.twig
@@ -3,7 +3,7 @@ process_name=job-queue-consumer_%(process_num)02d
 numprocs=%(ENV_AKENEO_JOB_QUEUE_CONSUMER_PROCESSES)s
 numprocs_start=01
 {% if version_compare(@('akeneo.major_version'), '6', '>=') %}
-command=php /app/bin/console messenger:consume ui_job import_export_job data_maintenance_job
+command=php /app/bin/console messenger:consume {{ @('akeneo.messenger_consumers') }}
 {% else %}
 command=php /app/bin/console akeneo:batch:job-queue-consumer-daemon
 {% endif %}

--- a/src/akeneo/harness.yml
+++ b/src/akeneo/harness.yml
@@ -39,6 +39,8 @@ attributes:
     major_version: 6
     secret: AMjnA6QnWfkZ9s8vB2XXLALXuxZm7fmC
     edition: ~
+    # Akeneo 6+ only
+    messenger_consumers: ui_job import_export_job data_maintenance_job
     enterprise:
       distribution:
         project_name: ~


### PR DESCRIPTION
For instance the Events API needs `webhooks` if enabled