### PR TITLE
Upgrade to NGINX 1.23

### DIFF
--- a/src/_base/docker/image/nginx/Dockerfile.twig
+++ b/src/_base/docker/image/nginx/Dockerfile.twig
@@ -2,7 +2,7 @@
 FROM {{ @('docker.repository') ~ ':' ~ @('app.version') }}-console as console
 {% endif %}
 
-FROM nginx:1.21-alpine
+FROM nginx:1.23-alpine
 COPY root /
 
 {% if @('app.build') == 'static' %}

--- a/src/_base/docker/image/relay/Dockerfile
+++ b/src/_base/docker/image/relay/Dockerfile
@@ -1,2 +1,2 @@
-FROM nginx:1.21-alpine
+FROM nginx:1.23-alpine
 COPY root /

--- a/src/_base/docker/image/tls-offload/Dockerfile
+++ b/src/_base/docker/image/tls-offload/Dockerfile
@@ -1,2 +1,2 @@
-FROM nginx:1.21-alpine
+FROM nginx:1.23-alpine
 COPY root /


### PR DESCRIPTION
https://hub.docker.com/_/nginx no longer lists 1.21 as a supported tag.