### PR TITLE
Remove redis save option so redis 7 can be used

### DIFF
--- a/src/_base/harness/attributes/docker-base.yml
+++ b/src/_base/harness/attributes/docker-base.yml
@@ -159,10 +159,14 @@ attributes:
         # Evict any least recently used key even if they don't have a TTL
         maxmemory-policy: allkeys-lru
         # Save snapshots every X changes have happened within Y seconds (these are the defaults in redis.conf)
-        save:
-          - 3600 1
-          - 300 100
-          - 60 10000
+        # Redis < 7
+        # save:
+        #   - 3600 1
+        #   - 300 100
+        #   - 60 10000
+        # Redis >= 7
+        # save:
+        #   - '3600 1 300 100 60 10000'
       resources:
         # 1.5 * maxmemory to allow copy on write snapshots
         memory: "1.5Gi"


### PR DESCRIPTION
There is a difference in config format for redis 7, and since save are it's defaults, it doesn't need supplying.

So remove the need for a workaround to supply save options if using redis 7