### PR TITLE
Update github actions tag workflow to remove node12 warning

### DIFF
--- a/.github/workflows/release-archives.yml
+++ b/.github/workflows/release-archives.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
             fetch-depth: 0
 


### PR DESCRIPTION
actions/checkout@2 uses node12, actions/checkout@3 node16 removing this warning:

> The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/