### PR TITLE
feat(all): avoid composer v2 update on PHP 8.3

### DIFF
--- a/src/_base/docker/image/console/Dockerfile.twig
+++ b/src/_base/docker/image/console/Dockerfile.twig
@@ -15,7 +15,7 @@ RUN (getent group "${CODE_OWNER_GROUP}" >/dev/null 2>&1 || groupadd "${CODE_OWNE
  && chmod +x /sbin/tini \
  && mkdir -p /tmp/php-file-cache \
  && chown -R build:build /tmp/php-file-cache
-{%- if @('php.composer.major_version') != '1' %} \
+{%- if @('php.composer.update') %} \
  && composer self-update --{{ @('php.composer.major_version') }} \
  && rm -f /root/.composer/*.phar
 {%- endif %}
@@ -55,7 +55,7 @@ RUN . {{ @('app.code_owner_home')}}/.nvm/nvm.sh \
  && npm install -g corepack yarn
 {% endif %}
 
-{% if @('php.composer.major_version') != '1' %}
+{% if @('php.composer.major_version') != '1' and version_compare(@('php.version', '8.3', '<')) %}
 RUN composer --no-plugins global remove hirak/prestissimo
 {% endif %}
 

--- a/src/_base/harness/attributes/common-05-php.yml
+++ b/src/_base/harness/attributes/common-05-php.yml
@@ -93,9 +93,9 @@ attributes.default:
   php:
     version: "8.2"
     distro_codename: >
-      = @('php.version') >= 8.3 ? 'bookworm'
-      : @('php.version') >= 8.0 ? 'bullseye' 
-      : @('php.version') >= 7.3 ? 'buster'
+      = version_compare(@('php.version'), '8.3', '>=') ? 'bookworm'
+      : version_compare(@('php.version'), '8.0', '>=') ? 'bullseye' 
+      : version_compare(@('php.version'), '7.3', '>=') ? 'buster'
       : 'stretch'
     cli:
       ini:
@@ -107,6 +107,9 @@ attributes.default:
       install_extensions: []
     composer:
       major_version: 2
+      update: >
+        = version_compare(@('php.version'), '8.3', '>=') ? @('php.composer.major_version') != 2
+        ? @('php.composer.major_version') != 1
     cron:
       ini: = @('php.cli.ini')
     entrypoint:


### PR DESCRIPTION
as PHP 8.3 image contains composer v2

also avoid removal of non-existent hirak/prestissimo global package on PHP 8.3 due to being a composer v1 package