### PR TITLE
Simplify release process using Github released archives

### DIFF
--- a/.github/workflows/release-archives.yml
+++ b/.github/workflows/release-archives.yml
@@ -1,0 +1,31 @@
+on:
+  release:
+    types:
+      - created
+
+name: Attach archives to release
+
+jobs:
+  build:
+    name: Build and upload archives
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+            fetch-depth: 0
+
+      - name: Create archives
+        run: ./build --archive
+      
+      - name: Generate sha256sum
+        working-directory: ./dist
+        run: sha256sum harness-*.tgz > ./sha256sum
+
+      - name: "Upload archives to Release"
+        uses: softprops/action-gh-release@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          files: |
+            ./dist/harness-*.tgz
+            ./dist/sha256sum

--- a/build
+++ b/build
@@ -3,7 +3,31 @@
 set -e
 set -x
 
+function usage() {
+    cat <<EOF
+$0 [--archive]
+EOF
+}
+
 HARNESSES=(akeneo drupal magento1 magento2 spryker symfony wordpress)
+ARCHIVE=0
+ARGS=()
+
+while [ $# -ne 0 ]; do
+  case "$1" in
+    --help)
+      usage
+      exit 0
+      ;;
+    --archive)
+      ARCHIVE=1
+      ;;
+    *)
+      ARGS+=("$1")
+  esac
+  shift 1
+done
+
 
 function main()
 {
@@ -12,7 +36,14 @@ function main()
     for harness in "${HARNESSES[@]}"
     do
         build "$harness"
+        if [ "$ARCHIVE" -gt 0 ]; then
+            archive "$harness"
+        fi
     done
+
+    if [ "$ARCHIVE" -gt 0 ]; then
+        archive "php"
+    fi
 }
 
 function build()
@@ -48,6 +79,16 @@ function build_base()
     mkdir "$harness_dist_path"
 
     rsync -va "./src/_base/" "$harness_dist_path"
+}
+
+function archive()
+{
+    pushd ./dist >/dev/null
+
+    tar -czvf "./harness-$1.tgz" "./harness-$1"
+    rm -rf "./harness-$1"
+
+    popd >/dev/null
 }
 
 main

--- a/build
+++ b/build
@@ -85,7 +85,7 @@ function archive()
 {
     pushd ./dist >/dev/null
 
-    tar -czvf "./harness-$1.tgz" "./harness-$1"
+    tar -czvf "./harness-$1.tgz" "harness-$1"
     rm -rf "./harness-$1"
 
     popd >/dev/null


### PR DESCRIPTION
Still requires versions updating in files, but doesn't require sub-tree forks

In the least this will be useful for testing pre-releases.