### PR TITLE
Mountpoint chown recursive now optional

### DIFF
--- a/src/_base/harness/attributes/docker-base.yml
+++ b/src/_base/harness/attributes/docker-base.yml
@@ -282,10 +282,12 @@ attributes:
           initContainers:
             volumePermissions:
               image: = @('pipeline.base.services.webapp.initContainers.volumePermissions.image')
+              recursive: = @('pipeline.base.services.webapp.initContainers.volumePermissions.recursive')
         webapp:
           initContainers:
             volumePermissions:
               image: busybox:1.35
+              recursive: true
       ingress:
         annotations: {}
         target_service: "= @('services.varnish.enabled') ? 'varnish' : 'webapp'"

--- a/src/_base/helm/app/templates/application/cron/deployment.yaml
+++ b/src/_base/helm/app/templates/application/cron/deployment.yaml
@@ -32,7 +32,9 @@ spec:
         image: {{ .initContainers.volumePermissions.image }}
         command:
         - "/bin/chown"
+        {{- if .initContainers.volumePermissions.recursive }}
         - "-R"
+        {{- end }}
         - "www-data"
         {{- include "application.volumes.wwwDataPaths" $ | indent 8 }}
         volumeMounts:

--- a/src/_base/helm/app/templates/application/webapp/deployment.yaml
+++ b/src/_base/helm/app/templates/application/webapp/deployment.yaml
@@ -32,7 +32,9 @@ spec:
         image: {{ .Values.services.webapp.initContainers.volumePermissions.image }}
         command:
         - "/bin/chown"
+        {{- if .initContainers.volumePermissions.recursive }}
         - "-R"
+        {{- end }}
         - "www-data"
         {{- include "application.volumes.wwwDataPaths" . | indent 8 }}
         volumeMounts:

--- a/src/_base/helm/app/templates/application/webapp/deployment.yaml
+++ b/src/_base/helm/app/templates/application/webapp/deployment.yaml
@@ -32,7 +32,7 @@ spec:
         image: {{ .Values.services.webapp.initContainers.volumePermissions.image }}
         command:
         - "/bin/chown"
-        {{- if .initContainers.volumePermissions.recursive }}
+        {{- if .Values.services.webapp.initContainers.volumePermissions.recursive }}
         - "-R"
         {{- end }}
         - "www-data"

--- a/src/akeneo/harness/attributes/docker.yml
+++ b/src/akeneo/harness/attributes/docker.yml
@@ -45,6 +45,7 @@ attributes:
           initContainers:
             volumePermissions:
               image: = @('pipeline.base.services.webapp.initContainers.volumePermissions.image')
+              recursive: = @('pipeline.base.services.webapp.initContainers.volumePermissions.recursive')
         php-base:
           environment:
             APP_HOST: = @('pipeline.base.hostname')

--- a/src/akeneo/helm/app/templates/application/job-queue-consumer/deployment.yaml
+++ b/src/akeneo/helm/app/templates/application/job-queue-consumer/deployment.yaml
@@ -32,7 +32,9 @@ spec:
         image: {{ .initContainers.volumePermissions.image }}
         command:
         - "/bin/chown"
+        {{- if .initContainers.volumePermissions.recursive }}
         - "-R"
+        {{- end }}
         - "www-data"
         {{- include "application.volumes.wwwDataPaths" $ | indent 8 }}
         volumeMounts:


### PR DESCRIPTION
When there are a large amount of files, the recursive chown on some filesystems causes a big delay in allowing the pod to start up.

The recursive chown on NFS is ignored due to user management largely being ignored, but some filesystems do offer the ability to change the user.

The intention of this was to change the owner of the mountpoint rather than the owner of the files within the mountpoint, as hopefully the files within are already owned correctly.