### PR TITLE
Ensure static builds convert sidekick run to passthru

### DIFF
--- a/src/_base/docker/image/console/Dockerfile.twig
+++ b/src/_base/docker/image/console/Dockerfile.twig
@@ -55,7 +55,7 @@ RUN composer --no-plugins global remove hirak/prestissimo
 {% if @('app.build') == 'static' %}
 COPY --chown=build:build .my127ws/application  /home/build/application
 COPY --chown=build:build ./                    /app
-RUN app build
+RUN SIDEKICK_VERBOSE=yes app build
 {% else %}
 VOLUME /app
 VOLUME /home/build/application


### PR DESCRIPTION
So that the logs are available in console on failure, rather than lost, and not embedded as files in the resulting image