### PR TITLE
Remove duplicate php-fpm container

### DIFF
--- a/src/_base/_twig/docker-compose.yml/service/webapp.yml.twig
+++ b/src/_base/_twig/docker-compose.yml/service/webapp.yml.twig
@@ -1,3 +1,2 @@
 {% set blocks  = '_twig/docker-compose.yml/' %}
 {% include blocks ~ 'service/nginx.yml.twig' %}
-{% include blocks ~ 'service/php-fpm.yml.twig' %}


### PR DESCRIPTION
Fixes #761 

services.php-fpm.enabled is true for helm chart purposes since #609, so will be included as part of the main application.yml.twig loop over enabled services.

A few alternatives:
1. Set enabled to false in services for docker and true in helm for pipeline.base.services (potential breaking change?)
2. Add an if statement in the application.yml.twig to skip over php-fpm.