### PR TITLE
Update mysql to use oracle linux explicitly

### DIFF
--- a/src/_base/harness/attributes/common.yml
+++ b/src/_base/harness/attributes/common.yml
@@ -370,8 +370,7 @@ attributes.default:
 
   mysql:
     image: mysql
-    # arm64 support is currently in a different tag
-    tag: "= host_architecture() == 'amd64' ? '8.0' : '8.0-oracle'"
+    tag: 8.0-oracle
 
   rabbitmq:
     image: rabbitmq


### PR DESCRIPTION
Docker official repository [mysql](https://hub.docker.com/_/mysql) now uses Oracle linux for it's 8.0 tag, however explicit distro tag I think should be preferred to stop continual switching of upstream preference