### PR TITLE
Use the extended utilization metrics for HPA

### DIFF
--- a/src/_base/helm/app/templates/horizontal-pod-autoscaler.yaml
+++ b/src/_base/helm/app/templates/horizontal-pod-autoscaler.yaml
@@ -29,25 +29,17 @@ spec:
     - type: Resource
       resource:
         name: memory
-        {{- if semverCompare ">=1.23-0" $.Capabilities.KubeVersion.Version }}
         target:
           type: Utilization
           averageUtilization: {{ . }}
-        {{- else }}
-        targetAverageUtilization: {{ . }}
-        {{- end }}
     {{- end }}
     {{- with $autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource
       resource:
         name: cpu
-        {{- if semverCompare ">=1.23-0" $.Capabilities.KubeVersion.Version }}
         target:
           type: Utilization
           averageUtilization: {{ . }}
-        {{- else }}
-        targetAverageUtilization: {{ . }}
-        {{- end }}
     {{- end }}
   scaleTargetRef:
     apiVersion: apps/v1

--- a/src/_base/helm/app/templates/horizontal-pod-autoscaler.yaml
+++ b/src/_base/helm/app/templates/horizontal-pod-autoscaler.yaml
@@ -29,15 +29,25 @@ spec:
     - type: Resource
       resource:
         name: memory
+        {{- if semverCompare ">=1.23-0" $.Capabilities.KubeVersion.Version }}
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+        {{- else }}
         targetAverageUtilization: {{ . }}
+        {{- end }}
     {{- end }}
     {{- with $autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource
       resource:
         name: cpu
+        {{- if semverCompare ">=1.23-0" $.Capabilities.KubeVersion.Version }}
         target:
           type: Utilization
           averageUtilization: {{ . }}
+        {{- else }}
+        targetAverageUtilization: {{ . }}
+        {{- end }}
     {{- end }}
   scaleTargetRef:
     apiVersion: apps/v1


### PR DESCRIPTION
target is supported by v2beta2, targetAverageUtilization v2beta1. The latter we never supported.

Verified with harness-docker's extended kubeval test cases