### PR TITLE
Ensure all startup commands convert sidekick run to passthru

### DIFF
--- a/src/_base/docker/image/console/root/entrypoint.sh.twig
+++ b/src/_base/docker/image/console/root/entrypoint.sh.twig
@@ -47,5 +47,6 @@ bootstrap
 if [ "${1:-}" == "sleep" ]; then
     exec /sbin/tini -- bash -c "$(printf "%q " "$@")"
 else
+    export SIDEKICK_VERBOSE=yes
     exec /sbin/tini -- "$@"
 fi

--- a/src/_base/docker/image/console/root/usr/lib/sidekick.sh
+++ b/src/_base/docker/image/console/root/usr/lib/sidekick.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERBOSE="no"
+VERBOSE="${SIDEKICK_VERBOSE:-no}"
 
 RUN_CWD=""
 

--- a/src/_base/docker/image/cron/root/entrypoint.sh.twig
+++ b/src/_base/docker/image/cron/root/entrypoint.sh.twig
@@ -13,7 +13,8 @@ setup_app_networking()
 }
 
 run_steps()
-{
+(
+    export SIDEKICK_VERBOSE=yes
     # run any command required to be executed at docker startup
     {% for step in @('php.entrypoint.steps') -%}
     {{ step|raw }}
@@ -34,7 +35,7 @@ run_steps()
           rm /usr/local/etc/php/conf.d/docker-php-ext-tideways.ini
       fi
     fi
-}
+)
 
 dump_environment_variables()
 {

--- a/src/_base/docker/image/php-fpm/root/entrypoint.sh.twig
+++ b/src/_base/docker/image/php-fpm/root/entrypoint.sh.twig
@@ -1,7 +1,9 @@
 #!/bin/bash
 
 run_steps()
-{
+(
+    export SIDEKICK_VERBOSE=yes
+
     {% for poolName, pool in @('php-fpm.pools') -%}
     FPM_NAME="{{ poolName }}" FPM_PORT="{{ pool.port }}" envsubst < /usr/local/etc/php-fpm.d/pool.conf.template > /usr/local/etc/php-fpm.d/{{ poolName }}.conf;
     {% endfor %}
@@ -22,7 +24,7 @@ run_steps()
           rm /usr/local/etc/php/conf.d/docker-php-ext-tideways.ini
       fi
     fi
-}
+)
 
 run_steps
 


### PR DESCRIPTION
The /tmp/my127ws-std* files created during startup, when on failure, are not available.

Also this is a workaround to the bug in k8s 1.25 app-init/app-migrate not being able to write to these files when root user