### PR TITLE
Jenkins Slack Notifications

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -409,7 +409,7 @@ pipeline {
                 if (env.CHANGE_URL) {
                     // Jenkins builds pull requests by merging the pull request branch into the pull request's target branch,
                     // so we build on commits that do not technically exist and can't link to them.
-                    gitMessage = "<${env.CHANGE_URL}|Pull Request #${env.CHANGE_ID}> merged into target branch ${CHANGE_TARGET}"
+                    gitMessage = "<${env.CHANGE_URL}|Pull Request #${env.CHANGE_ID}> merged into target branch https://github.com/inviqa/harness-base-php/tree/${CHANGE_TARGET}|${CHANGE_TARGET}>"
                 }
                 fields << [
                     title: 'Source',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -409,7 +409,7 @@ pipeline {
                 if (env.CHANGE_URL) {
                     // Jenkins builds pull requests by merging the pull request branch into the pull request's target branch,
                     // so we build on commits that do not technically exist and can't link to them.
-                    gitMessage = "<${env.CHANGE_URL}|Pull Request #${env.CHANGE_ID}> merged into target branch <https://github.com/inviqa/harness-base-php/tree/${CHANGE_TARGET}|${CHANGE_TARGET}>"
+                    gitMessage = "<${env.CHANGE_URL}|Pull Request #${env.CHANGE_ID}> ${env.CHANGE_TITLE} - merged into target branch <https://github.com/inviqa/harness-base-php/tree/${CHANGE_TARGET}|${CHANGE_TARGET}>"
                 }
                 fields << [
                     title: 'Source',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -371,15 +371,15 @@ pipeline {
                             stages {
                                 stage('Spryker Mutagen') {
                                     steps { sh './test spryker dynamic mutagen' }
-                                    post { failure { script { failureMessages << 'Spryker static acceptance' } } }
+                                    post { failure { script { failureMessages << 'Spryker mutagen acceptance' } } }
                                 }
                                 stage('Spryker Static') {
                                     steps { sh './test spryker static' }
-                                    post { failure { script { failureMessages << 'Spryker dynamic acceptance' } } }
+                                    post { failure { script { failureMessages << 'Spryker static acceptance' } } }
                                 }
                                 stage('Spryker Dynamic') {
                                     steps { sh './test spryker dynamic' }
-                                    post { failure { script { failureMessages << 'Spryker mutagen acceptance' } } }
+                                    post { failure { script { failureMessages << 'Spryker dynamic acceptance' } } }
                                 }
                             }
                         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -403,8 +403,8 @@ pipeline {
                 def fields = []
 
                 def shortCommitHash = "${GIT_COMMIT}".substring(0, 7)
-                def commitLink = "<https://github.com/inviqa/harness-base-php/commit/GIT_COMMIT".replace('GIT_COMMIT', GIT_COMMIT) + "|${shortCommitHash}>"
-                def gitMessage = "Branch <https://github.com/inviqa/harness-base-php/tree/GIT_BRANCH".replace('GIT_BRANCH', GIT_BRANCH) + "|${GIT_BRANCH}> @ ${commitLink}"
+                def commitLink = "<https://github.com/inviqa/harness-base-php/commit/${GIT_COMMIT}|${shortCommitHash}>"
+                def gitMessage = "Branch <https://github.com/inviqa/harness-base-php/tree/${GIT_BRANCH}|${GIT_BRANCH}> @ ${commitLink}"
 
                 if (env.CHANGE_URL) {
                     // Jenkins builds pull requests by merging the pull request branch into the pull request's target branch,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,7 @@ def isHarnessChange(harnesses) {
     def harnessLabels = harnesses.collect { "harness-${it}".toString() } << 'harness-all'
     return !env.CHANGE_ID || pullRequest.labels.size() == 0 || harnessLabels.any { pullRequest.labels.contains(it) }
 }
+def failureMessages = []
 
 pipeline {
     agent { label 'linux-amd64' }
@@ -9,6 +10,8 @@ pipeline {
         COMPOSE_DOCKER_CLI_BUILD = 1
         DOCKER_BUILDKIT = 1
         MY127WS_KEY = credentials('base-my127ws-key-20190523')
+        SLACK_NOTIFICATION_CHANNEL = credentials('slack-notification-channel')
+        SLACK_TOKEN_CREDENTIAL_ID = credentials('slack-token-credential-id')
     }
     options {
         buildDiscarder(logRotator(daysToKeepStr: '30'))
@@ -22,6 +25,7 @@ pipeline {
                 sh './quality'
                 milestone(10)
             }
+            post { failure { script { failureMessages << 'Global quality checks' } } }
         }
         stage('Build and Test') {
             parallel {
@@ -45,6 +49,7 @@ pipeline {
                                 sh './delete_running_containers.sh'
                                 sh './build'
                             }
+                            post { failure { script { failureMessages << 'PHP, Drupal, Akeneo, Wordpress prepare' } } }
                         }
                         stage('Quality Tests') {
                             environment {
@@ -77,6 +82,7 @@ pipeline {
                                 sh './test akeneo4 dynamic mutagen'
                                 sh './test wordpress dynamic mutagen'
                             }
+                            post { failure { script { failureMessages << 'PHP, Drupal, Akeneo, Wordpress quality checks' } } }
                         }
                         stage('Acceptance Tests') {
                             environment {
@@ -87,100 +93,124 @@ pipeline {
                                 stage('PHP') {
                                     when { expression { return isHarnessChange(['base']) } }
                                     steps { sh './test php static' }
+                                    post { failure { script { failureMessages << 'PHP static acceptance' } } }
                                 }
                                 stage('Drupal 10') {
                                     when { expression { return isHarnessChange(['drupal']) } }
                                     steps { sh './test drupal10 static' }
+                                    post { failure { script { failureMessages << 'Drupal 10 static acceptance' } } }
                                 }
                                 stage('Drupal 9') {
                                     when { expression { return isHarnessChange(['drupal']) } }
                                     steps { sh './test drupal9 static' }
+                                    post { failure { script { failureMessages << 'Drupal 9 static acceptance' } } }
                                 }
                                 stage('Drupal 8') {
                                     when { expression { return isHarnessChange(['drupal']) } }
                                     steps { sh './test drupal8 static' }
+                                    post { failure { script { failureMessages << 'Drupal 8 static acceptance' } } }
                                 }
                                 stage('Akeneo 6') {
                                     when { expression { return isHarnessChange(['akeneo']) } }
                                     steps { sh './test akeneo6 static' }
+                                    post { failure { script { failureMessages << 'Akeneo 6 static acceptance' } } }
                                 }
                                 stage('Akeneo 5') {
                                     when { expression { return isHarnessChange(['akeneo']) } }
                                     steps { sh './test akeneo5 static' }
+                                    post { failure { script { failureMessages << 'Akeneo 5 static acceptance' } } }
                                 }
                                 stage('Akeneo 4') {
                                     when { expression { return isHarnessChange(['akeneo']) } }
                                     steps { sh './test akeneo4 static' }
+                                    post { failure { script { failureMessages << 'Akeneo 4 static acceptance' } } }
                                 }
                                 stage('Wordpress') {
                                     when { expression { return isHarnessChange(['wordpress']) } }
                                     steps { sh './test wordpress static' }
+                                    post { failure { script { failureMessages << 'Wordpress static acceptance' } } }
                                 }
 
                                 stage('PHP Dynamic') {
                                     when { expression { return isHarnessChange(['base']) } }
                                     steps { sh './test php dynamic' }
+                                    post { failure { script { failureMessages << 'PHP dynamic acceptance' } } }
                                 }
                                 stage('Drupal 10 Dynamic') {
                                     when { expression { return isHarnessChange(['drupal']) } }
                                     steps { sh './test drupal10 dynamic' }
+                                    post { failure { script { failureMessages << 'Drupal 10 dynamic acceptance' } } }
                                 }
                                 stage('Drupal 9 Dynamic') {
                                     when { expression { return isHarnessChange(['drupal']) } }
                                     steps { sh './test drupal9 dynamic' }
+                                    post { failure { script { failureMessages << 'Drupal 9 dynamic acceptance' } } }
                                 }
                                 stage('Drupal 8 Dynamic') {
                                     when { expression { return isHarnessChange(['drupal']) } }
                                     steps { sh './test drupal8 dynamic' }
+                                    post { failure { script { failureMessages << 'Drupal 8 dynamic acceptance' } } }
                                 }
                                 stage('Akeneo 6 Dynamic') {
                                     when { expression { return isHarnessChange(['akeneo']) } }
                                     steps { sh './test akeneo6 dynamic' }
+                                    post { failure { script { failureMessages << 'Akeneo 6 dynamic acceptance' } } }
                                 }
                                 stage('Akeneo 5 Dynamic') {
                                     when { expression { return isHarnessChange(['akeneo']) } }
                                     steps { sh './test akeneo5 dynamic' }
+                                    post { failure { script { failureMessages << 'Akeneo 5 dynamic acceptance' } } }
                                 }
                                 stage('Akeneo 4 Dynamic') {
                                     when { expression { return isHarnessChange(['akeneo']) } }
                                     steps { sh './test akeneo4 dynamic' }
+                                    post { failure { script { failureMessages << 'Akeneo 4 dynamic acceptance' } } }
                                 }
                                 stage('Wordpress Dynamic') {
                                     when { expression { return isHarnessChange(['wordpress']) } }
                                     steps { sh './test wordpress dynamic' }
+                                    post { failure { script { failureMessages << 'Wordpress dynamic acceptance' } } }
                                 }
 
                                 stage('PHP Mutagen') {
                                     when { expression { return isHarnessChange(['base']) } }
                                     steps { sh './test php dynamic mutagen' }
+                                    post { failure { script { failureMessages << 'PHP mutagen acceptance' } } }
                                 }
                                 stage('Drupal 10 Mutagen') {
                                     when { expression { return isHarnessChange(['drupal']) } }
                                     steps { sh './test drupal10 dynamic mutagen' }
+                                    post { failure { script { failureMessages << 'Drupal 10 mutagen acceptance' } } }
                                 }
                                 stage('Drupal 9 Mutagen') {
                                     when { expression { return isHarnessChange(['drupal']) } }
                                     steps { sh './test drupal9 dynamic mutagen' }
+                                    post { failure { script { failureMessages << 'Drupal 9 mutagen acceptance' } } }
                                 }
                                 stage('Drupal 8 Mutagen') {
                                     when { expression { return isHarnessChange(['drupal']) } }
                                     steps { sh './test drupal8 dynamic mutagen' }
+                                    post { failure { script { failureMessages << 'Drupal 8 mutagen acceptance' } } }
                                 }
                                 stage('Akeneo 6 Mutagen') {
                                     when { expression { return isHarnessChange(['akeneo']) } }
                                     steps { sh './test akeneo6 dynamic mutagen' }
+                                    post { failure { script { failureMessages << 'Akeneo 6 mutagen acceptance' } } }
                                 }
                                 stage('Akeneo 5 Mutagen') {
                                     when { expression { return isHarnessChange(['akeneo']) } }
                                     steps { sh './test akeneo5 dynamic mutagen' }
+                                    post { failure { script { failureMessages << 'Akeneo 5 mutagen acceptance' } } }
                                 }
                                 stage('Akeneo 4 Dynamic Mutagen') {
                                     when { expression { return isHarnessChange(['akeneo']) } }
                                     steps { sh './test akeneo4 dynamic mutagen' }
+                                    post { failure { script { failureMessages << 'Akeneo 4 mutagen acceptance' } } }
                                 }
                                 stage('Wordpress Mutagen') {
                                     when { expression { return isHarnessChange(['wordpress']) } }
                                     steps { sh './test wordpress dynamic mutagen' }
+                                    post { failure { script { failureMessages << 'Wordpress mutagen acceptance' } } }
                                 }
                             }
                         }
@@ -213,6 +243,7 @@ pipeline {
                                 sh './delete_running_containers.sh'
                                 sh './build'
                             }
+                            post { failure { script { failureMessages << 'Symfony, Magento 2, Magento 1 prepare' } } }
                         }
                         stage('Quality Tests') {
                             environment {
@@ -232,6 +263,7 @@ pipeline {
                                 sh './test magento2 dynamic mutagen'
                                 sh './test magento1 dynamic mutagen'
                             }
+                            post { failure { script { failureMessages << 'Symfony, Magento 2, Magento 1 quality checks' } } }
                         }
                         stage('Acceptance Tests') {
                             environment {
@@ -242,40 +274,49 @@ pipeline {
                                 stage('Symfony') {
                                     when { expression { return isHarnessChange(['symfony']) } }
                                     steps { sh './test symfony static' }
+                                    post { failure { script { failureMessages << 'Symfony static acceptance' } } }
                                 }
                                 stage('Magento 2') {
                                     when { expression { return isHarnessChange(['magento2']) } }
                                     steps { sh './test magento2 static' }
+                                    post { failure { script { failureMessages << 'Magento 2 static acceptance' } } }
                                 }
                                 stage('Magento 1') {
                                     when { expression { return isHarnessChange(['magento1']) } }
                                     steps { sh './test magento1 static' }
+                                    post { failure { script { failureMessages << 'Magento 1 static acceptance' } } }
                                 }
 
                                 stage('Symfony Dynamic') {
                                     when { expression { return isHarnessChange(['symfony']) } }
                                     steps { sh './test symfony dynamic' }
+                                    post { failure { script { failureMessages << 'Symfony dynamic acceptance' } } }
                                 }
                                 stage('Magento 2 Dynamic') {
                                     when { expression { return isHarnessChange(['magento2']) } }
                                     steps { sh './test magento2 dynamic' }
+                                    post { failure { script { failureMessages << 'Magento 2 dynamic acceptance' } } }
                                 }
                                 stage('Magento 1 Dynamic') {
                                     when { expression { return isHarnessChange(['magento1']) } }
                                     steps { sh './test magento1 dynamic' }
+                                    post { failure { script { failureMessages << 'Magento 1 dynamic acceptance' } } }
                                 }
 
                                 stage('Symfony Mutagen') {
                                     when { expression { return isHarnessChange(['symfony']) } }
                                     steps { sh './test symfony dynamic mutagen' }
+                                    post { failure { script { failureMessages << 'Symfony mutagen acceptance' } } }
                                 }
                                 stage('Magento 2 Mutagen') {
                                     when { expression { return isHarnessChange(['magento2']) } }
                                     steps { sh './test magento2 dynamic mutagen' }
+                                    post { failure { script { failureMessages << 'Magento 2 mutagen acceptance' } } }
                                 }
                                 stage('Magento 1 Mutagen') {
                                     when { expression { return isHarnessChange(['magento1']) } }
                                     steps { sh './test magento1 dynamic mutagen' }
+                                    post { failure { script { failureMessages << 'Magento 1 mutagen acceptance' } } }
                                 }
                             }
                         }
@@ -308,6 +349,7 @@ pipeline {
                             steps {
                                 sh './delete_running_containers.sh'
                             }
+                            post { failure { script { failureMessages << 'Spryker prepare' } } }
                         }
                         stage('Quality Tests') {
                             environment {
@@ -319,6 +361,7 @@ pipeline {
                                 sh './test spryker static'
                                 sh './test spryker dynamic'
                             }
+                            post { failure { script { failureMessages << 'Spryker quality checks' } } }
                         }
                         stage('Acceptance Tests') {
                             environment {
@@ -328,12 +371,15 @@ pipeline {
                             stages {
                                 stage('Spryker Mutagen') {
                                     steps { sh './test spryker dynamic mutagen' }
+                                    post { failure { script { failureMessages << 'Spryker static acceptance' } } }
                                 }
                                 stage('Spryker Static') {
                                     steps { sh './test spryker static' }
+                                    post { failure { script { failureMessages << 'Spryker dynamic acceptance' } } }
                                 }
                                 stage('Spryker Dynamic') {
                                     steps { sh './test spryker dynamic' }
+                                    post { failure { script { failureMessages << 'Spryker mutagen acceptance' } } }
                                 }
                             }
                         }
@@ -350,6 +396,32 @@ pipeline {
         }
     }
     post {
+        failure {
+            script {
+                def message = "${env.JOB_BASE_NAME} #${env.BUILD_NUMBER} - Failure after ${currentBuild.durationString.minus(' and counting')} (<${env.RUN_DISPLAY_URL}|View Build>)"
+                def fields = []
+                def failureMessage = failureMessages.join("\n")
+                if (failureMessage) {
+                    fields = [
+                        [
+                            title: 'Reason(s)',
+                            value: failureMessage,
+                            short: false
+                        ]
+                    ]
+                }
+                def attachments = [
+                    [
+                        text: message,
+                        fallback: "${message}\n${failureMessage}",
+                        color: 'danger',
+                        fields: fields
+                    ]
+                ]
+
+                slackSend (channel: env.SLACK_NOTIFICATION_CHANNEL, color: 'danger', attachments: attachments, tokenCredentialId: env.SLACK_TOKEN_CREDENTIAL_ID)
+            }
+        }
         always {
             sh './delete_running_containers.sh'
             cleanWs()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -412,8 +412,8 @@ pipeline {
                     gitMessage = "<${env.CHANGE_URL}|Pull Request #${env.CHANGE_ID}> merged into target branch ${CHANGE_TARGET}"
                 }
                 fields << [
-                    title: 'Source'
-                    value: gitMessage
+                    title: 'Source',
+                    value: gitMessage,
                     short: false
                 ]
                 fallbackMessages << gitMessage

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -409,7 +409,7 @@ pipeline {
                 if (env.CHANGE_URL) {
                     // Jenkins builds pull requests by merging the pull request branch into the pull request's target branch,
                     // so we build on commits that do not technically exist and can't link to them.
-                    gitMessage = "<${env.CHANGE_URL}|Pull Request #${env.CHANGE_ID}> merged into target branch https://github.com/inviqa/harness-base-php/tree/${CHANGE_TARGET}|${CHANGE_TARGET}>"
+                    gitMessage = "<${env.CHANGE_URL}|Pull Request #${env.CHANGE_ID}> merged into target branch <https://github.com/inviqa/harness-base-php/tree/${CHANGE_TARGET}|${CHANGE_TARGET}>"
                 }
                 fields << [
                     title: 'Source',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -398,7 +398,7 @@ pipeline {
     post {
         failure {
             script {
-                def message = "${env.JOB_BASE_NAME} #${env.BUILD_NUMBER} - Failure after ${currentBuild.durationString.minus(' and counting')} (<${env.RUN_DISPLAY_URL}|View Build>)"
+                def message = "${env.JOB_NAME} #${env.BUILD_NUMBER} - Failure after ${currentBuild.durationString.minus(' and counting')} (<${env.RUN_DISPLAY_URL}|View Build>)"
                 def fallbackMessages = [ message ]
                 def fields = []
 

--- a/src/_base/application/overlay/Jenkinsfile.twig
+++ b/src/_base/application/overlay/Jenkinsfile.twig
@@ -182,7 +182,7 @@ pipeline {
                 if (env.CHANGE_URL) {
                     // Jenkins builds pull requests by merging the pull request branch into the pull request's target branch,
                     // so we build on commits that do not technically exist and can't link to them.
-                    gitMessage = "<${env.CHANGE_URL}|{{ @('jenkins.notifications.global.change_request_name') }} #${env.CHANGE_ID}>{% if bool(@('jenkins.notifications.global.change_request_build_on_merge')) %} merged into target branch " + "<{{ @('jenkins.notifications.global.branch_link_template') }}".replace('GIT_BRANCH', CHANGE_TARGET) + "|${CHANGE_TARGET}>{% endif %}"
+                    gitMessage = "<${env.CHANGE_URL}|{{ @('jenkins.notifications.global.change_request_name') }} #${env.CHANGE_ID}> ${env.CHANGE_TITLE}{% if bool(@('jenkins.notifications.global.change_request_build_on_merge')) %} - merged into target branch " + "<{{ @('jenkins.notifications.global.branch_link_template') }}".replace('GIT_BRANCH', CHANGE_TARGET) + "|${CHANGE_TARGET}>{% endif %}"
                 }
                 fields << [
                     title: 'Source',

--- a/src/_base/application/overlay/Jenkinsfile.twig
+++ b/src/_base/application/overlay/Jenkinsfile.twig
@@ -1,3 +1,4 @@
+def failureMessages = []
 pipeline {
     agent { label 'linux-amd64' }
     environment {
@@ -16,6 +17,7 @@ pipeline {
                 sh 'ws enable console'
                 milestone(10)
             }
+            post { failure { script { failureMessages << 'Development environment console' } } }
         }
 {% else %}
         stage('Build') {
@@ -23,6 +25,7 @@ pipeline {
                 sh 'ws install'
                 milestone(10)
             }
+            post { failure { script { failureMessages << 'Development environment install' } } }
         }
 {% endif %}
         stage('Checks without development dependencies') {
@@ -31,18 +34,34 @@ pipeline {
                 sh 'ws exec app composer:development_dependencies'
                 milestone(20)
             }
+            post { failure { script { failureMessages << 'Checks without development dependencies' } } }
         }
         stage('Test')  {
             parallel {
-                stage('quality')    { steps { sh 'ws exec composer test-quality'    } }
-                stage('unit')       { steps { sh 'ws exec composer test-unit'       } }
+                stage('quality') {
+                    steps { sh 'ws exec composer test-quality' }
+                    post { failure { script { failureMessages << 'Quality checks' } } }
+                }
+                stage('unit') {
+                    steps { sh 'ws exec composer test-unit' }
+                    post { failure { script { failureMessages << 'Unit tests' } } }
+                }
 {% if not @('jenkins.tests.isolated') %}
-                stage('acceptance') { steps { sh 'ws exec composer test-acceptance' } }
+                stage('acceptance') {
+                    steps { sh 'ws exec composer test-acceptance' }
+                    post { failure { script { failureMessages << 'Acceptance tests' } } }
+                }
 {% if @('services.lighthouse.enabled') %}
-                stage('lighthouse') { steps { sh 'ws lighthouse' } }
+                stage('lighthouse') {
+                    steps { sh 'ws lighthouse' }
+                    post { failure { script { failureMessages << 'Lighthouse tests' } } }
+                }
 {% endif %}
 {% endif %}
-                stage('helm kubeval qa')  { steps { sh 'ws helm kubeval --cleanup qa' } }
+                stage('helm kubeval qa')  {
+                    steps { sh 'ws helm kubeval --cleanup qa' }
+                    post { failure { script { failureMessages << 'Helm chart rendering' } } }
+                }
             }
         }
 {% if @('jenkins.tests.isolated') %}
@@ -55,12 +74,19 @@ pipeline {
 {% endif %}
                 milestone(30)
             }
+            post { failure { script { failureMessages << 'Development environment full install' } } }
         }
         stage('End-to-end Test') {
             parallel {
-                stage('acceptance') { steps { sh 'ws exec composer test-acceptance' } }
+                stage('acceptance') {
+                    steps { sh 'ws exec composer test-acceptance' }
+                    post { failure { script { failureMessages << 'Acceptance tests' } } }
+                }
 {% if @('services.lighthouse.enabled') %}
-                stage('lighthouse') { steps { sh 'ws lighthouse' } }
+                stage('lighthouse') {
+                    steps { sh 'ws lighthouse' }
+                    post { failure { script { failureMessages << 'Lighthouse tests' } } }
+                }
 {% endif %}
             }
         }
@@ -113,6 +139,7 @@ pipeline {
                 }
 {% endif %}
             }
+            post { failure { script { failureMessages << 'Publish' } } }
         }
 {% endif %}
 {% if bool(@('pipeline.qa.enabled')) %}
@@ -135,10 +162,39 @@ pipeline {
                     sh 'ws app deploy qa'
                 }
             }
+            post { failure { script { failureMessages << 'Deploy QA' } } }
         }
 {% endif %}
     }
     post {
+{% if @('jenkins.notification.slack.channel') && @('jenkins.notification.slack.tokenCredentialId') %}
+        failure {
+            script {
+                def message = "${env.JOB_BASE_NAME} #${env.BUILD_NUMBER} - Failure after ${currentBuild.durationString.minus(' and counting')} (<${env.RUN_DISPLAY_URL}|View Build>)"
+                def fields = []
+                def slackFailureMessage = failureMessages.join("\n")
+                if (slackFailureMessage) {
+                    fields = [
+                        [
+                            title: 'Reason(s)',
+                            value: slackFailureMessage,
+                            short: false
+                        ]
+                    ]
+                }
+                def attachments = [
+                    [
+                        text: message,
+                        fallback: "${message}\n${slackFailureMessage}",
+                        color: 'danger',
+                        fields: fields
+                    ]
+                ]
+
+                slackSend (channel: '{{ @('jenkins.notification.slack.channel') }}', color: 'danger', attachments: attachments, tokenCredentialId: '{{ @('jenkins.notification.slack.tokenCredentialId') }}')
+            }
+        }
+{% endif %}
         always {
             sh 'ws destroy'
             cleanWs()

--- a/src/_base/application/overlay/Jenkinsfile.twig
+++ b/src/_base/application/overlay/Jenkinsfile.twig
@@ -167,22 +167,22 @@ pipeline {
 {% endif %}
     }
     post {
-{% if @('jenkins.notifications.slack.channel') and @('jenkins.notifications.slack.tokenCredentialId') %}
+{% if @('jenkins.notifications.slack.channel') and @('jenkins.notifications.slack.token_credential_id') %}
         failure {
             script {
-                def message = "{% if bool(@('jenkins.notifications.slack.fullBuildName')) %}${env.JOB_NAME}{% else %}${env.JOB_BASE_NAME}{% endif %} #${env.BUILD_NUMBER} - Failure after ${currentBuild.durationString.minus(' and counting')} (<${env.RUN_DISPLAY_URL}|View Build>)"
+                def message = "{% if bool(@('jenkins.notifications.global.full_build_name')) %}${env.JOB_NAME}{% else %}${env.JOB_BASE_NAME}{% endif %} #${env.BUILD_NUMBER} - Failure after ${currentBuild.durationString.minus(' and counting')} (<${env.RUN_DISPLAY_URL}|View Build>)"
                 def fallbackMessages = [ message ]
                 def fields = []
 
-{% if @('jenkins.notifications.slack.branchLinkTemplate') and @('jenkins.notifications.slack.commitLinkTemplate') %}
+{% if @('jenkins.notifications.global.branch_link_template') and @('jenkins.notifications.global.commit_link_template') %}
                 def shortCommitHash = "${GIT_COMMIT}".substring(0, 7)
-                def commitLink = "commit <{{ @('jenkins.notifications.slack.commitLinkTemplate') }}".replace('GIT_COMMIT', GIT_COMMIT) + "|${shortCommitHash}>"
-                def gitMessage = "Branch <{{ @('jenkins.notifications.slack.branchLinkTemplate') }}".replace('GIT_BRANCH', GIT_BRANCH) + "|${GIT_BRANCH}> at ${commitLink}"
+                def commitLink = "commit <{{ @('jenkins.notifications.global.commit_link_template') }}".replace('GIT_COMMIT', GIT_COMMIT) + "|${shortCommitHash}>"
+                def gitMessage = "Branch <{{ @('jenkins.notifications.global.branch_link_template') }}".replace('GIT_BRANCH', GIT_BRANCH) + "|${GIT_BRANCH}> at ${commitLink}"
 
                 if (env.CHANGE_URL) {
                     // Jenkins builds pull requests by merging the pull request branch into the pull request's target branch,
                     // so we build on commits that do not technically exist and can't link to them.
-                    gitMessage = "<${env.CHANGE_URL}|{{ @('jenkins.notifications.slack.changeRequestName') }} #${env.CHANGE_ID}> merged into target branch " + "<{{ @('jenkins.notifications.slack.branchLinkTemplate') }}".replace('GIT_BRANCH', CHANGE_TARGET) + "|${CHANGE_TARGET}>"
+                    gitMessage = "<${env.CHANGE_URL}|{{ @('jenkins.notifications.global.change_request_name') }} #${env.CHANGE_ID}> merged into target branch " + "<{{ @('jenkins.notifications.global.branch_link_template') }}".replace('GIT_BRANCH', CHANGE_TARGET) + "|${CHANGE_TARGET}>"
                 }
                 fields << [
                     title: 'Source',
@@ -210,7 +210,7 @@ pipeline {
                     ]
                 ]
 
-                slackSend (channel: '{{ @('jenkins.notifications.slack.channel') }}', color: 'danger', attachments: attachments, tokenCredentialId: '{{ @('jenkins.notifications.slack.tokenCredentialId') }}')
+                slackSend (channel: '{{ @('jenkins.notifications.slack.channel') }}', color: 'danger', attachments: attachments, tokenCredentialId: '{{ @('jenkins.notifications.slack.token_credential_id') }}')
             }
         }
 {% endif %}

--- a/src/_base/application/overlay/Jenkinsfile.twig
+++ b/src/_base/application/overlay/Jenkinsfile.twig
@@ -185,8 +185,8 @@ pipeline {
                     gitMessage = "<${env.CHANGE_URL}|{{ @('jenkins.notifications.slack.changeRequestName') }} #${env.CHANGE_ID}> merged into target branch ${CHANGE_TARGET}"
                 }
                 fields << [
-                    title: 'Source'
-                    value: gitMessage
+                    title: 'Source',
+                    value: gitMessage,
                     short: false
                 ]
                 fallbackMessages << gitMessage

--- a/src/_base/application/overlay/Jenkinsfile.twig
+++ b/src/_base/application/overlay/Jenkinsfile.twig
@@ -182,7 +182,7 @@ pipeline {
                 if (env.CHANGE_URL) {
                     // Jenkins builds pull requests by merging the pull request branch into the pull request's target branch,
                     // so we build on commits that do not technically exist and can't link to them.
-                    gitMessage = "<${env.CHANGE_URL}|{{ @('jenkins.notifications.slack.changeRequestName') }} #${env.CHANGE_ID}> merged into target branch ${CHANGE_TARGET}"
+                    gitMessage = "<${env.CHANGE_URL}|{{ @('jenkins.notifications.slack.changeRequestName') }} #${env.CHANGE_ID}> merged into target branch " + "<{{ @('jenkins.notifications.slack.branchLinkTemplate') }}".replace('GIT_BRANCH', CHANGE_TARGET) + "|${CHANGE_TARGET}>"
                 }
                 fields << [
                     title: 'Source',

--- a/src/_base/application/overlay/Jenkinsfile.twig
+++ b/src/_base/application/overlay/Jenkinsfile.twig
@@ -182,7 +182,7 @@ pipeline {
                 if (env.CHANGE_URL) {
                     // Jenkins builds pull requests by merging the pull request branch into the pull request's target branch,
                     // so we build on commits that do not technically exist and can't link to them.
-                    gitMessage = "<${env.CHANGE_URL}|{{ @('jenkins.notifications.global.change_request_name') }} #${env.CHANGE_ID}> merged into target branch " + "<{{ @('jenkins.notifications.global.branch_link_template') }}".replace('GIT_BRANCH', CHANGE_TARGET) + "|${CHANGE_TARGET}>"
+                    gitMessage = "<${env.CHANGE_URL}|{{ @('jenkins.notifications.global.change_request_name') }} #${env.CHANGE_ID}>{% if bool(@('jenkins.notifications.global.change_request_build_on_merge')) %} merged into target branch " + "<{{ @('jenkins.notifications.global.branch_link_template') }}".replace('GIT_BRANCH', CHANGE_TARGET) + "|${CHANGE_TARGET}>{% endif %}"
                 }
                 fields << [
                     title: 'Source',

--- a/src/_base/application/overlay/Jenkinsfile.twig
+++ b/src/_base/application/overlay/Jenkinsfile.twig
@@ -170,7 +170,7 @@ pipeline {
 {% if @('jenkins.notifications.slack.channel') and @('jenkins.notifications.slack.tokenCredentialId') %}
         failure {
             script {
-                def message = "${env.JOB_BASE_NAME} #${env.BUILD_NUMBER} - Failure after ${currentBuild.durationString.minus(' and counting')} (<${env.RUN_DISPLAY_URL}|View Build>)"
+                def message = "{% if bool(@('jenkins.notifications.slack.fullBuildName')) %}${env.JOB_NAME}{% else %}${env.JOB_BASE_NAME}{% endif %} #${env.BUILD_NUMBER} - Failure after ${currentBuild.durationString.minus(' and counting')} (<${env.RUN_DISPLAY_URL}|View Build>)"
                 def fallbackMessages = [ message ]
                 def fields = []
 

--- a/src/_base/application/overlay/Jenkinsfile.twig
+++ b/src/_base/application/overlay/Jenkinsfile.twig
@@ -167,7 +167,7 @@ pipeline {
 {% endif %}
     }
     post {
-{% if @('jenkins.notifications.slack.channel') && @('jenkins.notifications.slack.tokenCredentialId') %}
+{% if @('jenkins.notifications.slack.channel') and @('jenkins.notifications.slack.tokenCredentialId') %}
         failure {
             script {
                 def message = "${env.JOB_BASE_NAME} #${env.BUILD_NUMBER} - Failure after ${currentBuild.durationString.minus(' and counting')} (<${env.RUN_DISPLAY_URL}|View Build>)"

--- a/src/_base/application/overlay/Jenkinsfile.twig
+++ b/src/_base/application/overlay/Jenkinsfile.twig
@@ -171,21 +171,40 @@ pipeline {
         failure {
             script {
                 def message = "${env.JOB_BASE_NAME} #${env.BUILD_NUMBER} - Failure after ${currentBuild.durationString.minus(' and counting')} (<${env.RUN_DISPLAY_URL}|View Build>)"
+                def fallbackMessages = [ message ]
                 def fields = []
+
+{% if @('jenkins.notifications.slack.branchLinkTemplate') and @('jenkins.notifications.slack.commitLinkTemplate') %}
+                def shortCommitHash = "${GIT_COMMIT}".substring(0, 7)
+                def commitLink = "commit <{{ @('jenkins.notifications.slack.commitLinkTemplate') }}".replace('GIT_COMMIT', GIT_COMMIT) + "|${shortCommitHash}>"
+                def gitMessage = "Branch <{{ @('jenkins.notifications.slack.branchLinkTemplate') }}".replace('GIT_BRANCH', GIT_BRANCH) + "|${GIT_BRANCH}> at ${commitLink}"
+
+                if (env.CHANGE_URL) {
+                    // Jenkins builds pull requests by merging the pull request branch into the pull request's target branch,
+                    // so we build on commits that do not technically exist and can't link to them.
+                    gitMessage = "<${env.CHANGE_URL}|{{ @('jenkins.notifications.slack.changeRequestName') }} #${env.CHANGE_ID}> merged into target branch ${CHANGE_TARGET}"
+                }
+                fields << [
+                    title: 'Source'
+                    value: gitMessage
+                    short: false
+                ]
+                fallbackMessages << gitMessage
+{% endif %}
+
                 def failureMessage = failureMessages.join("\n")
                 if (failureMessage) {
-                    fields = [
-                        [
-                            title: 'Reason(s)',
-                            value: failureMessage,
-                            short: false
-                        ]
+                    fields << [
+                        title: 'Reason(s)',
+                        value: failureMessage,
+                        short: false
                     ]
+                    fallbackMessages << failureMessage
                 }
                 def attachments = [
                     [
                         text: message,
-                        fallback: "${message}\n${failureMessage}",
+                        fallback: fallbackMessages.join("\n"),
                         color: 'danger',
                         fields: fields
                     ]

--- a/src/_base/application/overlay/Jenkinsfile.twig
+++ b/src/_base/application/overlay/Jenkinsfile.twig
@@ -172,12 +172,12 @@ pipeline {
             script {
                 def message = "${env.JOB_BASE_NAME} #${env.BUILD_NUMBER} - Failure after ${currentBuild.durationString.minus(' and counting')} (<${env.RUN_DISPLAY_URL}|View Build>)"
                 def fields = []
-                def slackFailureMessage = failureMessages.join("\n")
-                if (slackFailureMessage) {
+                def failureMessage = failureMessages.join("\n")
+                if (failureMessage) {
                     fields = [
                         [
                             title: 'Reason(s)',
-                            value: slackFailureMessage,
+                            value: failureMessage,
                             short: false
                         ]
                     ]
@@ -185,7 +185,7 @@ pipeline {
                 def attachments = [
                     [
                         text: message,
-                        fallback: "${message}\n${slackFailureMessage}",
+                        fallback: "${message}\n${failureMessage}",
                         color: 'danger',
                         fields: fields
                     ]

--- a/src/_base/application/overlay/Jenkinsfile.twig
+++ b/src/_base/application/overlay/Jenkinsfile.twig
@@ -167,7 +167,7 @@ pipeline {
 {% endif %}
     }
     post {
-{% if @('jenkins.notification.slack.channel') && @('jenkins.notification.slack.tokenCredentialId') %}
+{% if @('jenkins.notifications.slack.channel') && @('jenkins.notifications.slack.tokenCredentialId') %}
         failure {
             script {
                 def message = "${env.JOB_BASE_NAME} #${env.BUILD_NUMBER} - Failure after ${currentBuild.durationString.minus(' and counting')} (<${env.RUN_DISPLAY_URL}|View Build>)"
@@ -191,7 +191,7 @@ pipeline {
                     ]
                 ]
 
-                slackSend (channel: '{{ @('jenkins.notification.slack.channel') }}', color: 'danger', attachments: attachments, tokenCredentialId: '{{ @('jenkins.notification.slack.tokenCredentialId') }}')
+                slackSend (channel: '{{ @('jenkins.notifications.slack.channel') }}', color: 'danger', attachments: attachments, tokenCredentialId: '{{ @('jenkins.notifications.slack.tokenCredentialId') }}')
             }
         }
 {% endif %}

--- a/src/_base/harness/attributes/common.yml
+++ b/src/_base/harness/attributes/common.yml
@@ -29,14 +29,19 @@ attributes.default:
       buildkit:
         enabled: true
     notifications:
-      slack:
+      global:
         # 'GIT_BRANCH' is replaced with the git branch name, e.g. https://github.com/inviqa/harness-base-php/tree/GIT_BRANCH
-        branchLinkTemplate: ~
-        channel: ~
-        changeRequestName: 'Pull Request'
+        branch_link_template: ~
+        # What is a change request called in the web UI? e.g. Pull Request or Merge Request
+        change_request_name: 'Pull Request'
         # 'GIT_COMMIT' is replaced with the git commit hash, e.g. https://github.com/inviqa/harness-base-php/commit/GIT_COMMIT
-        commitLinkTemplate: ~
-        fullBuildName: false
+        commit_link_template: ~
+        # If multiple build configurations are reporting into the same method, set to true to show which build configuration it is, rather than just "PR-123"
+        full_build_name: false
+      slack:
+        # Which slack channel to post to
+        channel: ~
+        # ID of a jenkins credential that contains a secret to use with the Jenkins CI Slack app to talk to your slack instance
         tokenCredentialId: ~
     tests:
       isolated: true

--- a/src/_base/harness/attributes/common.yml
+++ b/src/_base/harness/attributes/common.yml
@@ -30,7 +30,12 @@ attributes.default:
         enabled: true
     notifications:
       slack:
+        # 'GIT_BRANCH' is replaced with the git branch name, e.g. https://github.com/inviqa/harness-base-php/tree/GIT_BRANCH
+        branchLinkTemplate: ~
         channel: ~
+        changeRequestName: 'Pull Request'
+        # 'GIT_COMMIT' is replaced with the git commit hash, e.g. https://github.com/inviqa/harness-base-php/commit/GIT_COMMIT
+        commitLinkTemplate: ~
         tokenCredentialId: ~
     tests:
       isolated: true

--- a/src/_base/harness/attributes/common.yml
+++ b/src/_base/harness/attributes/common.yml
@@ -36,6 +36,7 @@ attributes.default:
         changeRequestName: 'Pull Request'
         # 'GIT_COMMIT' is replaced with the git commit hash, e.g. https://github.com/inviqa/harness-base-php/commit/GIT_COMMIT
         commitLinkTemplate: ~
+        fullBuildName: false
         tokenCredentialId: ~
     tests:
       isolated: true

--- a/src/_base/harness/attributes/common.yml
+++ b/src/_base/harness/attributes/common.yml
@@ -28,6 +28,10 @@ attributes.default:
     docker:
       buildkit:
         enabled: true
+    notifications:
+      slack:
+        channel: ~
+        tokenCredentialId: ~
     tests:
       isolated: true
       use_global_services: false

--- a/src/_base/harness/attributes/common.yml
+++ b/src/_base/harness/attributes/common.yml
@@ -32,6 +32,8 @@ attributes.default:
       global:
         # 'GIT_BRANCH' is replaced with the git branch name, e.g. https://github.com/inviqa/harness-base-php/tree/GIT_BRANCH
         branch_link_template: ~
+        # Does the change request build upon a merge of the branch into the target branch?
+        change_request_build_on_merge: true
         # What is a change request called in the web UI? e.g. Pull Request or Merge Request
         change_request_name: 'Pull Request'
         # 'GIT_COMMIT' is replaced with the git commit hash, e.g. https://github.com/inviqa/harness-base-php/commit/GIT_COMMIT

--- a/src/drupal/application/overlay/Jenkinsfile.twig
+++ b/src/drupal/application/overlay/Jenkinsfile.twig
@@ -1,3 +1,4 @@
+def failureMessages = []
 pipeline {
     agent { label 'linux-amd64' }
     environment {
@@ -16,6 +17,7 @@ pipeline {
                 sh 'ws enable console'
                 milestone(10)
             }
+            post { failure { script { failureMessages << 'Development environment console' } } }
         }
 {% else %}
         stage('Build') {
@@ -23,6 +25,7 @@ pipeline {
                 sh 'ws install'
                 milestone(10)
             }
+            post { failure { script { failureMessages << 'Development environment install' } } }
         }
 {% endif %}
         stage('Checks without development dependencies') {
@@ -31,17 +34,30 @@ pipeline {
                 sh 'ws exec app composer:development_dependencies'
                 milestone(20)
             }
+            post { failure { script { failureMessages << 'Checks without development dependencies' } } }
         }
         stage('Test')  {
             parallel {
-                stage('quality')    { steps { sh 'ws exec composer test-quality'    } }
+                stage('quality') {
+                    steps { sh 'ws exec composer test-quality' }
+                    post { failure { script { failureMessages << 'Quality checks' } } }
+                }
 {% if not @('jenkins.tests.isolated') %}
-                stage('acceptance') { steps { sh 'ws exec composer test-acceptance' } }
+                stage('acceptance') {
+                    steps { sh 'ws exec composer test-acceptance' }
+                    post { failure { script { failureMessages << 'Acceptance tests' } } }
+                }
 {% if @('services.lighthouse.enabled') %}
-                stage('lighthouse') { steps { sh 'ws lighthouse' } }
+                stage('lighthouse') {
+                    steps { sh 'ws lighthouse' }
+                    post { failure { script { failureMessages << 'Lighthouse tests' } } }
+                }
 {% endif %}
 {% endif %}
-                stage('helm kubeval qa')  { steps { sh 'ws helm kubeval --cleanup qa' } }
+                stage('helm kubeval qa')  {
+                    steps { sh 'ws helm kubeval --cleanup qa' }
+                    post { failure { script { failureMessages << 'Helm chart rendering' } } }
+                }
             }
         }
 {% if @('jenkins.tests.isolated') %}
@@ -54,12 +70,19 @@ pipeline {
 {% endif %}
                 milestone(30)
             }
+            post { failure { script { failureMessages << 'Development environment full install' } } }
         }
         stage('End-to-end Test') {
             parallel {
-                stage('acceptance') { steps { sh 'ws exec composer test-acceptance' } }
+                stage('acceptance') {
+                    steps { sh 'ws exec composer test-acceptance' }
+                    post { failure { script { failureMessages << 'Acceptance tests' } } }
+                }
 {% if @('services.lighthouse.enabled') %}
-                stage('lighthouse') { steps { sh 'ws lighthouse' } }
+                stage('lighthouse') {
+                    steps { sh 'ws lighthouse' }
+                    post { failure { script { failureMessages << 'Lighthouse tests' } } }
+                }
 {% endif %}
             }
         }
@@ -68,14 +91,25 @@ pipeline {
             steps {
                 sh 'ws test-unit'
             }
+            post { failure { script { failureMessages << 'Unit tests' } } }
         }
 {% if @('pipeline.publish.enabled') == 'yes' %}
+{% if bool(@('pipeline.publish.enabled')) %}
         stage('Publish') {
-{% if @('pipeline.publish.environment') %}
+{% set env = @('pipeline.publish.environment') %}
+{% set docker_registry_credential_id = @('docker.registry.credential_id') %}
+{% set ssh_credential_id = @('pipeline.publish.chart.git.ssh_credential_id') %}
+{% if env or docker_registry_credential_id or ssh_credential_id %}
             environment {
-{% for key, value in @('pipeline.publish.environment') %}
+{% for key, value in env %}
                 {{ key }} = {{ value }}
 {% endfor %}
+{% if docker_registry_credential_id %}
+                DOCKER_REGISTRY_CREDS = credentials('{{ docker_registry_credential_id }}')
+{% endif %}
+{% if ssh_credential_id %}
+                WS_APP_PUBLISH_CHART_SSH_PRIVATE_KEY = credentials('{{ ssh_credential_id }}')
+{% endif %}
             }
 {% endif %}
             when {
@@ -84,11 +118,16 @@ pipeline {
 {% for branch in @('pipeline.publish.branches') %}
                     branch '{{ branch }}'
 {% endfor %}
-{% if @('pipeline.qa.enabled') == 'yes' %}
+{% if bool(@('pipeline.qa.enabled')) %}
                     branch '{{ @('pipeline.qa.branch') }}'
 {% endif %}
-{% if @('pipeline.preview.enabled') == 'yes' %}
-{% for branch in @('pipeline.preview.target_branches') %}
+{% if bool(@('pipeline.preview.enabled')) %}
+{% if @('pipeline.preview.pull_request_labels') %}
+                    expression {
+                        return env.CHANGE_ID && {{ @('pipeline.preview.pull_request_labels') | json_encode }}.any { pullRequest.labels.contains(it) }
+                    }
+{% endif %}
+{% for branch in @('pipeline.preview.target_branches') | default([]) %}
                     changeRequest target: '{{ branch }}'
 {% endfor %}
 {% endif %}
@@ -103,6 +142,7 @@ pipeline {
                 }
 {% endif %}
             }
+            post { failure { script { failureMessages << 'Publish' } } }
         }
 {% endif %}
 {% if bool(@('pipeline.qa.enabled')) %}
@@ -125,10 +165,39 @@ pipeline {
                     sh 'ws app deploy qa'
                 }
             }
+            post { failure { script { failureMessages << 'Deploy QA' } } }
         }
 {% endif %}
     }
     post {
+{% if @('jenkins.notification.slack.channel') && @('jenkins.notification.slack.tokenCredentialId') %}
+        failure {
+            script {
+                def message = "${env.JOB_BASE_NAME} #${env.BUILD_NUMBER} - Failure after ${currentBuild.durationString.minus(' and counting')} (<${env.RUN_DISPLAY_URL}|View Build>)"
+                def fields = []
+                def slackFailureMessage = failureMessages.join("\n")
+                if (slackFailureMessage) {
+                    fields = [
+                        [
+                            title: 'Reason(s)',
+                            value: slackFailureMessage,
+                            short: false
+                        ]
+                    ]
+                }
+                def attachments = [
+                    [
+                        text: message,
+                        fallback: "${message}\n${slackFailureMessage}",
+                        color: 'danger',
+                        fields: fields
+                    ]
+                ]
+
+                slackSend (channel: '{{ @('jenkins.notification.slack.channel') }}', color: 'danger', attachments: attachments, tokenCredentialId: '{{ @('jenkins.notification.slack.tokenCredentialId') }}')
+            }
+        }
+{% endif %}
         always {
             sh 'ws destroy'
             cleanWs()

--- a/src/drupal/application/overlay/Jenkinsfile.twig
+++ b/src/drupal/application/overlay/Jenkinsfile.twig
@@ -170,7 +170,7 @@ pipeline {
 {% endif %}
     }
     post {
-{% if @('jenkins.notification.slack.channel') && @('jenkins.notification.slack.tokenCredentialId') %}
+{% if @('jenkins.notification.slack.channel') and @('jenkins.notification.slack.tokenCredentialId') %}
         failure {
             script {
                 def message = "${env.JOB_BASE_NAME} #${env.BUILD_NUMBER} - Failure after ${currentBuild.durationString.minus(' and counting')} (<${env.RUN_DISPLAY_URL}|View Build>)"

--- a/src/drupal/application/overlay/Jenkinsfile.twig
+++ b/src/drupal/application/overlay/Jenkinsfile.twig
@@ -175,12 +175,12 @@ pipeline {
             script {
                 def message = "${env.JOB_BASE_NAME} #${env.BUILD_NUMBER} - Failure after ${currentBuild.durationString.minus(' and counting')} (<${env.RUN_DISPLAY_URL}|View Build>)"
                 def fields = []
-                def slackFailureMessage = failureMessages.join("\n")
-                if (slackFailureMessage) {
+                def failureMessage = failureMessages.join("\n")
+                if (failureMessage) {
                     fields = [
                         [
                             title: 'Reason(s)',
-                            value: slackFailureMessage,
+                            value: failureMessage,
                             short: false
                         ]
                     ]
@@ -188,7 +188,7 @@ pipeline {
                 def attachments = [
                     [
                         text: message,
-                        fallback: "${message}\n${slackFailureMessage}",
+                        fallback: "${message}\n${failureMessage}",
                         color: 'danger',
                         fields: fields
                     ]

--- a/src/drupal/application/overlay/Jenkinsfile.twig
+++ b/src/drupal/application/overlay/Jenkinsfile.twig
@@ -93,7 +93,6 @@ pipeline {
             }
             post { failure { script { failureMessages << 'Unit tests' } } }
         }
-{% if @('pipeline.publish.enabled') == 'yes' %}
 {% if bool(@('pipeline.publish.enabled')) %}
         stage('Publish') {
 {% set env = @('pipeline.publish.environment') %}
@@ -170,7 +169,7 @@ pipeline {
 {% endif %}
     }
     post {
-{% if @('jenkins.notification.slack.channel') and @('jenkins.notification.slack.tokenCredentialId') %}
+{% if @('jenkins.notifications.slack.channel') and @('jenkins.notifications.slack.tokenCredentialId') %}
         failure {
             script {
                 def message = "${env.JOB_BASE_NAME} #${env.BUILD_NUMBER} - Failure after ${currentBuild.durationString.minus(' and counting')} (<${env.RUN_DISPLAY_URL}|View Build>)"
@@ -194,7 +193,7 @@ pipeline {
                     ]
                 ]
 
-                slackSend (channel: '{{ @('jenkins.notification.slack.channel') }}', color: 'danger', attachments: attachments, tokenCredentialId: '{{ @('jenkins.notification.slack.tokenCredentialId') }}')
+                slackSend (channel: '{{ @('jenkins.notifications.slack.channel') }}', color: 'danger', attachments: attachments, tokenCredentialId: '{{ @('jenkins.notifications.slack.tokenCredentialId') }}')
             }
         }
 {% endif %}

--- a/src/drupal/application/overlay/Jenkinsfile.twig
+++ b/src/drupal/application/overlay/Jenkinsfile.twig
@@ -184,7 +184,7 @@ pipeline {
                 if (env.CHANGE_URL) {
                     // Jenkins builds pull requests by merging the pull request branch into the pull request's target branch,
                     // so we build on commits that do not technically exist and can't link to them.
-                    gitMessage = "<${env.CHANGE_URL}|{{ @('jenkins.notifications.slack.changeRequestName') }} #${env.CHANGE_ID}> merged into target branch ${CHANGE_TARGET}"
+                    gitMessage = "<${env.CHANGE_URL}|{{ @('jenkins.notifications.slack.changeRequestName') }} #${env.CHANGE_ID}> merged into target branch " + "<{{ @('jenkins.notifications.slack.branchLinkTemplate') }}".replace('GIT_BRANCH', CHANGE_TARGET) + "|${CHANGE_TARGET}>"
                 }
                 fields << [
                     title: 'Source',

--- a/src/drupal/application/overlay/Jenkinsfile.twig
+++ b/src/drupal/application/overlay/Jenkinsfile.twig
@@ -184,7 +184,7 @@ pipeline {
                 if (env.CHANGE_URL) {
                     // Jenkins builds pull requests by merging the pull request branch into the pull request's target branch,
                     // so we build on commits that do not technically exist and can't link to them.
-                    gitMessage = "<${env.CHANGE_URL}|{{ @('jenkins.notifications.global.change_request_name') }} #${env.CHANGE_ID}> merged into target branch " + "<{{ @('jenkins.notifications.global.branch_link_template') }}".replace('GIT_BRANCH', CHANGE_TARGET) + "|${CHANGE_TARGET}>"
+                    gitMessage = "<${env.CHANGE_URL}|{{ @('jenkins.notifications.global.change_request_name') }} #${env.CHANGE_ID}>{% if bool(@('jenkins.notifications.global.change_request_build_on_merge')) %} merged into target branch " + "<{{ @('jenkins.notifications.global.branch_link_template') }}".replace('GIT_BRANCH', CHANGE_TARGET) + "|${CHANGE_TARGET}>{% endif %}"
                 }
                 fields << [
                     title: 'Source',

--- a/src/drupal/application/overlay/Jenkinsfile.twig
+++ b/src/drupal/application/overlay/Jenkinsfile.twig
@@ -169,22 +169,22 @@ pipeline {
 {% endif %}
     }
     post {
-{% if @('jenkins.notifications.slack.channel') and @('jenkins.notifications.slack.tokenCredentialId') %}
+{% if @('jenkins.notifications.slack.channel') and @('jenkins.notifications.slack.token_credential_id') %}
         failure {
             script {
-                def message = "{% if bool(@('jenkins.notifications.slack.fullBuildName')) %}${env.JOB_NAME}{% else %}${env.JOB_BASE_NAME}{% endif %} #${env.BUILD_NUMBER} - Failure after ${currentBuild.durationString.minus(' and counting')} (<${env.RUN_DISPLAY_URL}|View Build>)"
+                def message = "{% if bool(@('jenkins.notifications.global.full_build_name')) %}${env.JOB_NAME}{% else %}${env.JOB_BASE_NAME}{% endif %} #${env.BUILD_NUMBER} - Failure after ${currentBuild.durationString.minus(' and counting')} (<${env.RUN_DISPLAY_URL}|View Build>)"
                 def fallbackMessages = [ message ]
                 def fields = []
 
-{% if @('jenkins.notifications.slack.branchLinkTemplate') and @('jenkins.notifications.slack.commitLinkTemplate') %}
+{% if @('jenkins.notifications.global.branch_link_template') and @('jenkins.notifications.global.commit_link_template') %}
                 def shortCommitHash = "${GIT_COMMIT}".substring(0, 7)
-                def commitLink = "commit <{{ @('jenkins.notifications.slack.commitLinkTemplate') }}".replace('GIT_COMMIT', GIT_COMMIT) + "|${shortCommitHash}>"
-                def gitMessage = "Branch <{{ @('jenkins.notifications.slack.branchLinkTemplate') }}".replace('GIT_BRANCH', GIT_BRANCH) + "|${GIT_BRANCH}> at ${commitLink}"
+                def commitLink = "commit <{{ @('jenkins.notifications.global.commit_link_template') }}".replace('GIT_COMMIT', GIT_COMMIT) + "|${shortCommitHash}>"
+                def gitMessage = "Branch <{{ @('jenkins.notifications.global.branch_link_template') }}".replace('GIT_BRANCH', GIT_BRANCH) + "|${GIT_BRANCH}> at ${commitLink}"
 
                 if (env.CHANGE_URL) {
                     // Jenkins builds pull requests by merging the pull request branch into the pull request's target branch,
                     // so we build on commits that do not technically exist and can't link to them.
-                    gitMessage = "<${env.CHANGE_URL}|{{ @('jenkins.notifications.slack.changeRequestName') }} #${env.CHANGE_ID}> merged into target branch " + "<{{ @('jenkins.notifications.slack.branchLinkTemplate') }}".replace('GIT_BRANCH', CHANGE_TARGET) + "|${CHANGE_TARGET}>"
+                    gitMessage = "<${env.CHANGE_URL}|{{ @('jenkins.notifications.global.change_request_name') }} #${env.CHANGE_ID}> merged into target branch " + "<{{ @('jenkins.notifications.global.branch_link_template') }}".replace('GIT_BRANCH', CHANGE_TARGET) + "|${CHANGE_TARGET}>"
                 }
                 fields << [
                     title: 'Source',
@@ -212,7 +212,7 @@ pipeline {
                     ]
                 ]
 
-                slackSend (channel: '{{ @('jenkins.notifications.slack.channel') }}', color: 'danger', attachments: attachments, tokenCredentialId: '{{ @('jenkins.notifications.slack.tokenCredentialId') }}')
+                slackSend (channel: '{{ @('jenkins.notifications.slack.channel') }}', color: 'danger', attachments: attachments, tokenCredentialId: '{{ @('jenkins.notifications.slack.token_credential_id') }}')
             }
         }
 {% endif %}

--- a/src/drupal/application/overlay/Jenkinsfile.twig
+++ b/src/drupal/application/overlay/Jenkinsfile.twig
@@ -187,8 +187,8 @@ pipeline {
                     gitMessage = "<${env.CHANGE_URL}|{{ @('jenkins.notifications.slack.changeRequestName') }} #${env.CHANGE_ID}> merged into target branch ${CHANGE_TARGET}"
                 }
                 fields << [
-                    title: 'Source'
-                    value: gitMessage
+                    title: 'Source',
+                    value: gitMessage,
                     short: false
                 ]
                 fallbackMessages << gitMessage

--- a/src/drupal/application/overlay/Jenkinsfile.twig
+++ b/src/drupal/application/overlay/Jenkinsfile.twig
@@ -172,7 +172,7 @@ pipeline {
 {% if @('jenkins.notifications.slack.channel') and @('jenkins.notifications.slack.tokenCredentialId') %}
         failure {
             script {
-                def message = "${env.JOB_BASE_NAME} #${env.BUILD_NUMBER} - Failure after ${currentBuild.durationString.minus(' and counting')} (<${env.RUN_DISPLAY_URL}|View Build>)"
+                def message = "{% if bool(@('jenkins.notifications.slack.fullBuildName')) %}${env.JOB_NAME}{% else %}${env.JOB_BASE_NAME}{% endif %} #${env.BUILD_NUMBER} - Failure after ${currentBuild.durationString.minus(' and counting')} (<${env.RUN_DISPLAY_URL}|View Build>)"
                 def fallbackMessages = [ message ]
                 def fields = []
 

--- a/src/drupal/application/overlay/Jenkinsfile.twig
+++ b/src/drupal/application/overlay/Jenkinsfile.twig
@@ -173,21 +173,40 @@ pipeline {
         failure {
             script {
                 def message = "${env.JOB_BASE_NAME} #${env.BUILD_NUMBER} - Failure after ${currentBuild.durationString.minus(' and counting')} (<${env.RUN_DISPLAY_URL}|View Build>)"
+                def fallbackMessages = [ message ]
                 def fields = []
+
+{% if @('jenkins.notifications.slack.branchLinkTemplate') and @('jenkins.notifications.slack.commitLinkTemplate') %}
+                def shortCommitHash = "${GIT_COMMIT}".substring(0, 7)
+                def commitLink = "commit <{{ @('jenkins.notifications.slack.commitLinkTemplate') }}".replace('GIT_COMMIT', GIT_COMMIT) + "|${shortCommitHash}>"
+                def gitMessage = "Branch <{{ @('jenkins.notifications.slack.branchLinkTemplate') }}".replace('GIT_BRANCH', GIT_BRANCH) + "|${GIT_BRANCH}> at ${commitLink}"
+
+                if (env.CHANGE_URL) {
+                    // Jenkins builds pull requests by merging the pull request branch into the pull request's target branch,
+                    // so we build on commits that do not technically exist and can't link to them.
+                    gitMessage = "<${env.CHANGE_URL}|{{ @('jenkins.notifications.slack.changeRequestName') }} #${env.CHANGE_ID}> merged into target branch ${CHANGE_TARGET}"
+                }
+                fields << [
+                    title: 'Source'
+                    value: gitMessage
+                    short: false
+                ]
+                fallbackMessages << gitMessage
+{% endif %}
+
                 def failureMessage = failureMessages.join("\n")
                 if (failureMessage) {
-                    fields = [
-                        [
-                            title: 'Reason(s)',
-                            value: failureMessage,
-                            short: false
-                        ]
+                    fields << [
+                        title: 'Reason(s)',
+                        value: failureMessage,
+                        short: false
                     ]
+                    fallbackMessages << failureMessage
                 }
                 def attachments = [
                     [
                         text: message,
-                        fallback: "${message}\n${failureMessage}",
+                        fallback: fallbackMessages.join("\n"),
                         color: 'danger',
                         fields: fields
                     ]

--- a/src/drupal/application/overlay/Jenkinsfile.twig
+++ b/src/drupal/application/overlay/Jenkinsfile.twig
@@ -184,7 +184,7 @@ pipeline {
                 if (env.CHANGE_URL) {
                     // Jenkins builds pull requests by merging the pull request branch into the pull request's target branch,
                     // so we build on commits that do not technically exist and can't link to them.
-                    gitMessage = "<${env.CHANGE_URL}|{{ @('jenkins.notifications.global.change_request_name') }} #${env.CHANGE_ID}>{% if bool(@('jenkins.notifications.global.change_request_build_on_merge')) %} merged into target branch " + "<{{ @('jenkins.notifications.global.branch_link_template') }}".replace('GIT_BRANCH', CHANGE_TARGET) + "|${CHANGE_TARGET}>{% endif %}"
+                    gitMessage = "<${env.CHANGE_URL}|{{ @('jenkins.notifications.global.change_request_name') }} #${env.CHANGE_ID}> ${env.CHANGE_TITLE}{% if bool(@('jenkins.notifications.global.change_request_build_on_merge')) %} - merged into target branch " + "<{{ @('jenkins.notifications.global.branch_link_template') }}".replace('GIT_BRANCH', CHANGE_TARGET) + "|${CHANGE_TARGET}>{% endif %}"
                 }
                 fields << [
                     title: 'Source',


### PR DESCRIPTION
Adds a slack notification on build failure.

The notification mentions:
1. The build, with a link
2. How long it took to fail
3. If it's a branch or tag build, the branch/tag and commit, with a link to both
4. If it's a pull request build, a link to the pull request, the change request title (if known) and optionally emphasising that the build happened on a merge of the PR's branch into the PR's target branch to guide people towards it being an integration failure.
5. The reason(s) why it failed

Parallel steps failing do seem to add to the failureMessages array okay in my testing. I was worried about concurrent writes.