### PR TITLE
Remove xarg max-args option to stop warning when using replace option

### DIFF
--- a/src/akeneo/application/skeleton/composer.json.twig
+++ b/src/akeneo/application/skeleton/composer.json.twig
@@ -94,7 +94,7 @@
       "@test-acceptance"
     ],
     "test-production-quality": [
-      "bash -e -o pipefail -c \"find src/ -type f -name '*.php' -print0 | xargs -0 --no-run-if-empty -n 1 -P 8 -i php -l {} | (grep -v 'No syntax errors detected' || echo OK)\"",
+      "bash -e -o pipefail -c \"find src/ -type f -name '*.php' -print0 | xargs -0 --no-run-if-empty -P 8 -i php -l {} | (grep -v 'No syntax errors detected' || echo OK)\"",
       "composer validate --no-check-publish"
     ],
     "test-quality": [

--- a/src/drupal/application/skeleton/composer.json.twig
+++ b/src/drupal/application/skeleton/composer.json.twig
@@ -166,7 +166,7 @@
       "@test-acceptance"
     ],
     "test-production-quality": [
-      "bash -e -o pipefail -c \"find docroot -type f ! -iregex 'docroot/core/.*?/?tests?/.*' ! -iregex 'docroot/modules/contrib/.*/tests?/.*' ! -path 'docroot/core/lib/Drupal/Component/Assertion/global_namespace_php5.php' \\( -name '*.inc' -o -name '*.install' -o -name '*.module' -o -name '*.php' -o -name '*.profile' -o -name '*.test' -o -name '*.theme' \\)  -print0 | xargs -0 --no-run-if-empty -n 1 -P 8 -i php -l {} | (grep -v 'No syntax errors detected' || echo OK)\"",
+      "bash -e -o pipefail -c \"find docroot -type f ! -iregex 'docroot/core/.*?/?tests?/.*' ! -iregex 'docroot/modules/contrib/.*/tests?/.*' ! -path 'docroot/core/lib/Drupal/Component/Assertion/global_namespace_php5.php' \\( -name '*.inc' -o -name '*.install' -o -name '*.module' -o -name '*.php' -o -name '*.profile' -o -name '*.test' -o -name '*.theme' \\)  -print0 | xargs -0 --no-run-if-empty -P 8 -i php -l {} | (grep -v 'No syntax errors detected' || echo OK)\"",
       "composer validate --no-check-publish"
     ],
     "test-quality": [

--- a/src/magento1/application/skeleton/_twig/composer.json/default.twig
+++ b/src/magento1/application/skeleton/_twig/composer.json/default.twig
@@ -93,7 +93,7 @@
             "@test-acceptance"
         ],
         "test-production-quality": [
-            "bash -e -o pipefail -c \"find public/app/code/ public/app/design/ -type f ! -path 'public/app/code/core/Mage/Adminhtml/Model/Extension.php' \\( -name '*.phtml' -o -name '*.php' \\) -print0 | xargs -0 --no-run-if-empty -n 1 -P 8 -i php -l {} | (grep -v 'No syntax errors detected' || echo OK)\"",
+            "bash -e -o pipefail -c \"find public/app/code/ public/app/design/ -type f ! -path 'public/app/code/core/Mage/Adminhtml/Model/Extension.php' \\( -name '*.phtml' -o -name '*.php' \\) -print0 | xargs -0 --no-run-if-empty -P 8 -i php -l {} | (grep -v 'No syntax errors detected' || echo OK)\"",
             "composer validate --no-check-publish"
         ],
         "test-quality": [

--- a/src/magento1/application/skeleton/_twig/composer.json/php-5.6.twig
+++ b/src/magento1/application/skeleton/_twig/composer.json/php-5.6.twig
@@ -94,7 +94,7 @@
             "@test-acceptance"
         ],
         "test-production-quality": [
-            "bash -e -o pipefail -c \"find public/app/code/ public/app/design/ -type f \\( -name '*.phtml' -o -name '*.php' \\) -print0 | xargs -0 --no-run-if-empty -n 1 -P 8 -i php -l {} | (grep -v 'No syntax errors detected' || echo OK)\"",
+            "bash -e -o pipefail -c \"find public/app/code/ public/app/design/ -type f \\( -name '*.phtml' -o -name '*.php' \\) -print0 | xargs -0 --no-run-if-empty -P 8 -i php -l {} | (grep -v 'No syntax errors detected' || echo OK)\"",
             "composer validate --no-check-publish"
         ],
         "test-quality": [

--- a/src/magento2/application/skeleton/composer.json.twig
+++ b/src/magento2/application/skeleton/composer.json.twig
@@ -86,7 +86,7 @@
             "@test-acceptance"
         ],
         "test-production-quality": [
-            "bash -e -o pipefail -c \"find src/ pub/ -type f \\( -name '*.phtml' -o -name '*.php' \\) -print0 | xargs -0 --no-run-if-empty -n 1 -P 8 -i php -l {} | (grep -v 'No syntax errors detected' || echo OK)\"",
+            "bash -e -o pipefail -c \"find src/ pub/ -type f \\( -name '*.phtml' -o -name '*.php' \\) -print0 | xargs -0 --no-run-if-empty -P 8 -i php -l {} | (grep -v 'No syntax errors detected' || echo OK)\"",
             "composer validate --no-check-publish",
             "app phpstan"
         ],

--- a/src/spryker/application/skeleton/composer-harness.json.twig
+++ b/src/spryker/application/skeleton/composer-harness.json.twig
@@ -79,7 +79,7 @@
       "APPLICATION_ENV=development DEVELOPMENT_CONSOLE_COMMANDS=1 vendor/bin/console dev:ide:generate-auto-completion"
     ],
     "test-production-quality": [
-      "bash -e -o pipefail -c \"find src/ -type f -name '*.php' -print0 | xargs -0 --no-run-if-empty -n 1 -P 8 -i php -l {} | (grep -v 'No syntax errors detected' || echo OK)\"",
+      "bash -e -o pipefail -c \"find src/ -type f -name '*.php' -print0 | xargs -0 --no-run-if-empty -P 8 -i php -l {} | (grep -v 'No syntax errors detected' || echo OK)\"",
       "composer validate --no-check-publish"
     ],
     "test-quality": [

--- a/src/symfony/application/skeleton/composer.json.twig
+++ b/src/symfony/application/skeleton/composer.json.twig
@@ -87,7 +87,7 @@
             "@test-acceptance"
         ],
         "test-production-quality": [
-            "bash -e -o pipefail -c \"find src/ -type f -name '*.php' -print0 | xargs -0 --no-run-if-empty -n 1 -P 8 -i php -l {} | (grep -v 'No syntax errors detected' || echo OK)\"",
+            "bash -e -o pipefail -c \"find src/ -type f -name '*.php' -print0 | xargs -0 --no-run-if-empty -P 8 -i php -l {} | (grep -v 'No syntax errors detected' || echo OK)\"",
             "composer validate --no-check-publish"
         ],
         "test-quality": [

--- a/src/wordpress/application/skeleton/composer.json.twig
+++ b/src/wordpress/application/skeleton/composer.json.twig
@@ -43,7 +43,7 @@
             "@test-acceptance"
         ],
         "test-production-quality": [
-            "bash -e -o pipefail -c \"find public/ -type f -name '*.php'  -print0 | xargs -0 --no-run-if-empty -n 1 -P 8 -i php -l {} | (grep -v 'No syntax errors detected' || echo OK)\"",
+            "bash -e -o pipefail -c \"find public/ -type f -name '*.php'  -print0 | xargs -0 --no-run-if-empty -P 8 -i php -l {} | (grep -v 'No syntax errors detected' || echo OK)\"",
             "composer validate --no-check-publish"
         ],
         "test-quality": [


### PR DESCRIPTION
```
xargs: warning: options --max-args and --replace/-I/-i are mutually exclusive, ignoring previous --max-args value
```