### PR TITLE
Make docker-compose bin configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ Each framework will fully override a base harness file if differing behaviour is
 
 ## Features of each harness
 
-* Local docker-compose development environment
+* Local docker compose development environment
 * Skeleton for simple set-up of new projects
-* Pipeline docker-compose environment for use in Jenkins or other tools to run tests
+* Pipeline docker compose environment for use in Jenkins or other tools to run tests
 * Helm chart for deploying QA, UAT and Production environments to Kubernetes clusters
 
 ## Harness Upgrade Instructions

--- a/src/_base/harness/attributes/common.yml
+++ b/src/_base/harness/attributes/common.yml
@@ -113,6 +113,7 @@ attributes.default:
     buildkit:
       enabled: true
     compose:
+      bin: 'docker-compose'
       file_version: '3.7'
       host_volume_options: "= ':' ~ (bool(@('delegated-volumes')) ? 'delegated' : 'cached')"
     # If using gitops helm chart repositories, it's recommended to put this configuration

--- a/src/_base/harness/config/cleanup.yml
+++ b/src/_base/harness/config/cleanup.yml
@@ -14,7 +14,7 @@ function('built_images', [services]): |
 
 command('built-images ls'):
   env:
-    IMAGES: = built_images(docker_service_images())
+    IMAGES: = built_images(docker_service_images(@('docker.compose.bin')))
   exec: |
     #!bash
     echo "$IMAGES"

--- a/src/_base/harness/config/commands.yml
+++ b/src/_base/harness/config/commands.yml
@@ -6,6 +6,7 @@ command('enable'):
     APP_MODE:             = @('app.mode')
     NAMESPACE:            = @('namespace')
     HAS_ASSETS:           = boolToString(@('aws.bucket') !== null and @('aws.bucket') !== '')
+    COMPOSE_BIN: = @('docker.compose.bin')
     COMPOSE_PROJECT_NAME: = @('namespace')
     COMPOSE_DOCKER_CLI_BUILD: = @('docker.buildkit.enabled') ? '1':'0'
     DOCKER_BUILDKIT:          = @('docker.buildkit.enabled') ? '1':'0'
@@ -21,6 +22,7 @@ command('enable console'):
     APP_MODE:             = @('app.mode')
     NAMESPACE:            = @('namespace')
     HAS_ASSETS:           = boolToString(@('aws.bucket') !== null and @('aws.bucket'))
+    COMPOSE_BIN: = @('docker.compose.bin')
     COMPOSE_PROJECT_NAME: = @('namespace')
     COMPOSE_DOCKER_CLI_BUILD: = @('docker.buildkit.enabled') ? '1':'0'
     DOCKER_BUILDKIT:          = @('docker.buildkit.enabled') ? '1':'0'
@@ -33,6 +35,7 @@ command('disable'):
   env:
     USE_MUTAGEN:          = boolToString(@('host.os') == 'darwin' and bool(@('mutagen')))
     NAMESPACE:            = @('namespace')
+    COMPOSE_BIN: = @('docker.compose.bin')
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)
@@ -42,6 +45,7 @@ command('destroy [--all]'):
   env:
     USE_MUTAGEN:          = boolToString(@('host.os') == 'darwin' and bool(@('mutagen')))
     NAMESPACE:            = @('namespace')
+    COMPOSE_BIN: = @('docker.compose.bin')
     COMPOSE_PROJECT_NAME: = @('namespace')
     DESTROY_ALL:          = boolToString(input.option('all'))
   exec: |
@@ -52,6 +56,7 @@ command('rebuild'):
   env:
     USE_MUTAGEN:          = boolToString(@('host.os') == 'darwin' and bool(@('mutagen')))
     NAMESPACE:            = @('namespace')
+    COMPOSE_BIN: = @('docker.compose.bin')
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
@@ -59,7 +64,7 @@ command('rebuild'):
 
 command('networks external'):
   env:
-    NETWORKS: = get_docker_external_networks()
+    NETWORKS: = get_docker_external_networks(@('docker.compose.bin'))
   exec: |
     #!bash(workspace:/)
     for NETWORK in ${NETWORKS}; do
@@ -70,35 +75,39 @@ command('networks external'):
 
 command('exec %'):
   env:
+    COMPOSE_BIN: = @('docker.compose.bin')
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|=
     if [ -t 0 ] && [ -t 1 ] ; then
-      docker-compose exec -u build console ={ input.argument('%') }
+      $COMPOSE_BIN exec -u build console ={ input.argument('%') }
     else
-      docker-compose exec -T -u build console ={ input.argument('%') }
+      $COMPOSE_BIN exec -T -u build console ={ input.argument('%') }
     fi
 
 command('logs %'):
   env:
+    COMPOSE_BIN: = @('docker.compose.bin')
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(harness:/)|=
-    docker-compose logs ={input.argument('%')}
+    $COMPOSE_BIN logs ={input.argument('%')}
 
 command('ps'):
   env:
+    COMPOSE_BIN: = @('docker.compose.bin')
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
-    docker-compose ps
+    $COMPOSE_BIN ps
 
 command('console'):
   env:
+    COMPOSE_BIN: = @('docker.compose.bin')
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
-    passthru docker-compose exec -u build console bash
+    passthru $COMPOSE_BIN exec -u build console bash
 
 command('composer %'):
   exec: |
@@ -111,10 +120,11 @@ command('db-console'): |
 
 command('db console'):
   env:
+    COMPOSE_BIN: = @('docker.compose.bin')
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
-    passthru "docker-compose exec console bash -c 'mysql --host \"\$DB_HOST\" --user \"\$DB_USER\" -p\"\$DB_PASS\" \"\$DB_NAME\"'"
+    passthru "$COMPOSE_BIN exec console bash -c 'mysql --host \"\$DB_HOST\" --user \"\$DB_USER\" -p\"\$DB_PASS\" \"\$DB_NAME\"'"
 
 command('assets download'):
   env:
@@ -138,43 +148,48 @@ command('assets upload'):
 
 command('frontend build'):
   env:
+    COMPOSE_BIN: = @('docker.compose.bin')
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
-    passthru docker-compose exec -u build console app build:frontend
+    passthru $COMPOSE_BIN exec -u build console app build:frontend
 
 command('frontend watch'):
   env:
+    COMPOSE_BIN: = @('docker.compose.bin')
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
     # Use `bash -i` to load up /home/build/.bashrc, which sets up node version manager (nvm) paths
-    docker-compose exec -u build --workdir '@('frontend.path')' console bash -i -c '@('frontend.watch')'
+    $COMPOSE_BIN exec -u build --workdir '@('frontend.path')' console bash -i -c '@('frontend.watch')'
 
 command('frontend console'):
   env:
+    COMPOSE_BIN: = @('docker.compose.bin')
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
     # Use `bash -i` to load up /home/build/.bashrc, which sets up node version manager (nvm) paths
-    passthru docker-compose exec -u build --workdir '@('frontend.path')' console bash -i
+    passthru $COMPOSE_BIN exec -u build --workdir '@('frontend.path')' console bash -i
 
 command('port <service>'):
   env:
+    COMPOSE_BIN: = @('docker.compose.bin')
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|=
-    passthru docker port "$(docker-compose ps -q ={input.argument('service')})"
+    passthru docker port "$($COMPOSE_BIN ps -q ={input.argument('service')})"
 
 command('service php-fpm restart'):
   env:
+    COMPOSE_BIN: = @('docker.compose.bin')
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
     passthru ws install --step=prepare
-    docker-compose exec console bash -c 'cp -r /.my127ws/docker/image/console/root/usr/local/etc/php/conf.d/* /usr/local/etc/php/conf.d/'
-    docker-compose exec php-fpm bash -c 'cp -r /.my127ws/docker/image/php-fpm/root/usr/local/etc/php/conf.d/* /usr/local/etc/php/conf.d/'
-    passthru docker-compose exec php-fpm supervisorctl restart php-fpm
+    $COMPOSE_BIN exec console bash -c 'cp -r /.my127ws/docker/image/console/root/usr/local/etc/php/conf.d/* /usr/local/etc/php/conf.d/'
+    $COMPOSE_BIN exec php-fpm bash -c 'cp -r /.my127ws/docker/image/php-fpm/root/usr/local/etc/php/conf.d/* /usr/local/etc/php/conf.d/'
+    passthru $COMPOSE_BIN exec php-fpm supervisorctl restart php-fpm
 
 command('set <attribute> <value>'):
   env:
@@ -249,20 +264,23 @@ command('feature tideways cli (on|off)'):
 
 command('feature tideways cli configure <server_key>'):
   env:
+    COMPOSE_BIN: = @('docker.compose.bin')
+    COMPOSE_PROJECT_NAME: = @('namespace')
     TIDEWAYS_SERVERKEY: = input.argument('server_key')
   exec: |
     #!bash(workspace:/)|=
     echo "Importing Provided Tideways CLI Key (from https://app.tideways.io/user/cli-import-settings)"
-    docker-compose exec -T -u build console tideways import "$TIDEWAYS_SERVERKEY"
+    $COMPOSE_BIN exec -T -u build console tideways import "$TIDEWAYS_SERVERKEY"
     echo "Imported Tideways CLI key"
 
 command('db import <database_file>'):
   env:
+    COMPOSE_BIN: = @('docker.compose.bin')
     COMPOSE_PROJECT_NAME: = @('namespace')
     DATABASE_FILE: = input.argument('database_file')
   exec: |
     #!bash(workspace:/)|=
-    passthru docker-compose exec -u build console app database:import "$DATABASE_FILE"
+    passthru $COMPOSE_BIN exec -u build console app database:import "$DATABASE_FILE"
 
 command('harness update existing'):
   env:
@@ -310,8 +328,9 @@ command('generate token <length>'):
 
 command('lighthouse [--with-results]'):
   env:
+    COMPOSE_BIN: = @('docker.compose.bin')
     COMPOSE_PROJECT_NAME: = @('namespace')
     OUTPUT_RESULTS:       = boolToString(input.option('with-results'))
   exec: |
     #!bash(workspace:/)|@
-    passthru docker-compose run -T --rm lighthouse bash -i /app/run.sh
+    passthru $COMPOSE_BIN run -T --rm lighthouse bash -i /app/run.sh

--- a/src/_base/harness/config/events.yml
+++ b/src/_base/harness/config/events.yml
@@ -5,11 +5,12 @@ after('harness.install'): |
 
 after('harness.refresh'):
   env:
+    COMPOSE_BIN: = @('docker.compose.bin')
     COMPOSE_PROJECT: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
-    run docker-compose stop
+    run $COMPOSE_BIN stop
     ws external-images pull
-    passthru "docker-compose config --services | grep -v cron | grep -v jenkins-runner | grep -v job-queue-consumer | xargs docker-compose build"
-    passthru "docker-compose config --services | grep -v cron | grep -v jenkins-runner | grep -v job-queue-consumer | xargs docker-compose up -d"
-    run docker-compose up -d --build
+    passthru "$COMPOSE_BIN config --services | grep -v cron | grep -v jenkins-runner | grep -v job-queue-consumer | xargs $COMPOSE_BIN build"
+    passthru "$COMPOSE_BIN config --services | grep -v cron | grep -v jenkins-runner | grep -v job-queue-consumer | xargs $COMPOSE_BIN up -d"
+    run $COMPOSE_BIN up -d --build

--- a/src/_base/harness/config/external-images.yml
+++ b/src/_base/harness/config/external-images.yml
@@ -28,7 +28,7 @@ function('external_images', [services]): |
 
 command('external-images config [--skip-exists] [<service>]'):
   env:
-    IMAGES: = external_images(docker_service_images(input.argument('service')))
+    IMAGES: = external_images(docker_service_images(@('docker.compose.bin'), input.argument('service')))
     SKIP_EXISTS: "= input.option('skip-exists') ? 1 : 0"
   exec: |
     #!php
@@ -47,6 +47,7 @@ command('external-images config [--skip-exists] [<service>]'):
 
 command('external-images pull [<service>]'):
   env:
+    COMPOSE_BIN: = @('docker.compose.bin')
     SERVICE: = input.argument('service')
   exec: |
     #!bash(workspace:/)|@
@@ -59,11 +60,11 @@ command('external-images pull [<service>]'):
       CONF_ARGS+=("$SERVICE")
     fi
 
-    passthru "ws external-images config $(printf '%q ' "${CONF_ARGS[@]}") | docker-compose -f - pull"
+    passthru "ws external-images config $(printf '%q ' "${CONF_ARGS[@]}") | $COMPOSE_BIN -f - pull"
 
 command('external-images ls [--all]'):
   env:
-    IMAGES: = external_images(docker_service_images())
+    IMAGES: = external_images(docker_service_images(@('docker.compose.bin')))
     SHOW_REMOTE: "= input.option('all') ? 1 : 0"
   exec: |
     #!php

--- a/src/_base/harness/config/functions.yml
+++ b/src/_base/harness/config/functions.yml
@@ -102,9 +102,9 @@ function('flatten', [array_input]): |
   $iterator = new RecursiveIteratorIterator(new RecursiveArrayIterator($array_input));
   = iterator_to_array($iterator, false);
 
-function('get_docker_external_networks'): |
+function('get_docker_external_networks', [compose_bin]): |
   #!php
-  $configRaw = shell_exec('docker-compose config');
+  $configRaw = shell_exec($compose_bin . ' config');
   if ($configRaw === null) {
     exit(1);
   }
@@ -123,9 +123,9 @@ function('get_docker_external_networks'): |
   }
   = join(" ", $externalNetworks);
 
-function('docker_service_images', [filterService]): |
+function('docker_service_images', [compose_bin, filterService]): |
   #!php
-  $configRaw = shell_exec('docker-compose config');
+  $configRaw = shell_exec($compose_bin . ' config');
   if ($configRaw === null) {
     exit(1);
   }

--- a/src/_base/harness/config/pipeline.yml
+++ b/src/_base/harness/config/pipeline.yml
@@ -1,6 +1,7 @@
 
 command('app build'):
   env:
+    COMPOSE_BIN: = @('docker.compose.bin')
     HAS_CRON: "= @('services.cron.enabled') ? 'true' : 'false'"
     HAS_JENKINS_RUNNER: "= @('services.jenkins-runner.enabled') ? 'true' : 'false'"
     HAS_JOB_QUEUE_CONSUMER: "= @('services.job-queue-consumer.enabled') ? 'true' : 'false'"
@@ -11,41 +12,43 @@ command('app build'):
     ws external-images pull
 
     # dependency ordered build
-    passthru docker-compose build console
+    passthru $COMPOSE_BIN build console
     if [[ "${HAS_WEBAPP}" == "true" ]] || [[ "${HAS_CRON}" == "true" ]] || [ "${HAS_JOB_QUEUE_CONSUMER}" == "true" ]; then
-      passthru docker-compose build php-fpm
+      passthru $COMPOSE_BIN build php-fpm
     fi
     if [[ "${HAS_WEBAPP}" == "true" ]]; then
-      passthru docker-compose build nginx
+      passthru $COMPOSE_BIN build nginx
     fi
     if [[ "${HAS_CRON}" == "true" ]]; then
-      passthru docker-compose build cron
+      passthru $COMPOSE_BIN build cron
     fi
     if [[ "${HAS_JENKINS_RUNNER}" == "true" ]]; then
-      passthru docker-compose build jenkins-runner
+      passthru $COMPOSE_BIN build jenkins-runner
     fi
     if [[ "${HAS_JOB_QUEUE_CONSUMER}" == "true" ]]; then
-      passthru docker-compose build job-queue-consumer
+      passthru $COMPOSE_BIN build job-queue-consumer
     fi
     if [[ "${HAS_SOLR}" == "true" ]]; then
-      passthru docker-compose build solr
+      passthru $COMPOSE_BIN build solr
     fi
 
 command('app build <service>'):
   env:
+    COMPOSE_BIN: = @('docker.compose.bin')
     SERVICE:    = input.argument('service')
   exec: |
     #!bash(workspace:/)|@
-    passthru docker-compose build "${SERVICE}"
+    passthru $COMPOSE_BIN build "${SERVICE}"
 
 command('app publish'):
   env:
+    COMPOSE_BIN: = @('docker.compose.bin')
     COMPOSE_HTTP_TIMEOUT: 180
     DOCKER_CLIENT_TIMEOUT: 180
   exec: |
     #!bash(workspace:/)|@
     echo '@('docker.registry.password')' | run docker login --username='@('docker.registry.username')' --password-stdin '@('docker.registry.url')'
-    passthru docker-compose push @('pipeline.publish.services')
+    passthru $COMPOSE_BIN push @('pipeline.publish.services')
     run docker logout '@('docker.registry.url')'
 
 command('app publish chart <release> <message>'):

--- a/src/_base/harness/config/xdebug.yml
+++ b/src/_base/harness/config/xdebug.yml
@@ -1,6 +1,7 @@
 command('feature xdebug version-sync'):
   env:
     XDEBUG_VERSION: = @('php.ext-xdebug.version')
+    COMPOSE_BIN: = @('docker.compose.bin')
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)

--- a/src/_base/harness/scripts/destroy.sh
+++ b/src/_base/harness/scripts/destroy.sh
@@ -1,12 +1,15 @@
 #!/usr/bin/env bash
 
+# shellcheck disable=SC2206
+COMPOSE_BIN=($COMPOSE_BIN)
+
 if [ "${DESTROY_ALL}" = yes ]; then
   RMI=all
 else
   RMI=local
 fi
 
-run docker-compose down --rmi "${RMI}" --volumes --remove-orphans --timeout 120
+run "${COMPOSE_BIN[*]}" down --rmi "${RMI}" --volumes --remove-orphans --timeout 120
 
 if [ "${USE_MUTAGEN}" = yes ]; then
   run ws mutagen stop

--- a/src/_base/harness/scripts/disable.sh
+++ b/src/_base/harness/scripts/disable.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 
+# shellcheck disable=SC2206
+COMPOSE_BIN=($COMPOSE_BIN)
+
 if [[ "$USE_MUTAGEN" = "yes" ]]; then
     run ws mutagen pause
 fi
 
-run docker-compose stop
+run "${COMPOSE_BIN[@]}" stop

--- a/src/_base/harness/scripts/enable.sh.twig
+++ b/src/_base/harness/scripts/enable.sh.twig
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
 
+# shellcheck disable=SC2206
+COMPOSE_BIN=($COMPOSE_BIN)
+
 console_enabled()
 {
     if [ "$APP_BUILD" = dynamic ]; then
         [ -f .my127ws/.flag-console-built ]
     else
-        [ -n "$(docker-compose ps --quiet console)" ]
+        [ -n "$("${COMPOSE_BIN[@]}" ps --quiet console)" ]
     fi
 }
 
@@ -18,12 +21,12 @@ enable_all()
         HAS_FLAG=yes
         IS_BUILT=yes
         # If the containers no longer exist, we need to rebuild them
-        if [ -z "$(docker-compose ps --quiet)" ]; then
+        if [ -z "$("${COMPOSE_BIN[@]}" ps --quiet)" ]; then
             IS_BUILT=no
         fi
     fi
 
-    if [ "$APP_BUILD" = dynamic ] && console_enabled && [ -z "$(docker-compose ps --quiet console)" ]; then
+    if [ "$APP_BUILD" = dynamic ] && console_enabled && [ -z "$("${COMPOSE_BIN[@]}" ps --quiet console)" ]; then
         rm .my127ws/.flag-console-built
     fi
 
@@ -32,9 +35,9 @@ enable_all()
         if [ "$HAS_FLAG" = no ]; then
             # remove all services, keeping console if considered built
             if console_enabled; then
-                passthru "docker-compose ps --services | grep -v -Fxe console | xargs docker-compose rm --force --stop --"
+                passthru "${COMPOSE_BIN[*]}  ps --services | grep -v -Fxe console | xargs ${COMPOSE_BIN[*]} rm --force --stop --"
             else
-                passthru docker-compose down
+                passthru "${COMPOSE_BIN[@]}" down
             fi
         fi
 
@@ -52,13 +55,13 @@ enable_all()
             passthru ws mutagen resume
         fi
 
-        passthru docker-compose up -d
-        passthru docker-compose exec -T -u build console app welcome
+        passthru "${COMPOSE_BIN[@]}" up -d
+        passthru "${COMPOSE_BIN[@]}" exec -T -u build console app welcome
     fi
 }
 
 enable_console() {
-    if [ "$APP_BUILD" = dynamic ] && console_enabled && [ -z "$(docker-compose ps --quiet console)" ]; then
+    if [ "$APP_BUILD" = dynamic ] && console_enabled && [ -z "$("${COMPOSE_BIN[@]}" ps --quiet console)" ]; then
         rm .my127ws/.flag-console-built
     fi
 
@@ -71,8 +74,8 @@ dynamic_console()
 {
     if console_enabled; then
         # ensure it is started
-        if [ -z "$(docker-compose ps --quiet console)" ]; then
-            passthru docker-compose up -d console
+        if [ -z "$("${COMPOSE_BIN[@]}" ps --quiet console)" ]; then
+            passthru "${COMPOSE_BIN[@]}" up -d console
         fi
         return;
     fi
@@ -85,8 +88,8 @@ dynamic_console()
 
     find .my127ws/docker/image/ -type d ! -perm u+rwx,go+rx,o-w -exec chmod u+rwx,go+rx,o-w {} +
 
-    passthru docker-compose up --build -d console
-    passthru docker-compose exec -T -u build console app build
+    passthru "${COMPOSE_BIN[@]}" up --build -d console
+    passthru "${COMPOSE_BIN[@]}" exec -T -u build console app build
 
     if [ "$USE_MUTAGEN" = yes ]; then
         ws mutagen resume
@@ -101,19 +104,19 @@ dynamic()
 
     dynamic_console
 
-    passthru "docker-compose config --services | grep -v -Fwe console -Fxe cron -Fxe jenkins-runner -Fxe job-queue-consumer | xargs docker-compose build"
+    passthru "${COMPOSE_BIN[*]} config --services | grep -v -Fwe console -Fxe cron -Fxe jenkins-runner -Fxe job-queue-consumer | xargs ${COMPOSE_BIN[*]} build"
 
     {% if @('services.cron.enabled') %}
-        passthru docker-compose build cron
+        passthru "${COMPOSE_BIN[@]}" build cron
     {% endif %}
     {% if @('services.jenkins-runner.enabled') %}
-        passthru docker-compose build jenkins-runner
+        passthru "${COMPOSE_BIN[@]}" build jenkins-runner
     {% endif %}
     {% if @('services.job-queue-consumer.enabled') %}
-        passthru docker-compose build job-queue-consumer
+        passthru "${COMPOSE_BIN[@]}" build job-queue-consumer
     {% endif %}
     {% if @('services.solr.enabled') %}
-        passthru docker-compose build solr
+        passthru "${COMPOSE_BIN[@]}" build solr
     {% endif %}
 }
 
@@ -122,7 +125,7 @@ static_console()
     if [ "$HAS_ASSETS" = yes ]; then
         ws assets download
     fi
-    passthru docker-compose up --build -d console
+    passthru "${COMPOSE_BIN[@]}" up --build -d console
 }
 
 static()
@@ -133,12 +136,12 @@ static()
 initial_start()
 {
     # Bring up all services apart from cron
-    passthru "docker-compose config --services | grep -v -Fxe cron | xargs docker-compose up -d"
+    passthru "${COMPOSE_BIN[*]} config --services | grep -v -Fxe cron | xargs ${COMPOSE_BIN[*]} up -d"
 
-    passthru docker-compose exec -T -u build console app init
+    passthru "${COMPOSE_BIN[@]}" exec -T -u build console app init
 
     {% if @('services.cron.enabled') %}
-    passthru docker-compose up -d cron
+    passthru "${COMPOSE_BIN[@]}" up -d cron
     {% endif %}
 }
 

--- a/src/_base/harness/scripts/enable.sh.twig
+++ b/src/_base/harness/scripts/enable.sh.twig
@@ -35,7 +35,10 @@ enable_all()
         if [ "$HAS_FLAG" = no ]; then
             # remove all services, keeping console if considered built
             if console_enabled; then
-                passthru "${COMPOSE_BIN[*]}  ps --services | grep -v -Fxe console | xargs ${COMPOSE_BIN[*]} rm --force --stop --"
+                # shellcheck disable=SC2143
+                if [ -n "$("${COMPOSE_BIN[@]}" ps --services | grep -v -Fxe console)" ]; then
+                    passthru "${COMPOSE_BIN[*]}  ps --services | grep -v -Fxe console | xargs ${COMPOSE_BIN[*]} rm --force --stop --"
+                fi
             else
                 passthru "${COMPOSE_BIN[@]}" down
             fi

--- a/src/_base/harness/scripts/rebuild.sh
+++ b/src/_base/harness/scripts/rebuild.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 
-run docker-compose down --rmi local --volumes --remove-orphans --timeout 120
+# shellcheck disable=SC2206
+COMPOSE_BIN=($COMPOSE_BIN)
+
+run "${COMPOSE_BIN[*]}" down --rmi local --volumes --remove-orphans --timeout 120
 
 passthru ws cleanup built-images
 

--- a/src/_base/harness/scripts/xdebug_version_sync.sh
+++ b/src/_base/harness/scripts/xdebug_version_sync.sh
@@ -2,12 +2,15 @@
 
 set -e -o pipefail
 
+# shellcheck disable=SC2206
+COMPOSE_BIN=($COMPOSE_BIN)
+
 UPDATE_CONTAINERS=0
 
 xdebug_version_sync()
 {
   local INSTALLED_VERSION
-  INSTALLED_VERSION="$(docker-compose exec -T -u root "$1" pecl info xdebug 2>&1 | grep "Release Version" | awk '{print $3}')"
+  INSTALLED_VERSION="$("${COMPOSE_BIN[@]}" exec -T -u root "$1" pecl info xdebug 2>&1 | grep "Release Version" | awk '{print $3}')"
   local INSTALLED_MAJOR_VERSION
   INSTALLED_MAJOR_VERSION="$(echo "$INSTALLED_VERSION" | cut -d '.' -f1)"
 
@@ -28,8 +31,8 @@ xdebug_version_sync()
       exit 1
   esac
 
-  run docker-compose exec -T -u root "$1" pecl uninstall xdebug
-  run docker-compose exec -T -u root "$1" pecl install "$INSTALL_CANDIDATE"
+  run "${COMPOSE_BIN[@]}" exec -T -u root "$1" pecl uninstall xdebug
+  run "${COMPOSE_BIN[@]}" exec -T -u root "$1" pecl install "$INSTALL_CANDIDATE"
 
   UPDATE_CONTAINERS=1
 }

--- a/src/drupal/docs/customise/commands.md
+++ b/src/drupal/docs/customise/commands.md
@@ -14,36 +14,29 @@ you use `docker-compose` from within a custom command._
 
 ### Refresh script - `ws drupal-refresh`
 ```yaml
-command('drupal-refresh'):
-  env:
-    COMPOSE_PROJECT_NAME: = @('namespace')
-  exec: |
-    #!bash(workspace:/)|@
-    docker-compose exec console echo "Running drupal-refresh"
-    ws composer install
-    ws drush -y cr
-    ws drush -y updb
-    ws frontend install
+command('drupal-refresh'): |
+  #!bash(workspace:/)|@
+  echo "Running drupal-refresh"
+  ws composer install
+  ws drush -y cr
+  ws drush -y updb
+  ws frontend install
 ```
 
 ### Sanitise the DB - `ws sanitise-db`
 ```yaml
-command('sanitise-db'):
-  env:
-    COMPOSE_PROJECT_NAME: = @('namespace')
-  exec: |
-    #!bash|=
-    docker-compose exec console echo "Running sanitise-db"
-    ws drush sql-sanitize --sanitize-password=password -y
-    ws drush uublk 1
-    ws drush uli
+command('sanitise-db'): |
+  #!bash|=
+  echo "Running sanitise-db"
+  ws drush sql-sanitize --sanitize-password=password -y
+  ws drush uublk 1
+  ws drush uli
 ```
 
 ### Database import - `ws import-db @drush.alias path/to/db.sql`
 ```yaml
 command('import-db <alias> <database>'):
   env:
-    COMPOSE_PROJECT_NAME: = @('namespace')
     ALIAS: = input.argument('alias')
     DB_FILE: = input.argument('database')
   exec: |

--- a/src/drupal/harness.yml
+++ b/src/drupal/harness.yml
@@ -90,16 +90,17 @@ command('drush %'):
 ---
 command('test-unit'):
   env:
+    COMPOSE_BIN: = @('docker.compose.bin')
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|=
-    docker-compose exec -T -u root php-fpm bash -c 'mkdir -p /app/docroot/sites/simpletest'
-    docker-compose exec -T -u root php-fpm bash -c 'chown -R www-data:www-data /app/docroot/sites/simpletest'
-    if ! docker-compose exec -T -u root php-fpm bash -c '[ -f /app/bin/phpunit ]'; then
+    $COMPOSE_BIN exec -T -u root php-fpm bash -c 'mkdir -p /app/docroot/sites/simpletest'
+    $COMPOSE_BIN exec -T -u root php-fpm bash -c 'chown -R www-data:www-data /app/docroot/sites/simpletest'
+    if ! $COMPOSE_BIN exec -T -u root php-fpm bash -c '[ -f /app/bin/phpunit ]'; then
       run "docker cp ${COMPOSE_PROJECT_NAME}_console_1:/app/bin - | docker cp - ${COMPOSE_PROJECT_NAME}_php-fpm_1:/app/"
       run "docker cp ${COMPOSE_PROJECT_NAME}_console_1:/app/vendor - | docker cp - ${COMPOSE_PROJECT_NAME}_php-fpm_1:/app/"
     fi
-    passthru docker-compose exec -T -u www-data php-fpm bash -c 'bin/phpunit'
+    passthru $COMPOSE_BIN exec -T -u www-data php-fpm bash -c 'bin/phpunit'
 ---
 import:
   - harness/config/*.yml

--- a/src/magento1/harness.yml
+++ b/src/magento1/harness.yml
@@ -132,9 +132,13 @@ attributes:
         #hostPath: "..." alternatively for single node testing
         size: 1Gi
 ---
-command('redis-flush'): |
-  #!bash(harness:/)|@
-  docker-compose -p @('namespace') exec redis redis-cli flushall
+command('redis-flush'): 
+  env:
+    COMPOSE_BIN: = @('docker.compose.bin')
+    COMPOSE_PROJECT_NAME: = @('namespace')
+  exec: |
+    #!bash(harness:/)|@
+    $COMPOSE_BIN exec redis redis-cli flushall
 ---
 import:
   - harness/config/*.yml

--- a/src/magento2/harness.yml
+++ b/src/magento2/harness.yml
@@ -238,10 +238,11 @@ command('redis-flush'): |
 
 command('redis flush'):
   env:
+    COMPOSE_BIN: = @('docker.compose.bin')
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(harness:/)|@
-    docker-compose exec redis redis-cli flushall
+    $COMPOSE_BIN exec redis redis-cli flushall
 
 command('magento %'):
   exec: |

--- a/src/spryker/harness.yml
+++ b/src/spryker/harness.yml
@@ -222,18 +222,20 @@ attributes:
 ---
 command('frontend yves watch'):
   env:
+    COMPOSE_BIN: = @('docker.compose.bin')
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
     # Use `bash -i` to load up /home/build/.bashrc, which sets up node version manager (nvm) paths
-    passthru docker-compose exec -u build --workdir '@('frontend.path')' console bash -i -c '@('frontend.yves.watch')'
+    passthru $COMPOSE_BIN exec -u build --workdir '@('frontend.path')' console bash -i -c '@('frontend.yves.watch')'
 command('frontend zed watch'):
   env:
+    COMPOSE_BIN: = @('docker.compose.bin')
     COMPOSE_PROJECT_NAME: = @('namespace')
   exec: |
     #!bash(workspace:/)|@
     # Use `bash -i` to load up /home/build/.bashrc, which sets up node version manager (nvm) paths
-    passthru docker-compose exec -u build --workdir '@('frontend.path')' console bash -i -c '@('frontend.zed.watch')'
+    passthru $COMPOSE_BIN exec -u build --workdir '@('frontend.path')' console bash -i -c '@('frontend.zed.watch')'
 
 command('spryker-reset'):
   env:

--- a/test
+++ b/test
@@ -161,9 +161,9 @@ function check_environment_started()
       project="$(git log -n 1 --pretty=format:'%H')"
     fi
 
-    if [ "$(docker-compose -p "$project" ps | grep -v "lighthouse" | grep -c Exit)" -gt 0 ]; then
+    if [ "$(docker compose -p "$project" ps | grep -v "lighthouse" | grep -c Exit)" -gt 0 ]; then
       echo 'Some containers failed to start'
-      docker-compose -p "$project" ps
+      docker compose -p "$project" ps
       return 1
     fi
 )


### PR DESCRIPTION
Allow it to be configurable for switching to docker compose v2 as exec-plugin later

also fix an issue where some docker compose v2 versions delete all containers on `docker compose rm` with no arguments