### PR TITLE
Upgrade to NGINX v1.25 as v1.23 is no longer supported

### DIFF
--- a/src/_base/docker/image/nginx/Dockerfile.twig
+++ b/src/_base/docker/image/nginx/Dockerfile.twig
@@ -2,7 +2,7 @@
 FROM {{ @('docker.repository') ~ ':' ~ @('app.version') }}-console as console
 {% endif %}
 
-FROM nginx:1.23-alpine
+FROM nginx:1.25-alpine
 COPY root /
 
 {% if @('app.build') == 'static' %}


### PR DESCRIPTION
tls-offload and relay dealt with in https://github.com/inviqa/harness-docker/pull/110