### PR TITLE
Run builds weekly on Monday mornings instead of every morning

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ pipeline {
         buildDiscarder(logRotator(daysToKeepStr: '30'))
         parallelsAlwaysFailFast()
     }
-    triggers { cron(env.BRANCH_NAME ==~ /^\d+\.\d+\.x$/ ? 'H H(2-6) * * 0' : '') }
+    triggers { cron(env.BRANCH_NAME ==~ /^\d+\.\d+\.x$/ ? 'H H(2-6) * * 1' : '') }
     stages {
         stage('Quality Checks') {
             steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ pipeline {
         buildDiscarder(logRotator(daysToKeepStr: '30'))
         parallelsAlwaysFailFast()
     }
-    triggers { cron(env.BRANCH_NAME ==~ /^\d+\.\d+\.x$/ ? 'H H(0-6) * * *' : '') }
+    triggers { cron(env.BRANCH_NAME ==~ /^\d+\.\d+\.x$/ ? 'H H(2-6) * * 0' : '') }
     stages {
         stage('Quality Checks') {
             steps {

--- a/src/_base/application/overlay/Jenkinsfile.twig
+++ b/src/_base/application/overlay/Jenkinsfile.twig
@@ -6,7 +6,7 @@ pipeline {
         MY127WS_KEY = credentials('{{ @('jenkins.credentials.my127ws_key') }}')
         MY127WS_ENV = "pipeline"
     }
-    triggers { cron(env.BRANCH_NAME == '{{ @('git.default_branch') }}' ? 'H H(2-6) * * 0' : '') }
+    triggers { cron(env.BRANCH_NAME == '{{ @('git.default_branch') }}' ? 'H H(2-6) * * 1' : '') }
     stages {
 {% if @('jenkins.tests.isolated') %}
         stage('Setup') {

--- a/src/_base/application/overlay/Jenkinsfile.twig
+++ b/src/_base/application/overlay/Jenkinsfile.twig
@@ -6,7 +6,7 @@ pipeline {
         MY127WS_KEY = credentials('{{ @('jenkins.credentials.my127ws_key') }}')
         MY127WS_ENV = "pipeline"
     }
-    triggers { cron(env.BRANCH_NAME == '{{ @('git.default_branch') }}' ? 'H H(0-6) * * *' : '') }
+    triggers { cron(env.BRANCH_NAME == '{{ @('git.default_branch') }}' ? 'H H(2-6) * * 0' : '') }
     stages {
 {% if @('jenkins.tests.isolated') %}
         stage('Setup') {

--- a/src/drupal/application/overlay/Jenkinsfile.twig
+++ b/src/drupal/application/overlay/Jenkinsfile.twig
@@ -6,7 +6,7 @@ pipeline {
         MY127WS_KEY = credentials('{{ @('jenkins.credentials.my127ws_key') }}')
         MY127WS_ENV = "pipeline"
     }
-    triggers { cron(env.BRANCH_NAME == '{{ @('git.default_branch') }}' ? 'H H(2-6) * * 0' : '') }
+    triggers { cron(env.BRANCH_NAME == '{{ @('git.default_branch') }}' ? 'H H(2-6) * * 1' : '') }
     stages {
 {% if @('jenkins.tests.isolated') %}
         stage('Setup') {

--- a/src/drupal/application/overlay/Jenkinsfile.twig
+++ b/src/drupal/application/overlay/Jenkinsfile.twig
@@ -6,7 +6,7 @@ pipeline {
         MY127WS_KEY = credentials('{{ @('jenkins.credentials.my127ws_key') }}')
         MY127WS_ENV = "pipeline"
     }
-    triggers { cron(env.BRANCH_NAME == '{{ @('git.default_branch') }}' ? 'H H(0-6) * * *' : '') }
+    triggers { cron(env.BRANCH_NAME == '{{ @('git.default_branch') }}' ? 'H H(2-6) * * 0' : '') }
     stages {
 {% if @('jenkins.tests.isolated') %}
         stage('Setup') {


### PR DESCRIPTION
In an effort to reduce our electricity consumption and carbon usage, run builds once a week on a Monday morning rather than every morning.

2am to 6am seems best in terms of the renewable electricity mix based on https://electricityinfo.org/fuel-mix-last-24-hours/ and the forecast for London in https://electricityinfo.org/carbon-intensity-by-region/