### PR TITLE
Update compose ps command to show container hash for DC v2.14

### DIFF
--- a/src/_base/harness/scripts/enable.sh.twig
+++ b/src/_base/harness/scripts/enable.sh.twig
@@ -8,7 +8,7 @@ console_enabled()
     if [ "$APP_BUILD" = dynamic ]; then
         [ -f .my127ws/.flag-console-built ]
     else
-        [ -n "$("${COMPOSE_BIN[@]}" ps --quiet console)" ]
+        [ -n "$("${COMPOSE_BIN[@]}" ps --quiet --all console)" ]
     fi
 }
 
@@ -21,12 +21,12 @@ enable_all()
         HAS_FLAG=yes
         IS_BUILT=yes
         # If the containers no longer exist, we need to rebuild them
-        if [ -z "$("${COMPOSE_BIN[@]}" ps --quiet)" ]; then
+        if [ -z "$("${COMPOSE_BIN[@]}" ps --quiet --all)" ]; then
             IS_BUILT=no
         fi
     fi
 
-    if [ "$APP_BUILD" = dynamic ] && console_enabled && [ -z "$("${COMPOSE_BIN[@]}" ps --quiet console)" ]; then
+    if [ "$APP_BUILD" = dynamic ] && console_enabled && [ -z "$("${COMPOSE_BIN[@]}" ps --quiet --all console)" ]; then
         rm .my127ws/.flag-console-built
     fi
 
@@ -64,7 +64,7 @@ enable_all()
 }
 
 enable_console() {
-    if [ "$APP_BUILD" = dynamic ] && console_enabled && [ -z "$("${COMPOSE_BIN[@]}" ps --quiet console)" ]; then
+    if [ "$APP_BUILD" = dynamic ] && console_enabled && [ -z "$("${COMPOSE_BIN[@]}" ps --quiet --all console)" ]; then
         rm .my127ws/.flag-console-built
     fi
 
@@ -77,7 +77,7 @@ dynamic_console()
 {
     if console_enabled; then
         # ensure it is started
-        if [ -z "$("${COMPOSE_BIN[@]}" ps --quiet console)" ]; then
+        if [ -z "$("${COMPOSE_BIN[@]}" ps --quiet --all console)" ]; then
             passthru "${COMPOSE_BIN[@]}" up -d console
         fi
         return;


### PR DESCRIPTION
## Background

It seems that the behaviour of `docker-compose ps --quiet` has changed from v2.13 to v2.14 of `docker-compose`

In v1 this command would return the stopped containers, but in v2.14 it only returns the containers if they are running.

The fix is to use the `--all` flag. With that the command lists all stopped containers.

## Changes
1. Add `--all` flag to all `docker-compose ps` commands in `enable.sh`
