### PR TITLE
Switch over to docker compose v2

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,6 +4,18 @@ In addition to the README's [Harness Upgrade Instructions], please note these sp
 
 ## Upgrading from 1.6.x to 2.0.x
 
+### `docker-compose` command now `docker compose`
+
+In line with the preferred way to run Docker Compose v2, the harness will now use the binary from it's Docker plugin architecture.
+
+This means all `docker-compose` commands are replaced with `docker compose`. For Docker Desktop users there is no difference, however Linux users may need to [install the Compose plugin](https://docs.docker.com/compose/install/linux/).
+
+If you really would like to continue using the old command, you can set in your `~/.config/my127/workspace/config.yml`:
+
+```yaml
+attribute('docker.compose.bin'): docker-compose
+```
+
 ### .my127ws/docker/app mult-stage Dockerfile replacing all php-derrived images
 
 .my127ws/docker/app has combined the php-fpm, cron, Akeneo job-queue-consumer, and Spryker jenkins-runner Dockerfile build contexts into one multi-stage Dockerfile (with templating of each stage still separate).

--- a/src/_base/application/skeleton/README.md.twig
+++ b/src/_base/application/skeleton/README.md.twig
@@ -19,7 +19,7 @@ Please follow the below steps to get started, if you encounter any issues instal
 - A working Docker setup
   - On macOS, use [Docker Desktop for Mac](https://docs.docker.com/docker-for-mac/install/).
   - On Linux, add the official Docker repository described under the "Server" section on [Install Docker Engine](https://docs.docker.com/engine/install/) and install the "docker-ce" package.
-    You will also need to have a recent [docker compose](https://docs.docker.com/compose/install/) version - at least `1.26.0`.
+    You will also need to have a recent [docker compose](https://docs.docker.com/compose/install/) version - at least `v2.20.3`.
 
 #### Setup
 

--- a/src/_base/application/skeleton/README.md.twig
+++ b/src/_base/application/skeleton/README.md.twig
@@ -19,7 +19,7 @@ Please follow the below steps to get started, if you encounter any issues instal
 - A working Docker setup
   - On macOS, use [Docker Desktop for Mac](https://docs.docker.com/docker-for-mac/install/).
   - On Linux, add the official Docker repository described under the "Server" section on [Install Docker Engine](https://docs.docker.com/engine/install/) and install the "docker-ce" package.
-    You will also need to have a recent [docker-compose](https://docs.docker.com/compose/install/) version - at least `1.26.0`.
+    You will also need to have a recent [docker compose](https://docs.docker.com/compose/install/) version - at least `1.26.0`.
 
 #### Setup
 

--- a/src/_base/harness/attributes/common.yml
+++ b/src/_base/harness/attributes/common.yml
@@ -130,7 +130,7 @@ attributes.default:
     buildkit:
       enabled: true
     compose:
-      bin: 'docker-compose'
+      bin: 'docker compose'
       file_version: '3.7'
       host_volume_options: "= ':' ~ (bool(@('delegated-volumes')) ? 'delegated' : 'cached')"
     # If using gitops helm chart repositories, it's recommended to put this configuration

--- a/src/drupal/docs/customise/advanced.md
+++ b/src/drupal/docs/customise/advanced.md
@@ -7,11 +7,11 @@ There may be times when you need to customise the Workspace environment beyond w
 
 ## Adding a new service
 
-If you need a service that isn't already provided (see [available base services](https://github.com/inviqa/harness-base-php/blob/2.0.x/src/_base/_twig/docker-compose.yml/service)) then you can register a new service following the [docker-compose](https://docs.docker.com/compose/compose-file/) notation.
+If you need a service that isn't already provided (see [available base services](https://github.com/inviqa/harness-base-php/blob/2.0.x/src/_base/_twig/docker-compose.yml/service)) then you can register a new service following the [docker compose](https://docs.docker.com/compose/compose-file/) notation.
 
 Create your new service file in the `tools/workspace/_twig/docker-compose.yml/service/` directory.  
 
-See the example `example.yml.twig` service file below. Note the indentation, this is deliberate and must be followed to avoid docker-compose errors.
+See the example `example.yml.twig` service file below. Note the indentation, this is deliberate and must be followed to avoid docker compose errors.
 ```yaml
   example:
     image: {{ @('services.example.image') }}
@@ -69,7 +69,7 @@ Opt in to using varnish with the following in your workspace.yml:
 attribute('services.varnish.enabled'): true
 ```
 
-To apply changes to your local environment, run `ws harness prepare && docker-compose up -d`.
+To apply changes to your local environment, run `ws harness prepare && docker compose up -d`.
 
 The harness ships with a version of the [geerlingguy/drupal-vm Varnish VCL], which supports the `purge_varnish` module as well as only allowing certain cookies to impact cachability of requests.
 
@@ -145,7 +145,7 @@ cache-control: max-age=3600, public
 
 You can also verify that varnish receives a `BAN` request with the following varnishlog query:
 ```bash
-docker-compose exec varnish varnishlog -q 'ReqMethod ~ BAN'
+docker compose exec varnish varnishlog -q 'ReqMethod ~ BAN'
 ```
 
 Now edit the homepage. Once you hit the Save button on the edit page, varnish should receive a ban request through.

--- a/src/drupal/docs/customise/commands.md
+++ b/src/drupal/docs/customise/commands.md
@@ -8,9 +8,9 @@ There are also a number of [default commands](https://github.com/inviqa/harness-
 If not, here are some example that might be a good starting point.
 
 _Note: If someone clones the project repository as a different name than what's in workspace.yml for
-`workspace('projectname')`, docker-compose commands will fail due to using the directory name by default.
+`workspace('projectname')`, docker compose commands will fail due to using the directory name by default.
 The way around this is to ensure you include the `COMPOSE_PROJECT_NAME` environment variable any time
-you use `docker-compose` from within a custom command._
+you use `docker compose` from within a custom command._
 
 ### Refresh script - `ws drupal-refresh`
 ```yaml


### PR DESCRIPTION
This expects docker compose v2 to be installed as a docker plugin rather than directly running it's binary.