### PR TITLE
feat(all): Add corepack support

### DIFF
--- a/src/_base/docker/image/console/Dockerfile.twig
+++ b/src/_base/docker/image/console/Dockerfile.twig
@@ -52,7 +52,8 @@ RUN . {{ @('app.code_owner_home')}}/.nvm/nvm.sh \
  && nvm install {{ @('node.version') }} \
  && nvm use {{ @('node.version') }} \
  && nvm alias default {{ @('node.version') }} \
- && npm install -g yarn
+ && npm install -g corepack \
+ && corepack enable
 {% endif %}
 
 {% if @('php.composer.major_version') != '1' %}

--- a/src/_base/docker/image/console/Dockerfile.twig
+++ b/src/_base/docker/image/console/Dockerfile.twig
@@ -52,8 +52,8 @@ RUN . {{ @('app.code_owner_home')}}/.nvm/nvm.sh \
  && nvm install {{ @('node.version') }} \
  && nvm use {{ @('node.version') }} \
  && nvm alias default {{ @('node.version') }} \
- && npm install -g corepack \
- && corepack enable
+ && npm install -g corepack yarn \
+ && corepack pack --all
 {% endif %}
 
 {% if @('php.composer.major_version') != '1' %}

--- a/src/_base/docker/image/console/Dockerfile.twig
+++ b/src/_base/docker/image/console/Dockerfile.twig
@@ -52,8 +52,7 @@ RUN . {{ @('app.code_owner_home')}}/.nvm/nvm.sh \
  && nvm install {{ @('node.version') }} \
  && nvm use {{ @('node.version') }} \
  && nvm alias default {{ @('node.version') }} \
- && npm install -g corepack yarn \
- && corepack pack --all
+ && npm install -g corepack yarn
 {% endif %}
 
 {% if @('php.composer.major_version') != '1' %}


### PR DESCRIPTION
nodejs is generally now being distributed with corepack, which takes over yarn and pnpm binaries and allows support for yarn 2+ without needing it to be committed to repositories, instead a "packageManager" package.json field will define the version used, and downloaded on execution of yarn or pnpm.

By default yarn 1 will be used, the same as yarn npm package. Currently, like node docker image, `corepack enable` needs to be run before package installation (or `corepack yarn ...`) to get this behaviour.