### PR TITLE
fix(akeneo): add a temporary restriction on symfony/console version

### DIFF
--- a/src/akeneo/application/skeleton/composer.json.twig
+++ b/src/akeneo/application/skeleton/composer.json.twig
@@ -38,7 +38,8 @@
 {%- endif %}
   "require": {
     "php": ">= {{ @('php.version') }}",
-    "akeneo/pim-{{ @('akeneo.edition') }}-dev": "^{{ @('akeneo.major_version') }}.0.0"
+    "akeneo/pim-{{ @('akeneo.edition') }}-dev": "^{{ @('akeneo.major_version') }}.0.0",
+    "symfony/console": "*, !=5.4.35, !=6.3.12, !=6.4.3, !=7.0.3"
   },
   "require-dev": {
     "behat/behat": "^3.12",


### PR DESCRIPTION
symfony/console versions 5.4.35, 6.3.12, 6.4.3, 7.0.3 have a regression in loose InputOption shortcut typechecks, which misses `false` as no option.

Some Akeneo commands use false (incorrectly) instead of null for shortcut