### PR TITLE
feat(all): improve XDebug and PHP config

### DIFF
--- a/src/_base/docker/image/app/root-base/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini.twig
+++ b/src/_base/docker/image/app/root-base/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini.twig
@@ -5,4 +5,5 @@
   {% for key, value in xdebug.config['v' ~ xdebug.version] -%}
     xdebug.{{ key }}={{ value }}
   {% endfor %}
+  opcache.jit_buffer_size = 0
 {% endif %}

--- a/src/_base/docker/image/console/root/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini.twig
+++ b/src/_base/docker/image/console/root/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini.twig
@@ -5,4 +5,5 @@
   {% for key, value in xdebug.config['v' ~ xdebug.version] -%}
     xdebug.{{ key }}={{ value }}
   {% endfor %}
+  opcache.jit_buffer_size = 0
 {% endif %}

--- a/src/_base/harness/config/commands-php.yml
+++ b/src/_base/harness/config/commands-php.yml
@@ -35,10 +35,25 @@ command('service php-fpm restart'):
     COMPOSE_BIN: = @('docker.compose.bin')
   exec: |
     #!bash(workspace:/)|@
+    echo 'Updating templates in .my127ws/'
     passthru ws install --step=prepare
-    $COMPOSE_BIN exec console bash -c 'cp -r /.my127ws/docker/image/console/root/usr/local/etc/php/conf.d/* /usr/local/etc/php/conf.d/'
+    echo 'Bringing up php-fpm with updated settings'
     $COMPOSE_BIN exec php-fpm bash -c 'cp -r /.my127ws/docker/image/app/root-base/usr/local/etc/php/conf.d/* /usr/local/etc/php/conf.d/'
+    $COMPOSE_BIN exec php-fpm bash -c 'cp -r /.my127ws/docker/image/app/root-base/usr/local/etc/php/php.ini /usr/local/etc/php/'
+    $COMPOSE_BIN exec php-fpm bash -c 'cp -r /.my127ws/docker/image/app/root-base/usr/local/etc/php-fpm.d/* /usr/local/etc/php-fpm.d/'
     passthru $COMPOSE_BIN exec php-fpm supervisorctl restart php-fpm
+
+command('console reload'):
+  env:
+    COMPOSE_BIN: = @('docker.compose.bin')
+  exec: |
+    #!bash(workspace:/)|@
+    echo 'Updating templates in .my127ws/'
+    passthru ws install --step=prepare
+    echo 'Configuring console with updated settings'
+    $COMPOSE_BIN exec console bash -c 'cp -r /.my127ws/docker/image/console/root/usr/local/etc/php/conf.d/* /usr/local/etc/php/conf.d/'
+    $COMPOSE_BIN exec console bash -c 'cp -r /.my127ws/docker/image/console/root/usr/local/etc/php/php.ini /usr/local/etc/php/php.ini'
+    
 
 command('feature blackfire (on|off)'):
   env:
@@ -47,10 +62,7 @@ command('feature blackfire (on|off)'):
   exec: |
     #!bash(workspace:/)|=
     ws set $ATTR_KEY $ATTR_VAL
-    echo 'Updating templates in .my127ws/'
-    run ws install --step=prepare
-    echo 'Bringing up php-fpm with the new setting'
-    run ws service php-fpm restart
+    passthru ws service php-fpm restart
     echo 'Done'
 
 command('feature blackfire cli (on|off)'):
@@ -60,10 +72,8 @@ command('feature blackfire cli (on|off)'):
   exec: |
     #!bash(workspace:/)|=
     ws set $ATTR_KEY $ATTR_VAL
-    echo 'Updating templates in .my127ws/'
-    run ws install --step=prepare
-    echo 'Bringing up console with the new setting'
-    run ws service
+    passthru ws console reload
+    echo 'Done'
 
 command('feature tideways (on|off)'):
   env:
@@ -72,10 +82,7 @@ command('feature tideways (on|off)'):
   exec: |
     #!bash(workspace:/)|=
     ws set $ATTR_KEY $ATTR_VAL
-    echo 'Updating templates in .my127ws/'
-    run ws install --step=prepare
-    echo 'Bringing up php-fpm with the new setting'
-    run ws service php-fpm restart
+    passthru ws service php-fpm restart
     echo 'Done'
 
 command('feature tideways cli (on|off)'):
@@ -85,10 +92,7 @@ command('feature tideways cli (on|off)'):
   exec: |
     #!bash(workspace:/)|=
     ws set $ATTR_KEY $ATTR_VAL
-    echo 'Updating templates in .my127ws/'
-    run ws install --step=prepare
-    echo 'Bringing up console with the new setting'
-    run ws service php-fpm restart
+    passthru ws console reload
     echo 'Done'
 
 command('feature tideways cli configure <server_key>'):

--- a/src/_base/harness/config/xdebug.yml
+++ b/src/_base/harness/config/xdebug.yml
@@ -1,4 +1,5 @@
 command('feature xdebug version-sync'):
+  description: Install xdebug version configured by "php.ext-xdebug.version" into running PHP containers
   env:
     XDEBUG_VERSION: = @('php.ext-xdebug.version')
     COMPOSE_BIN: = @('docker.compose.bin')
@@ -7,27 +8,23 @@ command('feature xdebug version-sync'):
     source .my127ws/harness/scripts/xdebug_version_sync.sh
 
 command('feature xdebug (on|off)'):
+  description: Enable XDebug for PHP-FPM (disables JIT)
   env:
     ATTR_KEY: 'php.ext-xdebug.enable'
     ATTR_VAL: = boolToString(input.command(3) == 'on')
   exec: |
     #!bash(workspace:/)|=
     ws set $ATTR_KEY $ATTR_VAL
-    echo 'Updating templates in .my127ws/'
-    run ws install --step=prepare
-    echo 'Bringing up php-fpm with the new setting'
-    run ws service php-fpm restart
+    passthru ws service php-fpm restart
     echo 'Done'
 
 command('feature xdebug cli (on|off)'):
+  description: Enable XDebug for PHP CLI (disables JIT)
   env:
     ATTR_KEY: 'php.ext-xdebug.cli.enable'
     ATTR_VAL: = boolToString(input.command(4) == 'on')
   exec: |
     #!bash(workspace:/)|=
     ws set $ATTR_KEY $ATTR_VAL
-    echo 'Updating templates in .my127ws/'
-    run ws install --step=prepare
-    echo 'Bringing up console with the new setting'
-    run ws service php-fpm restart
+    passthru ws console reload
     echo 'Done'

--- a/src/_base/harness/config/xdebug.yml
+++ b/src/_base/harness/config/xdebug.yml
@@ -8,7 +8,7 @@ command('feature xdebug version-sync'):
     source .my127ws/harness/scripts/xdebug_version_sync.sh
 
 command('feature xdebug (on|off)'):
-  description: Enable XDebug for PHP-FPM (disables JIT)
+  description: Enable/Disable XDebug for PHP-FPM (disables JIT)
   env:
     ATTR_KEY: 'php.ext-xdebug.enable'
     ATTR_VAL: = boolToString(input.command(3) == 'on')
@@ -19,7 +19,7 @@ command('feature xdebug (on|off)'):
     echo 'Done'
 
 command('feature xdebug cli (on|off)'):
-  description: Enable XDebug for PHP CLI (disables JIT)
+  description: Enable/Disable XDebug for PHP CLI (disables JIT)
   env:
     ATTR_KEY: 'php.ext-xdebug.cli.enable'
     ATTR_VAL: = boolToString(input.command(4) == 'on')


### PR DESCRIPTION
- split `service php-fpm restart` and `console reload` so `feature cli` commands work when webapp is disabled
- move common feature tasks (output, template update) to restart/reload
- disable JIT when xdebug is enabled to reduce noise - there's no good way afaik to do this via `ws set`, so it's in the xdebug extension config for now