### PR TITLE
Remove phpcsutils explicit dependency now that implicit dependency works

### DIFF
--- a/src/_base/harness/attributes/common.yml
+++ b/src/_base/harness/attributes/common.yml
@@ -235,7 +235,7 @@ attributes.default:
 
   php:
     version: "8.0"
-    distro_codename: "= @('php.version') >= 8.0 ? 'bullseye' : (@('php.version') >= 7.4 ? 'buster' : 'stretch')"
+    distro_codename: "= @('php.version') >= 8.0 ? 'bullseye' : (@('php.version') >= 7.3 ? 'buster' : 'stretch')"
     cli:
       ini:
         max_execution_time: 0

--- a/src/akeneo/application/skeleton/composer.json.twig
+++ b/src/akeneo/application/skeleton/composer.json.twig
@@ -50,7 +50,6 @@
     "behat/symfony2-extension": "^2.1",
 {% endif %}
     "phpcompatibility/php-compatibility": "dev-develop",
-    "phpcsstandards/phpcsutils": "1.0.0-alpha4",
     "phpmd/phpmd": "^2.13",
     "phpspec/phpspec": "^7.3",
     "phpstan/phpstan": "^1.9",

--- a/src/drupal/application/skeleton/composer.json.twig
+++ b/src/drupal/application/skeleton/composer.json.twig
@@ -136,7 +136,6 @@
     "mglaman/phpstan-drupal": "^1.0",
     "mikey179/vfsstream": "^1.0",
     "phpcompatibility/php-compatibility": "dev-develop",
-    "phpcsstandards/phpcsutils": "^1.0",
     "phpstan/phpstan": "^1.10",
     "phpstan/phpstan-deprecation-rules": "^1.1",
     "squizlabs/php_codesniffer": "^3.5"

--- a/src/magento1/application/skeleton/_twig/composer.json/default.twig
+++ b/src/magento1/application/skeleton/_twig/composer.json/default.twig
@@ -29,7 +29,6 @@
         "magetest/magento-phpspec-extension": "^5.0",
         "pdepend/pdepend": "2.5.2",
         "phpcompatibility/php-compatibility": "dev-develop",
-        "phpcsstandards/phpcsutils": "1.0.0-alpha4",
         "phpmd/phpmd": "@stable",
         "phpspec/phpspec": "^4.0",
         "phpstan/phpstan-shim": "~0.11.5",

--- a/src/magento2/application/skeleton/composer.json.twig
+++ b/src/magento2/application/skeleton/composer.json.twig
@@ -15,7 +15,6 @@
         "dmore/behat-chrome-extension": "^1.3",
         "dmore/chrome-mink-driver": "^2.7",
         "phpcompatibility/php-compatibility": "dev-develop",
-        "phpcsstandards/phpcsutils": "1.0.0-alpha4",
         "phpmd/phpmd": "^2.7",
         "phpspec/phpspec": "^6.0",
         "phpstan/phpstan": "^0.12",

--- a/src/spryker/application/skeleton/composer-harness.json.twig
+++ b/src/spryker/application/skeleton/composer-harness.json.twig
@@ -21,7 +21,6 @@
     "jakoch/phantomjs-installer": "^3.0",
     "phpstan/phpstan": "~1.6.9",
     "phpcompatibility/php-compatibility": "dev-develop",
-    "phpcsstandards/phpcsutils": "1.0.0-alpha4",
     "sensiolabs/behat-page-object-extension": "^2.3",
     "guzzlehttp/guzzle": "^6.3.0",
     "spryker/code-sniffer": "^0.15.9, !=0.17.7",

--- a/src/symfony/application/skeleton/composer.json.twig
+++ b/src/symfony/application/skeleton/composer.json.twig
@@ -23,7 +23,6 @@
         "dmore/behat-chrome-extension": "^1.3",
         "dmore/chrome-mink-driver": "^2.7",
         "phpcompatibility/php-compatibility": "dev-develop",
-        "phpcsstandards/phpcsutils": "1.0.0-alpha4",
         "phpmd/phpmd": "^2.7",
         "phpspec/phpspec": "^7.0",
         "phpstan/phpstan": "^0.12",

--- a/src/wordpress/application/skeleton/composer.json.twig
+++ b/src/wordpress/application/skeleton/composer.json.twig
@@ -13,7 +13,6 @@
         "dmore/behat-chrome-extension": "^1.3",
         "dmore/chrome-mink-driver": "^2.7",
         "phpcompatibility/php-compatibility": "dev-develop",
-        "phpcsstandards/phpcsutils": "1.0.0-alpha4",
         "phpmd/phpmd": "^2.7",
         "phpspec/phpspec": "^6.0",
         "phpstan/phpstan": "^0.12",


### PR DESCRIPTION
php-compatibility required previously an alpha package, which we added this explicit dependency to solve, however now that version is not supported by php-compatibility

In hindsight, `~1.0.0@alpha, ^1.0` might have been better