### PR TITLE
Add support for Drupal 10

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,6 +53,7 @@ pipeline {
                             }
                             steps {
                                 sh './test php static'
+                                sh './test drupal10 static'
                                 sh './test drupal9 static'
                                 sh './test drupal8 static'
                                 sh './test akeneo6 static'
@@ -60,6 +61,7 @@ pipeline {
                                 sh './test akeneo4 static'
                                 sh './test wordpress static'
                                 sh './test php dynamic'
+                                sh './test drupal10 dynamic'
                                 sh './test drupal9 dynamic'
                                 sh './test drupal8 dynamic'
                                 sh './test akeneo6 dynamic'
@@ -67,6 +69,7 @@ pipeline {
                                 sh './test akeneo4 dynamic'
                                 sh './test wordpress dynamic'
                                 sh './test php dynamic mutagen'
+                                sh './test drupal10 dynamic mutagen'
                                 sh './test drupal9 dynamic mutagen'
                                 sh './test drupal8 dynamic mutagen'
                                 sh './test akeneo6 dynamic mutagen'
@@ -84,6 +87,10 @@ pipeline {
                                 stage('PHP') {
                                     when { expression { return isHarnessChange(['base']) } }
                                     steps { sh './test php static' }
+                                }
+                                stage('Drupal 10') {
+                                    when { expression { return isHarnessChange(['drupal']) } }
+                                    steps { sh './test drupal10 static' }
                                 }
                                 stage('Drupal 9') {
                                     when { expression { return isHarnessChange(['drupal']) } }
@@ -114,6 +121,10 @@ pipeline {
                                     when { expression { return isHarnessChange(['base']) } }
                                     steps { sh './test php dynamic' }
                                 }
+                                stage('Drupal 10 Dynamic') {
+                                    when { expression { return isHarnessChange(['drupal']) } }
+                                    steps { sh './test drupal10 dynamic' }
+                                }
                                 stage('Drupal 9 Dynamic') {
                                     when { expression { return isHarnessChange(['drupal']) } }
                                     steps { sh './test drupal9 dynamic' }
@@ -142,6 +153,10 @@ pipeline {
                                 stage('PHP Mutagen') {
                                     when { expression { return isHarnessChange(['base']) } }
                                     steps { sh './test php dynamic mutagen' }
+                                }
+                                stage('Drupal 10 Mutagen') {
+                                    when { expression { return isHarnessChange(['drupal']) } }
+                                    steps { sh './test drupal10 dynamic mutagen' }
                                 }
                                 stage('Drupal 9 Mutagen') {
                                     when { expression { return isHarnessChange(['drupal']) } }

--- a/src/drupal/application/skeleton/behat.yml.twig
+++ b/src/drupal/application/skeleton/behat.yml.twig
@@ -12,6 +12,11 @@ default:
             sessions:
                 goutte:
                     goutte:
+                        # Symfony HttpClient
+                        server_parameters:
+                            verify_peer: false
+                            verify_host: false
+                        # Guzzle
                         guzzle_parameters:
                             verify: false
                 chrome:

--- a/src/drupal/application/skeleton/composer.json.twig
+++ b/src/drupal/application/skeleton/composer.json.twig
@@ -17,7 +17,8 @@
       "composer/installers": true,
       "dealerdirect/phpcodesniffer-composer-installer": true,
       "fenetikm/autoload-drupal": true,
-      "oomphinc/composer-installers-extender": true
+      "oomphinc/composer-installers-extender": true,
+      "phpstan/extension-installer": false
     }
   },
   "repositories": {
@@ -31,42 +32,48 @@
     }
   },
   "require": {
+    "php": ">= {{ @('php.version') }}",
 {% if version_compare(@('drupal.major_version'), '9', '>=') %}
-    "php": ">= 8.0",
     "composer/installers": "^2.1",
     "cweagans/composer-patches": "^1.7",
     "drupal/admin_toolbar": "^3.1",
+{% if version_compare(@('drupal.major_version'), '10', '>=') %}
+    "drupal/core-composer-scaffold": "^10.0",
+    "drupal/core-recommended": "^10.0",
+{% else %}
     "drupal/core-composer-scaffold": "^9.4",
     "drupal/core-recommended": "^9.4",
+{% endif %}
     "drupal/ctools": "^4.0",
     "drupal/environment_indicator": "^4.0",
     "drupal/field_group": "^3.2",
-    "drupal/hook_event_dispatcher": "^3.3",
+    "drupal/hook_event_dispatcher": "^3.3 || ~4.0.0-alpha2",
 {% if @('services.varnish.enabled') %}
     "drupal/http_cache_control": "^2.0",
 {% endif %}
     "drupal/inline_entity_form": "^1.0-rc12",
     "drupal/linkit": "~6.0.0@beta",
-    "drupal/login_emailusername": "2.0",
+    "drupal/login_emailusername": "^2.1",
     "drupal/menu_admin_per_menu": "1.5",
     "drupal/metatag": "1.22",
     "drupal/pathauto": "^1.11",
     "drupal/purge": "^3.4",
     "drupal/redirect": "1.8",
+{% if version_compare(@('drupal.major_version'), '10', '<') %}
     "drupal/roleassign": "^1.0.0@beta",
-    "drupal/seckit": "2.0",
+{% endif %}
+    "drupal/seckit": "^2.0",
     "drupal/stage_file_proxy": "^2.0",
-    "drupal/taxonomy_access_fix": "3.3",
+    "drupal/taxonomy_access_fix": "^3.3 || ~4.0.0@beta",
     "drupal/token": "^1.11",
     "drupal/ultimate_cron": "~2.0.0@alpha",
-{% if @('services.varnish.enabled') %}
+{% if version_compare(@('drupal.major_version'), '10', '<') and @('services.varnish.enabled') %}
     "drupal/varnish_purge": "^2.1",
 {% endif %}
     "drush/drush": "^11.1",
     "fenetikm/autoload-drupal": "dev-master#4503484bf2d78e6d739fe13324ab3e6b96d7c244",
     "oomphinc/composer-installers-extender": "^2.0"
 {% else %}
-    "php": ">= 7.4",
     "composer/installers": "^1.0",
     "cweagans/composer-patches": "^1.5.0",
     "drupal/admin_toolbar": "^1.0",
@@ -104,10 +111,16 @@
   "require-dev": {
     "behat/behat": "^3.7",
     "friends-of-behat/mink-extension": "^2.7",
-    "behat/mink-goutte-driver": "^1.3",
+    "behat/mink-goutte-driver": "^1.3 || ^2.0",
     "dmore/behat-chrome-extension": "^1.4",
     "dmore/chrome-mink-driver": "^2.9",
-{% if version_compare(@('drupal.major_version'), '9', '>=') %}
+{% if version_compare(@('drupal.major_version'), '10', '>=') %}
+    "drupal/core-dev": "^10.0",
+    "drupal/devel": "^5.1",
+    "drupal/drupal-extension": "~5.0.0@alpha",
+    "phpunit/phpunit": "^9.6",
+    "phpspec/prophecy-phpunit": "^2",
+{% elseif version_compare(@('drupal.major_version'), '9', '>=') %}
     "drupal/core-dev": "^9.4",
     "drupal/devel": "^4.1",
     "drupal/drupal-extension": "^4.2",

--- a/src/drupal/application/skeleton/composer.json.twig
+++ b/src/drupal/application/skeleton/composer.json.twig
@@ -115,7 +115,7 @@
 {% if version_compare(@('drupal.major_version'), '10', '>=') %}
     "drupal/core-dev": "^10.0",
     "drupal/devel": "^5.1",
-    "drupal/drupal-extension": "~5.0.0@alpha",
+    "drupal/drupal-extension": "~5.0.0@rc",
     "phpunit/phpunit": "^9.6",
     "phpspec/prophecy-phpunit": "^2",
 {% elseif version_compare(@('drupal.major_version'), '9', '>=') %}

--- a/src/drupal/application/skeleton/composer.json.twig
+++ b/src/drupal/application/skeleton/composer.json.twig
@@ -59,9 +59,7 @@
     "drupal/pathauto": "^1.11",
     "drupal/purge": "^3.4",
     "drupal/redirect": "1.8",
-{% if version_compare(@('drupal.major_version'), '10', '<') %}
-    "drupal/roleassign": "^1.0.0@beta",
-{% endif %}
+    "drupal/roleassign": "^2.0",
     "drupal/seckit": "^2.0",
     "drupal/stage_file_proxy": "^2.0",
     "drupal/taxonomy_access_fix": "^3.3 || ~4.0.0@beta",
@@ -94,7 +92,7 @@
     "drupal/pathauto": "^1.8",
     "drupal/purge": "^3.0",
     "drupal/redirect": "1.3",
-    "drupal/roleassign": "^1.0@alpha",
+    "drupal/roleassign": "^1.0@beta",
     "drupal/seckit": "1.1",
     "drupal/stage_file_proxy": "^1.0@alpha",
     "drupal/taxonomy_access_fix": "2.6",

--- a/src/drupal/application/skeleton/composer.json.twig
+++ b/src/drupal/application/skeleton/composer.json.twig
@@ -47,7 +47,7 @@
     "drupal/ctools": "^4.0",
     "drupal/environment_indicator": "^4.0",
     "drupal/field_group": "^3.2",
-    "drupal/hook_event_dispatcher": "^3.3 || ~4.0.0-alpha2",
+    "drupal/hook_event_dispatcher": "{{ version_compare(@('drupal.major_version'), '10', '>=') ? '^4.0 || ~4.0.0@alpha' : '^3.3' }}",
 {% if @('services.varnish.enabled') %}
     "drupal/http_cache_control": "^2.0",
 {% endif %}
@@ -62,7 +62,7 @@
     "drupal/roleassign": "^2.0",
     "drupal/seckit": "^2.0",
     "drupal/stage_file_proxy": "^2.0",
-    "drupal/taxonomy_access_fix": "^3.3 || ~4.0.0@beta",
+    "drupal/taxonomy_access_fix": "{{ version_compare(@('drupal.major_version'), '10', '>=') ? '^4.0 || ~4.0.0@beta' : '^3.3' }}",
     "drupal/token": "^1.11",
     "drupal/ultimate_cron": "~2.0.0@alpha",
 {% if version_compare(@('drupal.major_version'), '10', '<') and @('services.varnish.enabled') %}
@@ -115,7 +115,7 @@
 {% if version_compare(@('drupal.major_version'), '10', '>=') %}
     "drupal/core-dev": "^10.0",
     "drupal/devel": "^5.1",
-    "drupal/drupal-extension": "~5.0.0@rc",
+    "drupal/drupal-extension": "^5.0 || ~5.0.0@rc",
     "phpunit/phpunit": "^9.6",
     "phpspec/prophecy-phpunit": "^2",
 {% elseif version_compare(@('drupal.major_version'), '9', '>=') %}

--- a/src/drupal/application/skeleton/docroot/modules/custom/startup_core/startup_core.info.yml
+++ b/src/drupal/application/skeleton/docroot/modules/custom/startup_core/startup_core.info.yml
@@ -2,6 +2,7 @@ name: Startup Core
 description: 'Base module for core dependencies, global mods, config and tests.'
 type: module
 core: 8.x
+core_version_requirement: ^8 || ^9 || ^10
 package: Startup
 
 dependencies:

--- a/src/drupal/application/skeleton/docroot/profiles/custom/startup/startup.info.yml
+++ b/src/drupal/application/skeleton/docroot/profiles/custom/startup/startup.info.yml
@@ -2,6 +2,7 @@ name: Startup
 type: profile
 description: 'Startup profile'
 core: 8.x
+core_version_requirement: ^8 || ^9 || ^10
 
 distribution:
   name: Startup

--- a/src/drupal/harness.yml
+++ b/src/drupal/harness.yml
@@ -72,7 +72,7 @@ attributes:
     cli:
       ini:
         opcache.file_cache_only: '0'
-    version: "= version_compare(@('drupal.major_version'), '9', '>=') ? '8.0' : '7.4'"
+    version: "= version_compare(@('drupal.major_version'), '10', '>=') ? '8.1' : (version_compare(@('drupal.major_version'), '9', '>=') ? '8.0' : '7.4')"
   persistence:
     enabled: false
     drupal:

--- a/test
+++ b/test
@@ -41,8 +41,10 @@ function main()
         akeneo_version=6
         harness="akeneo"
     fi
-
-    if [[ "$harness" =~ ^(drupal9)$ ]]; then
+    if [[ "$harness" =~ ^(drupal10)$ ]]; then
+        drupal_version=10
+        harness="drupal"
+    elif [[ "$harness" =~ ^(drupal9)$ ]]; then
         drupal_version=9
         harness="drupal"
     elif [[ "$harness" =~ ^(drupal8)$ ]]; then


### PR DESCRIPTION
not enabled by default but can be enabled

One module not yet with any alpha releases or dev branches for Drupal 10:
* drupal/varnish_purge

Modules with alpha/beta releases:
* drupal/hook_event_dispatcher
* drupal/taxonomy_access_fix
* drupal/drupal-extension - now has a release candidate