### PR TITLE
Upgrade PHP 7.3 debian distros to buster

### DIFF
--- a/src/_base/harness/attributes/common.yml
+++ b/src/_base/harness/attributes/common.yml
@@ -235,7 +235,7 @@ attributes.default:
 
   php:
     version: "8.0"
-    distro_codename: "= @('php.version') >= 8.0 ? 'bullseye' : (@('php.version') >= 7.4 ? 'buster' : 'stretch')"
+    distro_codename: "= @('php.version') >= 8.0 ? 'bullseye' : (@('php.version') >= 7.3 ? 'buster' : 'stretch')"
     cli:
       ini:
         max_execution_time: 0


### PR DESCRIPTION
PHP 7.3 builds currently use stretch, but is EOL

We have buster images for them, so switch to buster