### PR TITLE
Ensure getenv is only getting from environment variables

### DIFF
--- a/src/drupal/application/overlay/docroot/sites/default/settings.local.php.twig
+++ b/src/drupal/application/overlay/docroot/sites/default/settings.local.php.twig
@@ -2,15 +2,15 @@
 
 $config_directories = [];
 
-$settings['hash_salt'] = getenv('DRUPAL_SALT');
+$settings['hash_salt'] = getenv('DRUPAL_SALT', true);
 
 $config_directories['sync'] = '../config/sync';
 
 $databases['default']['default'] = array (
-  'database'  => getenv('DB_NAME'),
-  'username'  => getenv('DB_USER'),
-  'password'  => getenv('DB_PASS'),
-  'host'      => getenv('DB_HOST'),
+  'database'  => getenv('DB_NAME', true),
+  'username'  => getenv('DB_USER', true),
+  'password'  => getenv('DB_PASS', true),
+  'host'      => getenv('DB_HOST', true),
   'prefix'    => '',
   'port'      => '3306',
   'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
@@ -22,7 +22,7 @@ $databases['default']['default'] = array (
 {% endif %}
 );
 
-$settings['trusted_host_patterns'][] = '^' . preg_quote(getenv('APP_HOST')) . '$';
+$settings['trusted_host_patterns'][] = '^' . preg_quote(getenv('APP_HOST', true)) . '$';
 
 {% if @('app.build') == 'static' %}
 // TODO: come up with an approach which allows asset aggregation

--- a/src/magento2/application/overlay/app/etc/_twig/env.php/session/redis.twig
+++ b/src/magento2/application/overlay/app/etc/_twig/env.php/session/redis.twig
@@ -1,12 +1,12 @@
   [
       'save'  => 'redis',
       'redis' => [
-          'host'                  => getenv('REDIS_SESSION_HOST')?:'redis-session',
-          'port'                  => getenv('REDIS_SESSION_PORT')?:'6379',
+          'host'                  => getenv('REDIS_SESSION_HOST', true)?:'redis-session',
+          'port'                  => getenv('REDIS_SESSION_PORT', true)?:'6379',
           'password'              => '',
           'timeout'               => '2.5',
           'persistent_identifier' => '',
-          'database'              => getenv('REDIS_DB')?:'1',
+          'database'              => getenv('REDIS_DB', true)?:'1',
           'compression_threshold' => '2048',
           'compression_library'   => 'gzip',
           'log_level'             => '1',

--- a/src/magento2/application/overlay/app/etc/env.php.twig
+++ b/src/magento2/application/overlay/app/etc/env.php.twig
@@ -10,16 +10,16 @@ return [
         'frontName' => 'admin'
     ],
     'crypt' => [
-        'key' => getenv('MAGENTO_CRYPT_KEY')
+        'key' => getenv('MAGENTO_CRYPT_KEY', true)
     ],
     'db' => [
         'table_prefix' => '',
         'connection' => [
             'default' => [
-                'host'     => getenv('DB_HOST'),
-                'dbname'   => getenv('DB_NAME'),
-                'username' => getenv('DB_USER'),
-                'password' => getenv('DB_PASS'),
+                'host'     => getenv('DB_HOST', true),
+                'dbname'   => getenv('DB_NAME', true),
+                'username' => getenv('DB_USER', true),
+                'password' => getenv('DB_PASS', true),
                 'model'    => 'mysql4',
                 'engine'   => 'innodb',
                 'initStatements' => 'SET NAMES utf8;',
@@ -37,11 +37,11 @@ return [
 {% if @('services.rabbitmq.enabled') -%}
     'queue' => [
         'amqp' => [
-            'host' => getenv('RABBITMQ_HOST'),
-            'port' => getenv('RABBITMQ_PORT'),
-            'user' => getenv('RABBITMQ_USER'),
-            'password' => getenv('RABBITMQ_PASSWORD'),
-            'virtualhost' => getenv('RABBITMQ_VHOST')
+            'host' => getenv('RABBITMQ_HOST', true),
+            'port' => getenv('RABBITMQ_PORT', true),
+            'user' => getenv('RABBITMQ_USER', true),
+            'password' => getenv('RABBITMQ_PASSWORD', true),
+            'virtualhost' => getenv('RABBITMQ_VHOST', true)
         ]
     ],
 {% endif -%}
@@ -49,7 +49,7 @@ return [
     'http_cache_hosts' => [
 {% for instanceNumber in 0..(@('replicas.varnish')-1) %}
         [
-            'host' => sprintf(getenv('VARNISH_HOSTNAME_TEMPLATE'), {{ instanceNumber }}),
+            'host' => sprintf(getenv('VARNISH_HOSTNAME_TEMPLATE', true), {{ instanceNumber }}),
             'port' => '80'
         ],
 {% endfor %}
@@ -61,17 +61,17 @@ return [
             'default' => [
                 'backend' => 'Cm_Cache_Backend_Redis',
                 'backend_options' => [
-                    'server' => getenv('REDIS_HOST')?:'redis',
+                    'server' => getenv('REDIS_HOST', true)?:'redis',
                     'database' => '2',
-                    'port' => getenv('REDIS_PORT')?:'6379'
+                    'port' => getenv('REDIS_PORT', true)?:'6379'
                 ]
             ],
             'page_cache' => [
                 'backend' => 'Cm_Cache_Backend_Redis',
                 'backend_options' => [
-                    'server' => getenv('REDIS_HOST')?:'redis',
+                    'server' => getenv('REDIS_HOST', true)?:'redis',
                     'database' => '3',
-                    'port' => getenv('REDIS_PORT')?:'6379',
+                    'port' => getenv('REDIS_PORT', true)?:'6379',
                     'compress_data' => '0'
                 ]
             ]
@@ -103,11 +103,11 @@ return [
                 'search' => [
 {% if @('services.elasticsearch.enabled') -%}
                     'engine' => 'elasticsearch7',
-                    'elasticsearch7_server_hostname' => getenv('ELASTICSEARCH_HOST')?:'elasticsearch',
-                    'elasticsearch7_server_port' => getenv('ELASTICSEARCH_PORT')?:'9200',
-                    'elasticsearch7_enable_auth' => getenv('ELASTICSEARCH_USERNAME') ? 1 : 0,
-                    'elasticsearch7_username' => getenv('ELASTICSEARCH_USERNAME')?:'',
-                    'elasticsearch7_password' => getenv('ELASTICSEARCH_PASSWORD')?:'',
+                    'elasticsearch7_server_hostname' => getenv('ELASTICSEARCH_HOST', true)?:'elasticsearch',
+                    'elasticsearch7_server_port' => getenv('ELASTICSEARCH_PORT', true)?:'9200',
+                    'elasticsearch7_enable_auth' => getenv('ELASTICSEARCH_USERNAME', true) ? 1 : 0,
+                    'elasticsearch7_username' => getenv('ELASTICSEARCH_USERNAME', true)?:'',
+                    'elasticsearch7_password' => getenv('ELASTICSEARCH_PASSWORD', true)?:'',
 {% endif -%}
                 ],
             ],

--- a/src/magento2/application/skeleton/app/etc/InviqaNonComposerComponentRegistration.php
+++ b/src/magento2/application/skeleton/app/etc/InviqaNonComposerComponentRegistration.php
@@ -49,7 +49,7 @@ $find = function () {
 };
 
 $cache = function ($find) {
-    if (getenv(State::PARAM_MODE) !== State::MODE_PRODUCTION) {
+    if (getenv(State::PARAM_MODE, true) !== State::MODE_PRODUCTION) {
         return $find();
     }
 

--- a/src/spryker/application/skeleton/config/Shared/config_local.php
+++ b/src/spryker/application/skeleton/config/Shared/config_local.php
@@ -34,9 +34,9 @@ use Twig\Cache\FilesystemCache;
 require 'common/config_oauth.php';
 
 $CURRENT_STORE = Store::getInstance()->getStoreName();
-$sprykerFrontendHost = getenv('YVES_HOST_' . $CURRENT_STORE);
-$sprykerBackendHost = getenv('ZED_HOST_' . $CURRENT_STORE);
-$sprykerBackendApiHost = getenv('ZED_API_HOST_' . $CURRENT_STORE);
+$sprykerFrontendHost = getenv('YVES_HOST_' . $CURRENT_STORE, true);
+$sprykerBackendHost = getenv('ZED_HOST_' . $CURRENT_STORE, true);
+$sprykerBackendApiHost = getenv('ZED_API_HOST_' . $CURRENT_STORE, true);
 
 $config[ConsoleConstants::ENABLE_DEVELOPMENT_CONSOLE_COMMANDS] = (bool)getenv('DEVELOPMENT_CONSOLE_COMMANDS', true);
 
@@ -74,8 +74,8 @@ $config[SessionConstants::ZED_SSL_ENABLED]
     = false;
 
 // ----------- Glue Application
-$config[GlueApplicationConstants::GLUE_APPLICATION_DOMAIN] = sprintf('http://%s', getenv('GLUE_HOST_' . $CURRENT_STORE));
-$config[GlueApplicationConstants::GLUE_APPLICATION_CORS_ALLOW_ORIGIN] = sprintf('http://%s', getenv('GLUE_HOST_' . $CURRENT_STORE));
+$config[GlueApplicationConstants::GLUE_APPLICATION_DOMAIN] = sprintf('http://%s', getenv('GLUE_HOST_' . $CURRENT_STORE, true));
+$config[GlueApplicationConstants::GLUE_APPLICATION_CORS_ALLOW_ORIGIN] = sprintf('http://%s', getenv('GLUE_HOST_' . $CURRENT_STORE, true));
 
 // ---------- Session
 $config[SessionConstants::YVES_SESSION_COOKIE_NAME] = $sprykerFrontendHost;
@@ -86,10 +86,10 @@ $config[SessionConstants::ZED_SESSION_COOKIE_NAME] = $sprykerBackendHost;
 $config[SessionConstants::ZED_SESSION_COOKIE_DOMAIN] = $sprykerBackendHost;
 
 // ---------- Database credentials
-$config[PropelConstants::ZED_DB_USERNAME] = getenv('DB_USER');
-$config[PropelConstants::ZED_DB_PASSWORD] = getenv('DB_PASS');
-$config[PropelConstants::ZED_DB_DATABASE] = getenv('DB_NAME');
-$config[PropelConstants::ZED_DB_HOST] = getenv('DB_HOST');
+$config[PropelConstants::ZED_DB_USERNAME] = getenv('DB_USER', true);
+$config[PropelConstants::ZED_DB_PASSWORD] = getenv('DB_PASS', true);
+$config[PropelConstants::ZED_DB_DATABASE] = getenv('DB_NAME', true);
+$config[PropelConstants::ZED_DB_HOST] = getenv('DB_HOST', true);
 $config[PropelConstants::ZED_DB_PORT] = 5432;
 $config[PropelConstants::USE_SUDO_TO_MANAGE_DATABASE] = false;
 $config[PropelConstants::ZED_DB_ENGINE]
@@ -97,93 +97,93 @@ $config[PropelConstants::ZED_DB_ENGINE]
     = PropelConfig::DB_ENGINE_PGSQL;
 
 // ---------- Elasticsearch
-$config[SearchElasticsearchConstants::HOST] = getenv('ELASTICSEARCH_HOST');
-$config[SearchElasticsearchConstants::TRANSPORT] = getenv('ELASTICSEARCH_SCHEME') ?: 'http';
-$config[SearchElasticsearchConstants::PORT] = getenv('ELASTICSEARCH_PORT');
-if (getenv('ELASTICSEARCH_USERNAME')) {
-    $config[SearchElasticsearchConstants::AUTH_HEADER] = base64_encode(getenv('ELASTICSEARCH_USERNAME') . ':' . getenv('ELASTICSEARCH_PASSWORD'));
+$config[SearchElasticsearchConstants::HOST] = getenv('ELASTICSEARCH_HOST', true);
+$config[SearchElasticsearchConstants::TRANSPORT] = getenv('ELASTICSEARCH_SCHEME', true) ?: 'http';
+$config[SearchElasticsearchConstants::PORT] = getenv('ELASTICSEARCH_PORT', true);
+if (getenv('ELASTICSEARCH_USERNAME', true)) {
+    $config[SearchElasticsearchConstants::AUTH_HEADER] = base64_encode(getenv('ELASTICSEARCH_USERNAME', true) . ':' . getenv('ELASTICSEARCH_PASSWORD', true));
 }
 $ELASTICA_INDEX_NAME = strtolower($CURRENT_STORE) . '_search';
 $config[CollectorConstants::ELASTICA_PARAMETER__INDEX_NAME] = $ELASTICA_INDEX_NAME;
 
 // ----------- Session and KV storage
-$config[StorageRedisConstants::STORAGE_REDIS_SCHEME] = getenv('REDIS_PROTOCOL');
-$config[StorageRedisConstants::STORAGE_REDIS_HOST] = getenv('REDIS_HOST');
-$config[StorageRedisConstants::STORAGE_REDIS_PORT] = getenv('REDIS_PORT');
-$config[StorageRedisConstants::STORAGE_REDIS_PASSWORD] = getenv('REDIS_PASSWORD');
+$config[StorageRedisConstants::STORAGE_REDIS_SCHEME] = getenv('REDIS_PROTOCOL', true);
+$config[StorageRedisConstants::STORAGE_REDIS_HOST] = getenv('REDIS_HOST', true);
+$config[StorageRedisConstants::STORAGE_REDIS_PORT] = getenv('REDIS_PORT', true);
+$config[StorageRedisConstants::STORAGE_REDIS_PASSWORD] = getenv('REDIS_PASSWORD', true);
 $config[StorageRedisConstants::STORAGE_REDIS_DATABASE] = 0;
-$config[SessionRedisConstants::YVES_SESSION_REDIS_SCHEME] = getenv('REDIS_PROTOCOL');
-$config[SessionRedisConstants::YVES_SESSION_REDIS_HOST] = getenv('REDIS_HOST');
-$config[SessionRedisConstants::YVES_SESSION_REDIS_PORT] = getenv('REDIS_PORT');
-$config[SessionRedisConstants::YVES_SESSION_REDIS_PASSWORD] = getenv('REDIS_PASSWORD');
+$config[SessionRedisConstants::YVES_SESSION_REDIS_SCHEME] = getenv('REDIS_PROTOCOL', true);
+$config[SessionRedisConstants::YVES_SESSION_REDIS_HOST] = getenv('REDIS_HOST', true);
+$config[SessionRedisConstants::YVES_SESSION_REDIS_PORT] = getenv('REDIS_PORT', true);
+$config[SessionRedisConstants::YVES_SESSION_REDIS_PASSWORD] = getenv('REDIS_PASSWORD', true);
 $config[SessionRedisConstants::YVES_SESSION_REDIS_DATABASE] = 1;
-$config[SessionRedisConstants::ZED_SESSION_REDIS_SCHEME] = getenv('REDIS_PROTOCOL');
-$config[SessionRedisConstants::ZED_SESSION_REDIS_HOST] = getenv('REDIS_HOST');
-$config[SessionRedisConstants::ZED_SESSION_REDIS_PORT] = getenv('REDIS_PORT');
-$config[SessionRedisConstants::ZED_SESSION_REDIS_PASSWORD] = getenv('REDIS_PASSWORD');
+$config[SessionRedisConstants::ZED_SESSION_REDIS_SCHEME] = getenv('REDIS_PROTOCOL', true);
+$config[SessionRedisConstants::ZED_SESSION_REDIS_HOST] = getenv('REDIS_HOST', true);
+$config[SessionRedisConstants::ZED_SESSION_REDIS_PORT] = getenv('REDIS_PORT', true);
+$config[SessionRedisConstants::ZED_SESSION_REDIS_PASSWORD] = getenv('REDIS_PASSWORD', true);
 $config[SessionRedisConstants::ZED_SESSION_REDIS_DATABASE] = 2;
 
 // >>> SECURITY BLOCKER
-$config[SecurityBlockerConstants::SECURITY_BLOCKER_REDIS_SCHEME] = getenv('REDIS_PROTOCOL');
-$config[SecurityBlockerConstants::SECURITY_BLOCKER_REDIS_HOST] = getenv('REDIS_HOST');
-$config[SecurityBlockerConstants::SECURITY_BLOCKER_REDIS_PORT] = getenv('REDIS_PORT');
-$config[SecurityBlockerConstants::SECURITY_BLOCKER_REDIS_PASSWORD] = getenv('REDIS_PASSWORD');
+$config[SecurityBlockerConstants::SECURITY_BLOCKER_REDIS_SCHEME] = getenv('REDIS_PROTOCOL', true);
+$config[SecurityBlockerConstants::SECURITY_BLOCKER_REDIS_HOST] = getenv('REDIS_HOST', true);
+$config[SecurityBlockerConstants::SECURITY_BLOCKER_REDIS_PORT] = getenv('REDIS_PORT', true);
+$config[SecurityBlockerConstants::SECURITY_BLOCKER_REDIS_PASSWORD] = getenv('REDIS_PASSWORD', true);
 $config[SecurityBlockerConstants::SECURITY_BLOCKER_REDIS_DATABASE] = 3;
 
 // ---------- RabbitMq
-$config[RabbitMqEnv::RABBITMQ_API_HOST] = getenv('RABBITMQ_HOST');
-$config[RabbitMqEnv::RABBITMQ_API_PORT] = getenv('RABBITMQ_API_PORT');
-$config[RabbitMqEnv::RABBITMQ_API_USERNAME] = getenv('RABBITMQ_USER');
-$config[RabbitMqEnv::RABBITMQ_API_PASSWORD] = getenv('RABBITMQ_PASSWORD');
+$config[RabbitMqEnv::RABBITMQ_API_HOST] = getenv('RABBITMQ_HOST', true);
+$config[RabbitMqEnv::RABBITMQ_API_PORT] = getenv('RABBITMQ_API_PORT', true);
+$config[RabbitMqEnv::RABBITMQ_API_USERNAME] = getenv('RABBITMQ_USER', true);
+$config[RabbitMqEnv::RABBITMQ_API_PASSWORD] = getenv('RABBITMQ_PASSWORD', true);
 $config[RabbitMqEnv::RABBITMQ_CONNECTIONS] = [
     'DE' => [
         RabbitMqEnv::RABBITMQ_CONNECTION_NAME => 'DE-connection',
-        RabbitMqEnv::RABBITMQ_HOST => getenv('RABBITMQ_HOST'),
-        RabbitMqEnv::RABBITMQ_PORT => getenv('RABBITMQ_PORT'),
-        RabbitMqEnv::RABBITMQ_PASSWORD => getenv('RABBITMQ_PASSWORD'),
-        RabbitMqEnv::RABBITMQ_USERNAME => getenv('RABBITMQ_USER'),
-        RabbitMqEnv::RABBITMQ_VIRTUAL_HOST => getenv('RABBITMQ_VHOST_DE'),
+        RabbitMqEnv::RABBITMQ_HOST => getenv('RABBITMQ_HOST', true),
+        RabbitMqEnv::RABBITMQ_PORT => getenv('RABBITMQ_PORT', true),
+        RabbitMqEnv::RABBITMQ_PASSWORD => getenv('RABBITMQ_PASSWORD', true),
+        RabbitMqEnv::RABBITMQ_USERNAME => getenv('RABBITMQ_USER', true),
+        RabbitMqEnv::RABBITMQ_VIRTUAL_HOST => getenv('RABBITMQ_VHOST_DE', true),
         RabbitMqEnv::RABBITMQ_STORE_NAMES => ['DE'],
     ],
     'AT' => [
         RabbitMqEnv::RABBITMQ_CONNECTION_NAME => 'AT-connection',
-        RabbitMqEnv::RABBITMQ_HOST => getenv('RABBITMQ_HOST'),
-        RabbitMqEnv::RABBITMQ_PORT => getenv('RABBITMQ_PORT'),
-        RabbitMqEnv::RABBITMQ_PASSWORD => getenv('RABBITMQ_PASSWORD'),
-        RabbitMqEnv::RABBITMQ_USERNAME => getenv('RABBITMQ_USER'),
-        RabbitMqEnv::RABBITMQ_VIRTUAL_HOST => getenv('RABBITMQ_VHOST_AT'),
+        RabbitMqEnv::RABBITMQ_HOST => getenv('RABBITMQ_HOST', true),
+        RabbitMqEnv::RABBITMQ_PORT => getenv('RABBITMQ_PORT', true),
+        RabbitMqEnv::RABBITMQ_PASSWORD => getenv('RABBITMQ_PASSWORD', true),
+        RabbitMqEnv::RABBITMQ_USERNAME => getenv('RABBITMQ_USER', true),
+        RabbitMqEnv::RABBITMQ_VIRTUAL_HOST => getenv('RABBITMQ_VHOST_AT', true),
         RabbitMqEnv::RABBITMQ_STORE_NAMES => ['AT'],
     ],
     'US' => [
         RabbitMqEnv::RABBITMQ_CONNECTION_NAME => 'US-connection',
-        RabbitMqEnv::RABBITMQ_HOST => getenv('RABBITMQ_HOST'),
-        RabbitMqEnv::RABBITMQ_PORT => getenv('RABBITMQ_PORT'),
-        RabbitMqEnv::RABBITMQ_PASSWORD => getenv('RABBITMQ_PASSWORD'),
-        RabbitMqEnv::RABBITMQ_USERNAME => getenv('RABBITMQ_USER'),
-        RabbitMqEnv::RABBITMQ_VIRTUAL_HOST => getenv('RABBITMQ_VHOST_US'),
+        RabbitMqEnv::RABBITMQ_HOST => getenv('RABBITMQ_HOST', true),
+        RabbitMqEnv::RABBITMQ_PORT => getenv('RABBITMQ_PORT', true),
+        RabbitMqEnv::RABBITMQ_PASSWORD => getenv('RABBITMQ_PASSWORD', true),
+        RabbitMqEnv::RABBITMQ_USERNAME => getenv('RABBITMQ_USER', true),
+        RabbitMqEnv::RABBITMQ_VIRTUAL_HOST => getenv('RABBITMQ_VHOST_US', true),
         RabbitMqEnv::RABBITMQ_STORE_NAMES => ['US'],
     ],
 ];
-$config[RabbitMqEnv::RABBITMQ_API_VIRTUAL_HOST] = getenv('RABBITMQ_VHOST_' . $CURRENT_STORE);
+$config[RabbitMqEnv::RABBITMQ_API_VIRTUAL_HOST] = getenv('RABBITMQ_VHOST_' . $CURRENT_STORE, true);
 $config[RabbitMqEnv::RABBITMQ_CONNECTIONS][$CURRENT_STORE][RabbitMqEnv::RABBITMQ_DEFAULT_CONNECTION] = true;
 
 // ---------- Scheduler
 $config[SchedulerConstants::ENABLED_SCHEDULERS] = [];
 
-if ((getenv('HAS_JENKINS_RUNNER') ?: 'true') === 'true') {
+if ((getenv('HAS_JENKINS_RUNNER', true) ?: 'true') === 'true') {
     $config[SchedulerConstants::ENABLED_SCHEDULERS] = [
         SchedulerConfig::PYZ_SCHEDULER_JENKINS,
     ];
     $config[SchedulerJenkinsConstants::JENKINS_CONFIGURATION] = [
         SchedulerConfig::PYZ_SCHEDULER_JENKINS => [
-            SchedulerJenkinsConfig::SCHEDULER_JENKINS_BASE_URL => 'http://' . getenv('JENKINS_HOST') . ':' . getenv('JENKINS_PORT') . '/',
+            SchedulerJenkinsConfig::SCHEDULER_JENKINS_BASE_URL => 'http://' . getenv('JENKINS_HOST', true) . ':' . getenv('JENKINS_PORT', true) . '/',
         ],
     ];
 }
 
 // ---------- Mail configuration
-$config[MailConstants::SMTP_HOST] = getenv('SMTP_HOST');
-$config[MailConstants::SMTP_PORT] = getenv('SMTP_PORT');
+$config[MailConstants::SMTP_HOST] = getenv('SMTP_HOST', true);
+$config[MailConstants::SMTP_PORT] = getenv('SMTP_PORT', true);
 
 // ---------- Setting to work with queue process timeout patch
 $config[QueueConstants::QUEUE_PROCESS_TIMEOUT] = 120;

--- a/src/spryker/application/skeleton/features/bootstrap/Page/YvesPage.php
+++ b/src/spryker/application/skeleton/features/bootstrap/Page/YvesPage.php
@@ -28,7 +28,7 @@ abstract class YvesPage extends Page
         if (!isset($parameters['base_url'])) {
             $parameters['base_url'] = isset($parameters['yves_base_url'])
                 ? $parameters['yves_base_url']
-                : 'http://' . getenv('YVES_HOST_DE');
+                : 'http://' . getenv('YVES_HOST_DE', true);
         }
 
         $this->baseUrl = rtrim($parameters['base_url'], '/');

--- a/src/wordpress/application/overlay/public/wp-config.php.twig
+++ b/src/wordpress/application/overlay/public/wp-config.php.twig
@@ -20,10 +20,10 @@
  */
 
 // ** MySQL settings ** //
-define('DB_NAME',     getenv('DB_NAME'));
-define('DB_USER',     getenv('DB_USER'));
-define('DB_PASSWORD', getenv('DB_PASS'));
-define('DB_HOST',     getenv('DB_HOST'));
+define('DB_NAME',     getenv('DB_NAME', true));
+define('DB_USER',     getenv('DB_USER', true));
+define('DB_PASSWORD', getenv('DB_PASS', true));
+define('DB_HOST',     getenv('DB_HOST', true));
 define('DB_CHARSET', 'utf8');
 define('DB_COLLATE', '');
 
@@ -36,14 +36,14 @@ define('DB_COLLATE', '');
  *
  * @since 2.6.0
  */
-define('AUTH_KEY',          getenv('WORDPRESS_AUTH_KEY'));
-define('SECURE_AUTH_KEY',   getenv('WORDPRESS_SECURE_AUTH_KEY'));
-define('LOGGED_IN_KEY',     getenv('WORDPRESS_LOGGED_IN_KEY'));
-define('NONCE_KEY',         getenv('WORDPRESS_NONCE_KEY'));
-define('AUTH_SALT',         getenv('WORDPRESS_AUTH_SALT'));
-define('SECURE_AUTH_SALT',  getenv('WORDPRESS_SECURE_AUTH_SALT'));
-define('LOGGED_IN_SALT',    getenv('WORDPRESS_LOGGED_IN_SALT'));
-define('NONCE_SALT',        getenv('WORDPRESS_NONCE_SALT'));
+define('AUTH_KEY',          getenv('WORDPRESS_AUTH_KEY', true));
+define('SECURE_AUTH_KEY',   getenv('WORDPRESS_SECURE_AUTH_KEY', true));
+define('LOGGED_IN_KEY',     getenv('WORDPRESS_LOGGED_IN_KEY', true));
+define('NONCE_KEY',         getenv('WORDPRESS_NONCE_KEY', true));
+define('AUTH_SALT',         getenv('WORDPRESS_AUTH_SALT', true));
+define('SECURE_AUTH_SALT',  getenv('WORDPRESS_SECURE_AUTH_SALT', true));
+define('LOGGED_IN_SALT',    getenv('WORDPRESS_LOGGED_IN_SALT', true));
+define('NONCE_SALT',        getenv('WORDPRESS_NONCE_SALT', true));
 
 /**
  * WordPress Database Table prefix.


### PR DESCRIPTION
None of these variables names start with HTTP_ but it's better to ensure this is seen rather than just copy/pasting for some potential future HTTP_ variable being overridable by request header.